### PR TITLE
protocol: Hex-encode random ActorID

### DIFF
--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -182,7 +182,7 @@ fn apply_updates_inside_nested_maps() {
     let birds_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
 
     let expected_change_request = amp::ChangeRequest {
-        actor: doc.actor_id.clone(),
+        actor: doc.actor_id,
         seq: 2,
         version: 0,
         time: req2.time,

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -12,7 +12,7 @@ pub struct ActorID(pub String);
 
 impl ActorID {
     pub fn random() -> ActorID {
-        ActorID(hex::encode(uuid::Uuid::new_v4().to_string()))
+        ActorID(hex::encode(uuid::Uuid::new_v4().as_bytes()))
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -12,7 +12,7 @@ pub struct ActorID(pub String);
 
 impl ActorID {
     pub fn random() -> ActorID {
-        ActorID(uuid::Uuid::new_v4().to_string())
+        ActorID(hex::encode(uuid::Uuid::new_v4().to_string()))
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {


### PR DESCRIPTION
Ran into this issue when using `Frontend::new_with_initial_state` where it would panic when it was trying to decode a bare UUID as a hex-encoded string.