### PR TITLE
Two level objtype

### DIFF
--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -10,7 +10,7 @@ use crate::time;
 use crate::undo_operation::UndoOperation;
 use crate::{Change, UnencodedChange};
 use automerge_protocol as amp;
-use automerge_protocol::{ActorID, Key, ObjType, ObjectID, OpID};
+use automerge_protocol::{ActorID, Key, MapType, ObjType, ObjectID, OpID, SequenceType};
 use std::borrow::BorrowMut;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -122,10 +122,10 @@ impl Backend {
                 let key = resolve_key(rop, &id, elemids2)?;
                 let pred = op_set.get_pred(&object_id, &key, insert);
                 let action = match rop.action {
-                    amp::OpType::MakeMap => OpType::Make(ObjType::Map),
-                    amp::OpType::MakeTable => OpType::Make(ObjType::Table),
-                    amp::OpType::MakeList => OpType::Make(ObjType::List),
-                    amp::OpType::MakeText => OpType::Make(ObjType::Text),
+                    amp::OpType::MakeMap => OpType::Make(ObjType::Map(MapType::Map)),
+                    amp::OpType::MakeTable => OpType::Make(ObjType::Map(MapType::Table)),
+                    amp::OpType::MakeList => OpType::Make(ObjType::Sequence(SequenceType::List)),
+                    amp::OpType::MakeText => OpType::Make(ObjType::Sequence(SequenceType::Text)),
                     amp::OpType::Del => OpType::Del,
                     amp::OpType::Link => OpType::Link(
                         child.ok_or_else(|| AutomergeError::LinkMissingChild(id.clone()))?,

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -336,7 +336,7 @@ const HEADER_BYTES: usize = PREAMBLE_BYTES + 1;
 mod tests {
     use super::*;
     use crate::op_type::OpType;
-    use automerge_protocol::{Key, ObjType, ObjectID, OpID, Value};
+    use automerge_protocol::{Key, ObjType, ObjectID, OpID, SequenceType, Value};
     use std::str::FromStr;
 
     #[test]
@@ -414,7 +414,7 @@ mod tests {
                     pred: vec![opid3.clone(), opid4.clone()],
                 },
                 Operation {
-                    action: OpType::Make(ObjType::List),
+                    action: OpType::Make(ObjType::Sequence(SequenceType::List)),
                     key: key2.clone(),
                     obj: obj2.clone(),
                     insert,

--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -2,7 +2,9 @@ use crate::encoding::{BooleanDecoder, Decodable, Decoder, DeltaDecoder, RLEDecod
 use crate::encoding::{BooleanEncoder, ColData, DeltaEncoder, Encodable, RLEEncoder};
 use crate::op::Operation;
 use crate::op_type::OpType;
-use automerge_protocol::{ActorID, ElementID, Key, ObjType, ObjectID, OpID, Value};
+use automerge_protocol::{
+    ActorID, ElementID, Key, MapType, ObjType, ObjectID, OpID, SequenceType, Value,
+};
 use core::fmt::Debug;
 use std::io;
 use std::io::{Read, Write};
@@ -229,10 +231,10 @@ impl<'a> Iterator for OperationIterator<'a> {
         let child = self.chld.next()?;
         let action = match action {
             Action::Set => OpType::Set(value),
-            Action::MakeList => OpType::Make(ObjType::List),
-            Action::MakeText => OpType::Make(ObjType::Text),
-            Action::MakeMap => OpType::Make(ObjType::Map),
-            Action::MakeTable => OpType::Make(ObjType::Table),
+            Action::MakeList => OpType::Make(ObjType::Sequence(SequenceType::List)),
+            Action::MakeText => OpType::Make(ObjType::Sequence(SequenceType::Text)),
+            Action::MakeMap => OpType::Make(ObjType::Map(MapType::Map)),
+            Action::MakeTable => OpType::Make(ObjType::Map(MapType::Table)),
             Action::Del => OpType::Del,
             Action::Inc => OpType::Inc(value.to_i64()?),
             Action::Link => OpType::Link(child),
@@ -537,10 +539,10 @@ impl ColumnEncoder {
                 self.val.append_null();
                 self.chld.append_null();
                 match kind {
-                    ObjType::List => Action::MakeList,
-                    ObjType::Map => Action::MakeMap,
-                    ObjType::Table => Action::MakeTable,
-                    ObjType::Text => Action::MakeText,
+                    ObjType::Sequence(SequenceType::List) => Action::MakeList,
+                    ObjType::Map(MapType::Map) => Action::MakeMap,
+                    ObjType::Map(MapType::Table) => Action::MakeTable,
+                    ObjType::Sequence(SequenceType::Text) => Action::MakeText,
                 }
             }
         };

--- a/automerge-backend/src/object_store.rs
+++ b/automerge-backend/src/object_store.rs
@@ -38,7 +38,7 @@ impl ObjState {
 
     pub fn is_seq(&self) -> bool {
         match self.obj_type {
-            ObjType::Text | ObjType::List => true,
+            ObjType::Sequence(_) => true,
             _ => false,
         }
     }

--- a/automerge-backend/src/op.rs
+++ b/automerge-backend/src/op.rs
@@ -201,10 +201,14 @@ impl<'de> Deserialize<'de> for Operation {
                 let insert = insert.unwrap_or(false);
                 let value = amp::Value::from(value, datatype);
                 let action = match action {
-                    amp::OpType::MakeMap => OpType::Make(amp::ObjType::Map),
-                    amp::OpType::MakeTable => OpType::Make(amp::ObjType::Table),
-                    amp::OpType::MakeList => OpType::Make(amp::ObjType::List),
-                    amp::OpType::MakeText => OpType::Make(amp::ObjType::Text),
+                    amp::OpType::MakeMap => OpType::Make(amp::ObjType::Map(amp::MapType::Map)),
+                    amp::OpType::MakeTable => OpType::Make(amp::ObjType::Map(amp::MapType::Table)),
+                    amp::OpType::MakeList => {
+                        OpType::Make(amp::ObjType::Sequence(amp::SequenceType::List))
+                    }
+                    amp::OpType::MakeText => {
+                        OpType::Make(amp::ObjType::Sequence(amp::SequenceType::Text))
+                    }
                     amp::OpType::Del => OpType::Del,
                     amp::OpType::Link => {
                         OpType::Link(child.ok_or_else(|| Error::missing_field("pred"))?)

--- a/automerge-backend/src/op_set.rs
+++ b/automerge-backend/src/op_set.rs
@@ -16,7 +16,7 @@ use crate::ordered_set::OrderedSet;
 use crate::pending_diff::PendingDiff;
 use crate::undo_operation::UndoOperation;
 use automerge_protocol::{
-    ChangeHash, Diff, DiffEdit, Key, MapDiff, ObjDiff, ObjType, ObjectID, OpID, SeqDiff,
+    ChangeHash, Diff, DiffEdit, Key, MapDiff, MapType, ObjDiff, ObjType, ObjectID, OpID, SeqDiff,
 };
 use core::cmp::max;
 use std::collections::HashMap;
@@ -49,7 +49,10 @@ pub(crate) struct OpSet {
 impl OpSet {
     pub fn init() -> OpSet {
         let mut objs = im_rc::HashMap::new();
-        objs.insert(ObjectID::Root, Rc::new(ObjState::new(ObjType::Map)));
+        objs.insert(
+            ObjectID::Root,
+            Rc::new(ObjState::new(ObjType::Map(MapType::Map))),
+        );
 
         OpSet {
             objs,

--- a/automerge-backend/src/op_type.rs
+++ b/automerge-backend/src/op_type.rs
@@ -1,4 +1,4 @@
-use automerge_protocol::{ObjType, ObjectID, Value};
+use automerge_protocol::{MapType, ObjType, ObjectID, SequenceType, Value};
 use serde::{Serialize, Serializer};
 
 #[derive(PartialEq, Debug, Clone)]
@@ -16,10 +16,10 @@ impl Serialize for OpType {
         S: Serializer,
     {
         let s = match self {
-            OpType::Make(ObjType::Map) => "makeMap",
-            OpType::Make(ObjType::Table) => "makeTable",
-            OpType::Make(ObjType::List) => "makeList",
-            OpType::Make(ObjType::Text) => "makeText",
+            OpType::Make(ObjType::Map(MapType::Map)) => "makeMap",
+            OpType::Make(ObjType::Map(MapType::Table)) => "makeTable",
+            OpType::Make(ObjType::Sequence(SequenceType::List)) => "makeList",
+            OpType::Make(ObjType::Sequence(SequenceType::Text)) => "makeText",
             OpType::Del => "del",
             OpType::Link(_) => "link",
             OpType::Inc(_) => "inc",

--- a/automerge-backend/tests/apply_change.rs
+++ b/automerge-backend/tests/apply_change.rs
@@ -39,7 +39,7 @@ fn test_incremental_diffs_in_a_map() {
         can_redo: false,
         diffs: Some(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap!( "bird".into() => hashmap!( "1@7b7723afd9e6480397a4d467b7693156".into() => "magpie".into() ))
         }.into()),
     };
@@ -91,7 +91,7 @@ fn test_increment_key_in_map() -> Result<(), AutomergeError> {
         diffs: Some(
             MapDiff {
                 object_id: ObjectID::Root.to_string(),
-                obj_type: ObjType::Map(MapType::Map),
+                obj_type: MapType::Map,
                 props: hashmap!(
                 "counter".into() => hashmap!{
                     "1@cdee6963c1664645920be8b41a933c2b".into() =>  Value::Counter(3).into(),
@@ -155,7 +155,7 @@ fn test_conflict_on_assignment_to_same_map_key() {
         diffs: Some(
             MapDiff {
                 object_id: ObjectID::Root.to_string(),
-                obj_type: ObjType::Map(MapType::Map),
+                obj_type: MapType::Map,
                 props: hashmap!( "bird".into() => hashmap!(
                             "1@ac11".into() => "magpie".into(),
                             "2@ac22".into() => "blackbird".into(),
@@ -218,7 +218,7 @@ fn delete_key_from_map() {
         can_redo: false,
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "bird".into() => hashmap!{}
             },
@@ -270,12 +270,12 @@ fn create_nested_maps() {
         version: 1,
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@d6226fcd55204b82b396f2473da3e26f".into() => Diff::Map(MapDiff{
                         object_id: "1@d6226fcd55204b82b396f2473da3e26f".try_into().unwrap(),
-                        obj_type: ObjType::Map(MapType::Map),
+                        obj_type: MapType::Map,
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                  "2@d6226fcd55204b82b396f2473da3e26f".into() => Diff::Value(Value::F64(3.0))
@@ -350,12 +350,12 @@ fn test_assign_to_nested_keys_in_map() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@3c39c994039042778f4779a01a59a917".into() => Diff::Map(MapDiff{
                         object_id: "1@3c39c994039042778f4779a01a59a917".into(),
-                        obj_type: ObjType::Map(MapType::Map),
+                        obj_type: MapType::Map,
                         props: hashmap!{
                             "sparrows".into() => hashmap!{
                                 "3@3c39c994039042778f4779a01a59a917".into() => Diff::Value(Value::F64(15.0))
@@ -413,12 +413,12 @@ fn test_create_lists() {
         deps: vec![change.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@f82cb62dabe64372ab87466b77792010".into() => Diff::Seq(SeqDiff{
                         object_id: "1@f82cb62dabe64372ab87466b77792010".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![DiffEdit::Insert{ index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -494,12 +494,12 @@ fn test_apply_updates_inside_lists() {
         seq: None,
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@4ee4a0d033b841c4b26d73d70a879547".into() => Diff::Seq(SeqDiff{
                         object_id: "1@4ee4a0d033b841c4b26d73d70a879547".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: Vec::new(),
                         props: hashmap!{
                             0 => hashmap!{
@@ -578,12 +578,12 @@ fn test_delete_list_elements() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@8a3d4716fdca49f4aa5835901f2034c7".into() => Diff::Seq(SeqDiff{
                         object_id:  "1@8a3d4716fdca49f4aa5835901f2034c7".try_into().unwrap(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         props: hashmap!{},
                         edits: vec![DiffEdit::Remove{index: 0}]
                     })
@@ -658,12 +658,12 @@ fn test_handle_list_element_insertion_and_deletion_in_same_change() {
         deps: vec![change2.hash, change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@ca95bc759404486bbe7b9dd2be779fa8".try_into().unwrap() => Diff::Seq(SeqDiff{
                         object_id: "1@ca95bc759404486bbe7b9dd2be779fa8".try_into().unwrap(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![
                             DiffEdit::Insert{index: 0},
                             DiffEdit::Remove{index: 0},
@@ -749,7 +749,7 @@ fn test_handle_changes_within_conflicted_objects() {
         deps: vec![change1.hash, change3.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "conflict".into() => hashmap!{
                     "1@9f17517523e54ee888e9cd51dfd7a572".into() => Diff::Unchanged(ObjDiff{
@@ -758,7 +758,7 @@ fn test_handle_changes_within_conflicted_objects() {
                     }),
                     "1@83768a19a13842beb6dde8c68a662fad".into() => Diff::Map(MapDiff{
                        object_id: "1@83768a19a13842beb6dde8c68a662fad".try_into().unwrap(),
-                       obj_type: ObjType::Map(MapType::Map),
+                       obj_type: MapType::Map,
                        props: hashmap!{
                            "sparrow".into() => hashmap!{
                              "2@83768a19a13842beb6dde8c68a662fad".into() => Diff::Value(Value::F64(12.0))
@@ -809,7 +809,7 @@ fn test_support_date_objects_at_root() {
         deps: vec![change.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "now".into() => hashmap!{
                     "1@955afa3bbcc140b3b4bac8836479d650".into() => Diff::Value(Value::Timestamp(1_586_528_122_277))
@@ -864,12 +864,12 @@ fn test_support_date_objects_in_a_list() {
         seq: None,
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "list".into() => hashmap!{
                     "1@27d467ecb1a640fb9bed448ce7cf6a44".into() => Diff::Seq(SeqDiff{
                         object_id: "1@27d467ecb1a640fb9bed448ce7cf6a44".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![DiffEdit::Insert{index: 0}],
                         props: hashmap!{
                             0 => hashmap!{

--- a/automerge-backend/tests/apply_local_change.rs
+++ b/automerge-backend/tests/apply_local_change.rs
@@ -67,7 +67,7 @@ fn test_apply_local_change() {
         deps: vec![changes[0].hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "bird".into() => hashmap!{
                     "1@eb738e04ef8848ce8b77309b6c7f7e39".into() => Diff::Value("magpie".into())
@@ -522,12 +522,12 @@ fn test_handle_list_insertion_and_deletion_in_same_change() {
         deps: Vec::new(),
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@0723d2a1940744868ffd6b294ada813f".into() => Diff::Seq(SeqDiff{
                         object_id: "1@0723d2a1940744868ffd6b294ada813f".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![
                             DiffEdit::Insert{index: 0},
                             DiffEdit::Remove{index: 0},

--- a/automerge-backend/tests/apply_local_change.rs
+++ b/automerge-backend/tests/apply_local_change.rs
@@ -3,8 +3,8 @@ use automerge_backend::{Backend, UnencodedChange};
 use automerge_backend::{OpType, Operation};
 use automerge_protocol as protocol;
 use automerge_protocol::{
-    ActorID, ChangeHash, DataType, Diff, DiffEdit, ElementID, MapDiff, ObjType, ObjectID, Op,
-    Patch, Request, RequestType, SeqDiff,
+    ActorID, ChangeHash, DataType, Diff, DiffEdit, ElementID, MapDiff, MapType, ObjType, ObjectID,
+    Op, Patch, Request, RequestType, SeqDiff, SequenceType,
 };
 use maplit::hashmap;
 use std::convert::TryInto;
@@ -67,7 +67,7 @@ fn test_apply_local_change() {
         deps: vec![changes[0].hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "bird".into() => hashmap!{
                     "1@eb738e04ef8848ce8b77309b6c7f7e39".into() => Diff::Value("magpie".into())
@@ -271,7 +271,7 @@ fn test_transform_list_indexes_into_element_ids() {
         message: None,
         deps: Vec::new(),
         operations: vec![Operation {
-            action: OpType::Make(ObjType::List),
+            action: OpType::Make(ObjType::Sequence(SequenceType::List)),
             key: "birds".into(),
             obj: ObjectID::Root,
             pred: Vec::new(),
@@ -522,12 +522,12 @@ fn test_handle_list_insertion_and_deletion_in_same_change() {
         deps: Vec::new(),
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@0723d2a1940744868ffd6b294ada813f".into() => Diff::Seq(SeqDiff{
                         object_id: "1@0723d2a1940744868ffd6b294ada813f".into(),
-                        obj_type: ObjType::List,
+                        obj_type: ObjType::Sequence(SequenceType::List),
                         edits: vec![
                             DiffEdit::Insert{index: 0},
                             DiffEdit::Remove{index: 0},
@@ -559,7 +559,7 @@ fn test_handle_list_insertion_and_deletion_in_same_change() {
         deps: Vec::new(),
         operations: vec![Operation {
             obj: ObjectID::Root,
-            action: OpType::Make(ObjType::List),
+            action: OpType::Make(ObjType::Sequence(SequenceType::List)),
             key: "birds".into(),
             insert: false,
             pred: Vec::new(),

--- a/automerge-backend/tests/get_patch.rs
+++ b/automerge-backend/tests/get_patch.rs
@@ -2,7 +2,8 @@ extern crate automerge_backend;
 use automerge_backend::{Backend, UnencodedChange};
 use automerge_backend::{OpType, Operation};
 use automerge_protocol::{
-    ActorID, Diff, DiffEdit, ElementID, MapDiff, ObjType, ObjectID, Patch, SeqDiff, Value,
+    ActorID, Diff, DiffEdit, ElementID, MapDiff, MapType, ObjType, ObjectID, Patch, SeqDiff,
+    SequenceType, Value,
 };
 use maplit::hashmap;
 use std::convert::TryInto;
@@ -56,7 +57,7 @@ fn test_include_most_recent_value_for_key() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "bird".into() => hashmap!{
                     "2@ec28cfbcdb9e4f32ad24b3c776e651b0".into() => Diff::Value("blackbird".into())
@@ -122,7 +123,7 @@ fn test_includes_conflicting_values_for_key() {
         deps: vec![change1.hash, change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "bird".into() => hashmap!{
                     "1@111111".into() => Diff::Value("magpie".into()),
@@ -187,7 +188,7 @@ fn test_handles_counter_increment_at_keys_in_a_map() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "counter".into() => hashmap!{
                     "1@46c92088e4484ae5945dc63bf606a4a5".into() => Diff::Value(Value::Counter(3))
@@ -214,7 +215,7 @@ fn test_creates_nested_maps() {
         deps: Vec::new(),
         operations: vec![
             Operation {
-                action: OpType::Make(ObjType::Map),
+                action: OpType::Make(ObjType::Map(MapType::Map)),
                 obj: ObjectID::Root,
                 key: "birds".into(),
                 pred: Vec::new(),
@@ -269,12 +270,12 @@ fn test_creates_nested_maps() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@06148f9422cb40579fd02f1975c34a51".into() => Diff::Map(MapDiff{
                         object_id: "1@06148f9422cb40579fd02f1975c34a51".into(),
-                        obj_type: ObjType::Map,
+                        obj_type: ObjType::Map(MapType::Map),
                         props: hashmap!{
                             "sparrows".into() => hashmap!{
                                 "4@06148f9422cb40579fd02f1975c34a51".into() => Diff::Value(Value::F64(15.0))
@@ -304,7 +305,7 @@ fn test_create_lists() {
         deps: Vec::new(),
         operations: vec![
             Operation {
-                action: OpType::Make(ObjType::List),
+                action: OpType::Make(ObjType::Sequence(SequenceType::List)),
                 obj: ObjectID::Root,
                 key: "birds".into(),
                 pred: Vec::new(),
@@ -333,12 +334,12 @@ fn test_create_lists() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@90bf7df682f747fa82ac604b35010906".into() => Diff::Seq(SeqDiff{
                         object_id: "1@90bf7df682f747fa82ac604b35010906".into(),
-                        obj_type: ObjType::List,
+                        obj_type: ObjType::Sequence(SequenceType::List),
                         edits: vec![DiffEdit::Insert { index :0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -369,14 +370,14 @@ fn test_includes_latests_state_of_list() {
         deps: Vec::new(),
         operations: vec![
             Operation {
-                action: OpType::Make(ObjType::List),
+                action: OpType::Make(ObjType::Sequence(SequenceType::List)),
                 obj: ObjectID::Root,
                 key: "todos".into(),
                 pred: Vec::new(),
                 insert: false,
             },
             Operation {
-                action: OpType::Make(ObjType::Map),
+                action: OpType::Make(ObjType::Map(MapType::Map)),
                 obj: "1@6caaa2e433de42ae9c3fa65c9ff3f03e".try_into().unwrap(),
                 key: ElementID::Head.into(),
                 insert: true,
@@ -412,18 +413,18 @@ fn test_includes_latests_state_of_list() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "todos".into() => hashmap!{
                     "1@6caaa2e433de42ae9c3fa65c9ff3f03e".into() => Diff::Seq(SeqDiff{
                         object_id: "1@6caaa2e433de42ae9c3fa65c9ff3f03e".into(),
-                        obj_type: ObjType::List,
+                        obj_type: ObjType::Sequence(SequenceType::List),
                         edits: vec![DiffEdit::Insert{index: 0}],
                         props: hashmap!{
                             0 => hashmap!{
                                 "2@6caaa2e433de42ae9c3fa65c9ff3f03e".into() => Diff::Map(MapDiff{
                                     object_id: "2@6caaa2e433de42ae9c3fa65c9ff3f03e".into(),
-                                    obj_type: ObjType::Map,
+                                    obj_type: ObjType::Map(MapType::Map),
                                     props: hashmap!{
                                         "title".into() => hashmap!{
                                             "3@6caaa2e433de42ae9c3fa65c9ff3f03e".into() => Diff::Value("water plants".into()),
@@ -479,7 +480,7 @@ fn test_includes_date_objects_at_root() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "now".into() => hashmap!{
                     "1@90f5dd5d4f524e95ad5929e08d1194f1".into() => Diff::Value(Value::Timestamp(1_586_541_033_457))
@@ -506,7 +507,7 @@ fn test_includes_date_objects_in_a_list() {
         deps: Vec::new(),
         operations: vec![
             Operation {
-                action: OpType::Make(ObjType::List),
+                action: OpType::Make(ObjType::Sequence(SequenceType::List)),
                 obj: ObjectID::Root,
                 key: "list".into(),
                 pred: Vec::new(),
@@ -535,12 +536,12 @@ fn test_includes_date_objects_in_a_list() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map,
+            obj_type: ObjType::Map(MapType::Map),
             props: hashmap! {
                 "list".into() => hashmap!{
                     "1@08b050f976a249349021a2e63d99c8e8".into() => Diff::Seq(SeqDiff{
                         object_id: "1@08b050f976a249349021a2e63d99c8e8".into(),
-                        obj_type: ObjType::List,
+                        obj_type: ObjType::Sequence(SequenceType::List),
                         edits: vec![DiffEdit::Insert {index: 0}],
                         props: hashmap!{
                             0 => hashmap!{

--- a/automerge-backend/tests/get_patch.rs
+++ b/automerge-backend/tests/get_patch.rs
@@ -57,7 +57,7 @@ fn test_include_most_recent_value_for_key() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "bird".into() => hashmap!{
                     "2@ec28cfbcdb9e4f32ad24b3c776e651b0".into() => Diff::Value("blackbird".into())
@@ -123,7 +123,7 @@ fn test_includes_conflicting_values_for_key() {
         deps: vec![change1.hash, change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "bird".into() => hashmap!{
                     "1@111111".into() => Diff::Value("magpie".into()),
@@ -188,7 +188,7 @@ fn test_handles_counter_increment_at_keys_in_a_map() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "counter".into() => hashmap!{
                     "1@46c92088e4484ae5945dc63bf606a4a5".into() => Diff::Value(Value::Counter(3))
@@ -270,12 +270,12 @@ fn test_creates_nested_maps() {
         deps: vec![change2.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@06148f9422cb40579fd02f1975c34a51".into() => Diff::Map(MapDiff{
                         object_id: "1@06148f9422cb40579fd02f1975c34a51".into(),
-                        obj_type: ObjType::Map(MapType::Map),
+                        obj_type: MapType::Map,
                         props: hashmap!{
                             "sparrows".into() => hashmap!{
                                 "4@06148f9422cb40579fd02f1975c34a51".into() => Diff::Value(Value::F64(15.0))
@@ -334,12 +334,12 @@ fn test_create_lists() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     "1@90bf7df682f747fa82ac604b35010906".into() => Diff::Seq(SeqDiff{
                         object_id: "1@90bf7df682f747fa82ac604b35010906".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![DiffEdit::Insert { index :0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -413,18 +413,18 @@ fn test_includes_latests_state_of_list() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "todos".into() => hashmap!{
                     "1@6caaa2e433de42ae9c3fa65c9ff3f03e".into() => Diff::Seq(SeqDiff{
                         object_id: "1@6caaa2e433de42ae9c3fa65c9ff3f03e".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![DiffEdit::Insert{index: 0}],
                         props: hashmap!{
                             0 => hashmap!{
                                 "2@6caaa2e433de42ae9c3fa65c9ff3f03e".into() => Diff::Map(MapDiff{
                                     object_id: "2@6caaa2e433de42ae9c3fa65c9ff3f03e".into(),
-                                    obj_type: ObjType::Map(MapType::Map),
+                                    obj_type: MapType::Map,
                                     props: hashmap!{
                                         "title".into() => hashmap!{
                                             "3@6caaa2e433de42ae9c3fa65c9ff3f03e".into() => Diff::Value("water plants".into()),
@@ -480,7 +480,7 @@ fn test_includes_date_objects_at_root() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "now".into() => hashmap!{
                     "1@90f5dd5d4f524e95ad5929e08d1194f1".into() => Diff::Value(Value::Timestamp(1_586_541_033_457))
@@ -536,12 +536,12 @@ fn test_includes_date_objects_in_a_list() {
         deps: vec![change1.hash],
         diffs: Some(Diff::Map(MapDiff {
             object_id: ObjectID::Root.to_string(),
-            obj_type: ObjType::Map(MapType::Map),
+            obj_type: MapType::Map,
             props: hashmap! {
                 "list".into() => hashmap!{
                     "1@08b050f976a249349021a2e63d99c8e8".into() => Diff::Seq(SeqDiff{
                         object_id: "1@08b050f976a249349021a2e63d99c8e8".into(),
-                        obj_type: ObjType::Sequence(SequenceType::List),
+                        obj_type: SequenceType::List,
                         edits: vec![DiffEdit::Insert {index: 0}],
                         props: hashmap!{
                             0 => hashmap!{

--- a/automerge-frontend/src/change_context.rs
+++ b/automerge-frontend/src/change_context.rs
@@ -140,7 +140,7 @@ impl<'a> ChangeContext<'a> {
             }) => {
                 let object_id = ObjectID::from_str(object_id_str).unwrap();
                 match obj_type {
-                    ObjType::Map(MapType::Map) => {
+                    MapType::Map => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -178,7 +178,7 @@ impl<'a> ChangeContext<'a> {
                         };
                         Ok(obj)
                     }
-                    ObjType::Map(MapType::Table) => {
+                    MapType::Table => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -222,7 +222,6 @@ impl<'a> ChangeContext<'a> {
                         };
                         Ok(obj)
                     }
-                    _ => panic!("Invalid object type (not map or table) inside MapDiff"),
                 }
             }
             Diff::Seq(SeqDiff {
@@ -233,7 +232,7 @@ impl<'a> ChangeContext<'a> {
             }) => {
                 let object_id = ObjectID::from_str(object_id_str).unwrap();
                 match obj_type {
-                    ObjType::Sequence(SequenceType::List) => {
+                    SequenceType::List => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -276,7 +275,7 @@ impl<'a> ChangeContext<'a> {
                         };
                         Ok(obj)
                     }
-                    ObjType::Sequence(SequenceType::Text) => {
+                    SequenceType::Text => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -319,7 +318,6 @@ impl<'a> ChangeContext<'a> {
                         };
                         Ok(obj)
                     }
-                    _ => panic!("Invalid object type (not map or table) inside MapDiff"),
                 }
             }
             Diff::Value(v) => Ok(Rc::new(RefCell::new(Object::Primitive(v.clone())))),

--- a/automerge-frontend/src/change_context.rs
+++ b/automerge-frontend/src/change_context.rs
@@ -1,7 +1,9 @@
-use automerge_protocol::{Diff, DiffEdit, MapDiff, ObjType, ObjectID, OpID, SeqDiff};
+use automerge_protocol::{
+    Diff, DiffEdit, MapDiff, MapType, ObjType, ObjectID, OpID, SeqDiff, SequenceType,
+};
 //use crate::AutomergeFrontendError;
 use crate::object::{Object, Values};
-use crate::{AutomergeFrontendError, MapType, SequenceType, Value};
+use crate::{AutomergeFrontendError, Value};
 use std::str::FromStr;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
@@ -138,7 +140,7 @@ impl<'a> ChangeContext<'a> {
             }) => {
                 let object_id = ObjectID::from_str(object_id_str).unwrap();
                 match obj_type {
-                    ObjType::Map => {
+                    ObjType::Map(MapType::Map) => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -176,7 +178,7 @@ impl<'a> ChangeContext<'a> {
                         };
                         Ok(obj)
                     }
-                    ObjType::Table => {
+                    ObjType::Map(MapType::Table) => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -231,7 +233,7 @@ impl<'a> ChangeContext<'a> {
             }) => {
                 let object_id = ObjectID::from_str(object_id_str).unwrap();
                 match obj_type {
-                    ObjType::List => {
+                    ObjType::Sequence(SequenceType::List) => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -274,7 +276,7 @@ impl<'a> ChangeContext<'a> {
                         };
                         Ok(obj)
                     }
-                    ObjType::Text => {
+                    ObjType::Sequence(SequenceType::Text) => {
                         let obj = Self::get_or_create_object(
                             &object_id,
                             original_objects,
@@ -328,16 +330,16 @@ impl<'a> ChangeContext<'a> {
                     original_objects,
                     updated,
                     || match subdiff.obj_type {
-                        ObjType::Map => {
+                        ObjType::Map(MapType::Map) => {
                             Object::Map(object_id.clone(), HashMap::new(), MapType::Map)
                         }
-                        ObjType::Table => {
+                        ObjType::Map(MapType::Table) => {
                             Object::Map(object_id.clone(), HashMap::new(), MapType::Table)
                         }
-                        ObjType::List => {
+                        ObjType::Sequence(SequenceType::List) => {
                             Object::Sequence(object_id.clone(), Vec::new(), SequenceType::List)
                         }
-                        ObjType::Text => {
+                        ObjType::Sequence(SequenceType::Text) => {
                             Object::Sequence(object_id.clone(), Vec::new(), SequenceType::Text)
                         }
                     },

--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -1,4 +1,4 @@
-use automerge_protocol::{ActorID, ObjectID, Op, OpID, Patch, Request, RequestType};
+use automerge_protocol::{ActorID, MapType, ObjectID, Op, OpID, Patch, Request, RequestType};
 
 mod change_context;
 mod error;
@@ -14,7 +14,7 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 use std::time;
 use std::{collections::HashMap, rc::Rc};
-pub use value::{Conflicts, MapType, SequenceType, Value};
+pub use value::{Conflicts, Value};
 
 /// Tracks the possible states of the frontend
 ///

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -326,12 +326,12 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
             .rfold(subdiff, |diff_so_far, intermediate| match intermediate {
                 Intermediate::Map(oid, map_type, k, opid) => amp::Diff::Map(amp::MapDiff {
                     object_id: oid.to_string(),
-                    obj_type: amp::ObjType::Map(map_type),
+                    obj_type: map_type,
                     props: hashmap! {k => hashmap!{opid.unwrap_or_else(random_op_id).to_string() => diff_so_far}},
                 }),
                 Intermediate::Seq(oid, seq_type, index, opid) => amp::Diff::Seq(amp::SeqDiff {
                     object_id: oid.to_string(),
-                    obj_type: amp::ObjType::Sequence(seq_type),
+                    obj_type: seq_type,
                     edits: Vec::new(),
                     props: hashmap! {index => hashmap!{opid.unwrap_or_else(random_op_id).to_string() => diff_so_far}},
                 }),
@@ -412,14 +412,14 @@ impl<'a, 'b> MutableDocument for MutationTracker<'a, 'b> {
                     let diff = match &*parent_obj {
                         Object::Map(oid, _, map_type) => amp::Diff::Map(amp::MapDiff {
                             object_id: oid.to_string(),
-                            obj_type: amp::ObjType::Map(*map_type),
+                            obj_type: *map_type,
                             props: hashmap! {change.path.name().unwrap().to_string() => HashMap::new()},
                         }),
                         Object::Sequence(oid, _, seq_type) => {
                             if let Some(PathElement::Index(i)) = change.path.name() {
                                 amp::Diff::Seq(amp::SeqDiff {
                                     object_id: oid.to_string(),
-                                    obj_type: amp::ObjType::Sequence(*seq_type),
+                                    obj_type: *seq_type,
                                     edits: vec![amp::DiffEdit::Remove { index: *i }],
                                     props: hashmap! {*i => HashMap::new()},
                                 })
@@ -497,7 +497,7 @@ impl<'a, 'b> MutableDocument for MutationTracker<'a, 'b> {
                             );
                             let seqdiff = amp::Diff::Seq(amp::SeqDiff {
                                 object_id: oid.to_string(),
-                                obj_type: amp::ObjType::Sequence(*seq_type),
+                                obj_type: *seq_type,
                                 edits: vec![amp::DiffEdit::Insert { index: *index }],
                                 props: hashmap! {
                                     *index => hashmap!{

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -1,6 +1,6 @@
 use crate::change_context::ChangeContext;
 use crate::object::Object;
-use crate::value::{random_op_id, value_to_op_requests, MapType, SequenceType};
+use crate::value::{random_op_id, value_to_op_requests};
 use crate::{AutomergeFrontendError, Value};
 use automerge_protocol as amp;
 use maplit::hashmap;
@@ -247,8 +247,8 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
         // the enclosing diffs
         #[derive(Debug)]
         enum Intermediate {
-            Map(amp::ObjectID, MapType, String, Option<amp::OpID>),
-            Seq(amp::ObjectID, SequenceType, usize, Option<amp::OpID>),
+            Map(amp::ObjectID, amp::MapType, String, Option<amp::OpID>),
+            Seq(amp::ObjectID, amp::SequenceType, usize, Option<amp::OpID>),
         };
         let mut intermediates: Vec<Intermediate> = Vec::new();
 
@@ -265,7 +265,7 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
                     if let Some(target) = vals.get(k) {
                         intermediates.push(Intermediate::Map(
                             oid.clone(),
-                            map_type.clone(),
+                            *map_type,
                             k.clone(),
                             current_obj.default_op_id_for_key(amp::RequestKey::Str(k.clone())),
                         ));
@@ -277,7 +277,7 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
                         if stack.is_empty() {
                             intermediates.push(Intermediate::Map(
                                 oid.clone(),
-                                map_type.clone(),
+                                *map_type,
                                 k.clone(),
                                 current_obj.default_op_id_for_key(amp::RequestKey::Str(k.clone())),
                             ))
@@ -290,7 +290,7 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
                     if let Some(Some(target)) = vals.get(*i) {
                         intermediates.push(Intermediate::Seq(
                             oid.clone(),
-                            seq_type.clone(),
+                            *seq_type,
                             *i,
                             current_obj.default_op_id_for_key(amp::RequestKey::Num(*i as u64)),
                         ));
@@ -304,7 +304,7 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
                         if stack.is_empty() {
                             intermediates.push(Intermediate::Seq(
                                 oid.clone(),
-                                seq_type.clone(),
+                                *seq_type,
                                 *i,
                                 current_obj.default_op_id_for_key(amp::RequestKey::Num(*i as u64)),
                             ))
@@ -326,12 +326,12 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
             .rfold(subdiff, |diff_so_far, intermediate| match intermediate {
                 Intermediate::Map(oid, map_type, k, opid) => amp::Diff::Map(amp::MapDiff {
                     object_id: oid.to_string(),
-                    obj_type: map_type.to_obj_type(),
+                    obj_type: amp::ObjType::Map(map_type),
                     props: hashmap! {k => hashmap!{opid.unwrap_or_else(random_op_id).to_string() => diff_so_far}},
                 }),
                 Intermediate::Seq(oid, seq_type, index, opid) => amp::Diff::Seq(amp::SeqDiff {
                     object_id: oid.to_string(),
-                    obj_type: seq_type.to_obj_type(),
+                    obj_type: amp::ObjType::Sequence(seq_type),
                     edits: Vec::new(),
                     props: hashmap! {index => hashmap!{opid.unwrap_or_else(random_op_id).to_string() => diff_so_far}},
                 }),
@@ -343,7 +343,7 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
     /// the root object
     fn wrap_root_assignment(&mut self, value: &Value) -> Result<(), AutomergeFrontendError> {
         match value {
-            Value::Map(kvs, MapType::Map) => {
+            Value::Map(kvs, amp::MapType::Map) => {
                 for (k, v) in kvs.iter() {
                     self.add_change(LocalChange::set(Path::root().key(k), v.clone()))?;
                 }
@@ -412,14 +412,14 @@ impl<'a, 'b> MutableDocument for MutationTracker<'a, 'b> {
                     let diff = match &*parent_obj {
                         Object::Map(oid, _, map_type) => amp::Diff::Map(amp::MapDiff {
                             object_id: oid.to_string(),
-                            obj_type: map_type.to_obj_type(),
+                            obj_type: amp::ObjType::Map(*map_type),
                             props: hashmap! {change.path.name().unwrap().to_string() => HashMap::new()},
                         }),
                         Object::Sequence(oid, _, seq_type) => {
                             if let Some(PathElement::Index(i)) = change.path.name() {
                                 amp::Diff::Seq(amp::SeqDiff {
                                     object_id: oid.to_string(),
-                                    obj_type: seq_type.to_obj_type(),
+                                    obj_type: amp::ObjType::Sequence(*seq_type),
                                     edits: vec![amp::DiffEdit::Remove { index: *i }],
                                     props: hashmap! {*i => HashMap::new()},
                                 })
@@ -497,7 +497,7 @@ impl<'a, 'b> MutableDocument for MutationTracker<'a, 'b> {
                             );
                             let seqdiff = amp::Diff::Seq(amp::SeqDiff {
                                 object_id: oid.to_string(),
-                                obj_type: seq_type.to_obj_type(),
+                                obj_type: amp::ObjType::Sequence(*seq_type),
                                 edits: vec![amp::DiffEdit::Insert { index: *index }],
                                 props: hashmap! {
                                     *index => hashmap!{

--- a/automerge-frontend/src/object.rs
+++ b/automerge-frontend/src/object.rs
@@ -1,4 +1,4 @@
-use crate::{MapType, SequenceType, Value};
+use crate::Value;
 use automerge_protocol as amp;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
@@ -42,8 +42,8 @@ impl Values {
 /// Internal data type used to represent the values of an automerge document
 #[derive(Clone, Debug)]
 pub enum Object {
-    Sequence(amp::ObjectID, Vec<Option<Values>>, SequenceType),
-    Map(amp::ObjectID, HashMap<String, Values>, MapType),
+    Sequence(amp::ObjectID, Vec<Option<Values>>, amp::SequenceType),
+    Map(amp::ObjectID, HashMap<String, Values>, amp::MapType),
     Primitive(amp::Value),
 }
 
@@ -54,13 +54,13 @@ impl Object {
                 vals.iter()
                     .filter_map(|v| v.clone().map(|v2| v2.to_value()))
                     .collect(),
-                seq_type.clone(),
+                *seq_type,
             ),
             Object::Map(_, vals, map_type) => Value::Map(
                 vals.iter()
                     .map(|(k, v)| (k.to_string(), v.to_value()))
                     .collect(),
-                map_type.clone(),
+                *map_type,
             ),
             Object::Primitive(v) => Value::Primitive(v.clone()),
         }

--- a/automerge-frontend/src/value.rs
+++ b/automerge-frontend/src/value.rs
@@ -181,7 +181,7 @@ pub(crate) fn value_to_op_requests(
                     .map(|(index, _)| amp::DiffEdit::Insert { index })
                     .collect(),
                 object_id: list_id,
-                obj_type: amp::ObjType::Sequence(*seq_type),
+                obj_type: *seq_type,
                 props: child_requests_and_diffs
                     .into_iter()
                     .enumerate()
@@ -226,7 +226,7 @@ pub(crate) fn value_to_op_requests(
                 .collect();
             let child_diff = amp::MapDiff {
                 object_id: map_id,
-                obj_type: amp::ObjType::Map(*map_type),
+                obj_type: *map_type,
                 props: child_requests_and_diffs
                     .into_iter()
                     .map(|(k, (_, diff_link))| {

--- a/automerge-frontend/src/value.rs
+++ b/automerge-frontend/src/value.rs
@@ -104,6 +104,7 @@ impl Value {
                     .iter()
                     .map(|v| match v {
                         Value::Primitive(amp::Value::Str(c)) => c.as_str(),
+                        // TODO fix panic
                         _ => panic!("Non string element in text sequence"),
                     })
                     .collect(),

--- a/automerge-frontend/tests/test_apply_patch.rs
+++ b/automerge-frontend/tests/test_apply_patch.rs
@@ -17,7 +17,7 @@ fn set_object_root_properties() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "bird".into() => hashmap!{
                     actor.op_id_at(1).to_string() => "magpie".into()
@@ -60,7 +60,7 @@ fn reveal_conflicts_on_root_properties() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "favouriteBird".into() => hashmap!{
                     actor1.op_id_at(1).to_string() => amp::Diff::Value("robin".into()),
@@ -103,12 +103,12 @@ fn create_nested_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(2).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                 actor.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(3))
@@ -142,12 +142,12 @@ fn apply_updates_inside_nested_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(2).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                 actor.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(3))
@@ -175,12 +175,12 @@ fn apply_updates_inside_nested_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "sparrows".into() => hashmap!{
                                 actor.op_id_at(3).to_string() => amp::Diff::Value(amp::Value::Int(15))
@@ -229,12 +229,12 @@ fn apply_updates_inside_map_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "favouriteBirds".into() => hashmap!{
                     actor1.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor1.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "blackbirds".into() => hashmap!{
                                 actor1.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(1)),
@@ -243,7 +243,7 @@ fn apply_updates_inside_map_conflicts() {
                     }),
                     actor2.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor2.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                 actor2.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(3)),
@@ -287,12 +287,12 @@ fn apply_updates_inside_map_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "favouriteBirds".into() => hashmap!{
                     actor1.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor1.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "blackbirds".into() => hashmap!{
                                 actor1.op_id_at(3).to_string() => amp::Diff::Value(amp::Value::Int(2)),
@@ -344,7 +344,7 @@ fn delete_keys_in_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "magpies".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Value(amp::Value::Int(2))
@@ -375,7 +375,7 @@ fn delete_keys_in_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "magpies".into() => hashmap!{}
             },
@@ -405,12 +405,12 @@ fn create_lists() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert { index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -446,12 +446,12 @@ fn apply_updates_inside_lists() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert { index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -477,12 +477,12 @@ fn apply_updates_inside_lists() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![],
                         props: hashmap!{
                             0 => hashmap!{
@@ -532,18 +532,18 @@ fn apply_updates_inside_list_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     other_actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: other_actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert{ index: 0}],
                         props: hashmap!{
                             0 => hashmap!{
                                 actor1.op_id_at(2).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor1.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
+                                    obj_type: amp::MapType::Map,
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor1.op_id_at(3).to_string() => amp::Diff::Value("woodpecker".into()),
@@ -555,7 +555,7 @@ fn apply_updates_inside_list_conflicts() {
                                 }),
                                 actor2.op_id_at(2).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor2.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
+                                    obj_type: amp::MapType::Map,
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor2.op_id_at(3).to_string() => amp::Diff::Value("lapwing".into()),
@@ -611,18 +611,18 @@ fn apply_updates_inside_list_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     other_actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: other_actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: Vec::new(),
                         props: hashmap!{
                             0 => hashmap!{
                                 actor1.op_id_at(2).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor1.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
+                                    obj_type: amp::MapType::Map,
                                     props: hashmap!{
                                         "numSeen".into() => hashmap!{
                                             actor1.op_id_at(5).to_string() => amp::Diff::Value(amp::Value::Int(2)),
@@ -683,12 +683,12 @@ fn delete_list_elements() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert { index: 0 }, amp::DiffEdit::Insert { index: 1 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -721,12 +721,12 @@ fn delete_list_elements() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Remove{ index: 0 }],
                         props: hashmap!{}
                     })
@@ -754,12 +754,12 @@ fn apply_updates_at_different_levels_of_object_tree() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "counts".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "magpie".into() => hashmap!{
                                 actor.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(2))
@@ -770,13 +770,13 @@ fn apply_updates_at_different_levels_of_object_tree() {
                 "details".into() => hashmap!{
                     actor.op_id_at(3).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(3).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert{ index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
                                 actor.op_id_at(4).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor.op_id_at(4).to_string(),
-                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
+                                    obj_type: amp::MapType::Map,
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor.op_id_at(5).to_string() => amp::Diff::Value("magpie".into())
@@ -818,12 +818,12 @@ fn apply_updates_at_different_levels_of_object_tree() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "counts".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map(amp::MapType::Map),
+                        obj_type: amp::MapType::Map,
                         props: hashmap!{
                             "magpie".into() => hashmap!{
                                 actor.op_id_at(7).to_string() => amp::Diff::Value(amp::Value::Int(3))
@@ -834,13 +834,13 @@ fn apply_updates_at_different_levels_of_object_tree() {
                 "details".into() => hashmap!{
                     actor.op_id_at(3).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(3).to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: Vec::new(),
                         props: hashmap!{
                             0 => hashmap!{
                                 actor.op_id_at(4).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor.op_id_at(4).to_string(),
-                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
+                                    obj_type: amp::MapType::Map,
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor.op_id_at(8).to_string() => amp::Diff::Value("Eurasian magpie".into())

--- a/automerge-frontend/tests/test_apply_patch.rs
+++ b/automerge-frontend/tests/test_apply_patch.rs
@@ -17,7 +17,7 @@ fn set_object_root_properties() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "bird".into() => hashmap!{
                     actor.op_id_at(1).to_string() => "magpie".into()
@@ -60,7 +60,7 @@ fn reveal_conflicts_on_root_properties() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "favouriteBird".into() => hashmap!{
                     actor1.op_id_at(1).to_string() => amp::Diff::Value("robin".into()),
@@ -103,12 +103,12 @@ fn create_nested_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(2).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                 actor.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(3))
@@ -142,12 +142,12 @@ fn apply_updates_inside_nested_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(2).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                 actor.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(3))
@@ -175,12 +175,12 @@ fn apply_updates_inside_nested_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "sparrows".into() => hashmap!{
                                 actor.op_id_at(3).to_string() => amp::Diff::Value(amp::Value::Int(15))
@@ -229,12 +229,12 @@ fn apply_updates_inside_map_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "favouriteBirds".into() => hashmap!{
                     actor1.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor1.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "blackbirds".into() => hashmap!{
                                 actor1.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(1)),
@@ -243,7 +243,7 @@ fn apply_updates_inside_map_conflicts() {
                     }),
                     actor2.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor2.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "wrens".into() => hashmap!{
                                 actor2.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(3)),
@@ -287,12 +287,12 @@ fn apply_updates_inside_map_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "favouriteBirds".into() => hashmap!{
                     actor1.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor1.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "blackbirds".into() => hashmap!{
                                 actor1.op_id_at(3).to_string() => amp::Diff::Value(amp::Value::Int(2)),
@@ -301,7 +301,7 @@ fn apply_updates_inside_map_conflicts() {
                     }),
                     actor2.op_id_at(1).to_string() => amp::Diff::Unchanged(amp::ObjDiff{
                         object_id: actor2.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                     })
                 }
             },
@@ -344,7 +344,7 @@ fn delete_keys_in_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "magpies".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Value(amp::Value::Int(2))
@@ -375,7 +375,7 @@ fn delete_keys_in_maps() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "magpies".into() => hashmap!{}
             },
@@ -405,12 +405,12 @@ fn create_lists() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert { index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -446,12 +446,12 @@ fn apply_updates_inside_lists() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert { index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -477,12 +477,12 @@ fn apply_updates_inside_lists() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![],
                         props: hashmap!{
                             0 => hashmap!{
@@ -532,18 +532,18 @@ fn apply_updates_inside_list_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     other_actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: other_actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert{ index: 0}],
                         props: hashmap!{
                             0 => hashmap!{
                                 actor1.op_id_at(2).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor1.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map,
+                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor1.op_id_at(3).to_string() => amp::Diff::Value("woodpecker".into()),
@@ -555,7 +555,7 @@ fn apply_updates_inside_list_conflicts() {
                                 }),
                                 actor2.op_id_at(2).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor2.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map,
+                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor2.op_id_at(3).to_string() => amp::Diff::Value("lapwing".into()),
@@ -611,18 +611,18 @@ fn apply_updates_inside_list_conflicts() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     other_actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: other_actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: Vec::new(),
                         props: hashmap!{
                             0 => hashmap!{
                                 actor1.op_id_at(2).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor1.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map,
+                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
                                     props: hashmap!{
                                         "numSeen".into() => hashmap!{
                                             actor1.op_id_at(5).to_string() => amp::Diff::Value(amp::Value::Int(2)),
@@ -631,7 +631,7 @@ fn apply_updates_inside_list_conflicts() {
                                 }),
                                 actor2.op_id_at(2).to_string() => amp::Diff::Unchanged(amp::ObjDiff{
                                     object_id: actor2.op_id_at(2).to_string(),
-                                    obj_type: amp::ObjType::Map,
+                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
                                 }),
                             },
                         }
@@ -683,12 +683,12 @@ fn delete_list_elements() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert { index: 0 }, amp::DiffEdit::Insert { index: 1 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -721,12 +721,12 @@ fn delete_list_elements() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Remove{ index: 0 }],
                         props: hashmap!{}
                     })
@@ -754,12 +754,12 @@ fn apply_updates_at_different_levels_of_object_tree() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "counts".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "magpie".into() => hashmap!{
                                 actor.op_id_at(2).to_string() => amp::Diff::Value(amp::Value::Int(2))
@@ -770,13 +770,13 @@ fn apply_updates_at_different_levels_of_object_tree() {
                 "details".into() => hashmap!{
                     actor.op_id_at(3).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(3).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert{ index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
                                 actor.op_id_at(4).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor.op_id_at(4).to_string(),
-                                    obj_type: amp::ObjType::Map,
+                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor.op_id_at(5).to_string() => amp::Diff::Value("magpie".into())
@@ -818,12 +818,12 @@ fn apply_updates_at_different_levels_of_object_tree() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "counts".into() => hashmap!{
                     actor.op_id_at(1).to_string() => amp::Diff::Map(amp::MapDiff{
                         object_id: actor.op_id_at(1).to_string(),
-                        obj_type: amp::ObjType::Map,
+                        obj_type: amp::ObjType::Map(amp::MapType::Map),
                         props: hashmap!{
                             "magpie".into() => hashmap!{
                                 actor.op_id_at(7).to_string() => amp::Diff::Value(amp::Value::Int(3))
@@ -834,13 +834,13 @@ fn apply_updates_at_different_levels_of_object_tree() {
                 "details".into() => hashmap!{
                     actor.op_id_at(3).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: actor.op_id_at(3).to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: Vec::new(),
                         props: hashmap!{
                             0 => hashmap!{
                                 actor.op_id_at(4).to_string() => amp::Diff::Map(amp::MapDiff{
                                     object_id: actor.op_id_at(4).to_string(),
-                                    obj_type: amp::ObjType::Map,
+                                    obj_type: amp::ObjType::Map(amp::MapType::Map),
                                     props: hashmap!{
                                         "species".into() => hashmap!{
                                             actor.op_id_at(8).to_string() => amp::Diff::Value("Eurasian magpie".into())

--- a/automerge-frontend/tests/test_backend_concurrency.rs
+++ b/automerge-frontend/tests/test_backend_concurrency.rs
@@ -28,7 +28,7 @@ fn use_version_and_sequence_number_from_backend() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "blackbirds".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::F64(24.0))
@@ -120,7 +120,7 @@ fn remove_pending_requests_once_handled() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "blackbirds".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(24))
@@ -154,7 +154,7 @@ fn remove_pending_requests_once_handled() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "partridges".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(1))
@@ -214,7 +214,7 @@ fn leave_request_queue_unchanged_on_remote_changes() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "pheasants".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(2))
@@ -248,7 +248,7 @@ fn leave_request_queue_unchanged_on_remote_changes() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "blackbirds".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(24))
@@ -300,7 +300,7 @@ fn dont_allow_out_of_order_request_patches() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "partridges".to_string() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(1))
@@ -345,12 +345,12 @@ fn handle_concurrent_insertions_into_lists() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap! {
                 "birds".to_string() => hashmap!{
                     doc.actor_id.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert{ index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -411,12 +411,12 @@ fn handle_concurrent_insertions_into_lists() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff{
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap!{
                 "birds".into() => hashmap!{
                     doc.actor_id.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert{ index: 1 }],
                         props: hashmap!{
                             1 => hashmap!{
@@ -451,12 +451,12 @@ fn handle_concurrent_insertions_into_lists() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff{
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map(amp::MapType::Map),
+            obj_type: amp::MapType::Map,
             props: hashmap!{
                 "birds".to_string() => hashmap!{
                     doc.actor_id.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
+                        obj_type: amp::SequenceType::List,
                         edits: vec![amp::DiffEdit::Insert { index: 0 }, amp::DiffEdit::Insert{ index: 2 }],
                         props: hashmap!{
                             0 => hashmap!{

--- a/automerge-frontend/tests/test_backend_concurrency.rs
+++ b/automerge-frontend/tests/test_backend_concurrency.rs
@@ -28,7 +28,7 @@ fn use_version_and_sequence_number_from_backend() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "blackbirds".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::F64(24.0))
@@ -120,7 +120,7 @@ fn remove_pending_requests_once_handled() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "blackbirds".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(24))
@@ -154,7 +154,7 @@ fn remove_pending_requests_once_handled() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "partridges".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(1))
@@ -214,7 +214,7 @@ fn leave_request_queue_unchanged_on_remote_changes() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "pheasants".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(2))
@@ -248,7 +248,7 @@ fn leave_request_queue_unchanged_on_remote_changes() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "blackbirds".into() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(24))
@@ -300,7 +300,7 @@ fn dont_allow_out_of_order_request_patches() {
         can_redo: false,
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "partridges".to_string() => hashmap!{
                     random_op_id() => amp::Diff::Value(amp::Value::Int(1))
@@ -345,12 +345,12 @@ fn handle_concurrent_insertions_into_lists() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff {
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap! {
                 "birds".to_string() => hashmap!{
                     doc.actor_id.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert{ index: 0 }],
                         props: hashmap!{
                             0 => hashmap!{
@@ -411,12 +411,12 @@ fn handle_concurrent_insertions_into_lists() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff{
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap!{
                 "birds".into() => hashmap!{
                     doc.actor_id.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert{ index: 1 }],
                         props: hashmap!{
                             1 => hashmap!{
@@ -451,12 +451,12 @@ fn handle_concurrent_insertions_into_lists() {
         deps: Vec::new(),
         diffs: Some(amp::Diff::Map(amp::MapDiff{
             object_id: amp::ObjectID::Root.to_string(),
-            obj_type: amp::ObjType::Map,
+            obj_type: amp::ObjType::Map(amp::MapType::Map),
             props: hashmap!{
                 "birds".to_string() => hashmap!{
                     doc.actor_id.op_id_at(1).to_string() => amp::Diff::Seq(amp::SeqDiff{
                         object_id: birds_id.to_string(),
-                        obj_type: amp::ObjType::List,
+                        obj_type: amp::ObjType::Sequence(amp::SequenceType::List),
                         edits: vec![amp::DiffEdit::Insert { index: 0 }, amp::DiffEdit::Insert{ index: 2 }],
                         props: hashmap!{
                             0 => hashmap!{

--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -1,6 +1,4 @@
-use automerge_frontend::{
-    AutomergeFrontendError, Frontend, LocalChange, MapType, Path, SequenceType, Value,
-};
+use automerge_frontend::{AutomergeFrontendError, Frontend, LocalChange, Path, Value};
 use automerge_protocol as amp;
 use maplit::hashmap;
 
@@ -272,7 +270,7 @@ fn create_lists() {
         .change(None, |doc| {
             doc.add_change(LocalChange::set(
                 Path::root().key("birds"),
-                Value::Sequence(vec!["chaffinch".into()], SequenceType::List),
+                Value::Sequence(vec!["chaffinch".into()], amp::SequenceType::List),
             ))?;
             Ok(())
         })
@@ -340,7 +338,7 @@ fn apply_updates_inside_lists() {
         .change(None, |doc| {
             doc.add_change(LocalChange::set(
                 Path::root().key("birds"),
-                Value::Sequence(vec!["chaffinch".into()], SequenceType::List),
+                Value::Sequence(vec!["chaffinch".into()], amp::SequenceType::List),
             ))?;
             Ok(())
         })
@@ -474,7 +472,7 @@ fn handle_counters_inside_maps() {
             hashmap! {
                 "wrens".into() => Value::Primitive(amp::Value::Counter(0))
             },
-            MapType::Map
+            amp::MapType::Map
         )
     );
 
@@ -484,7 +482,7 @@ fn handle_counters_inside_maps() {
             hashmap! {
                 "wrens".into() => Value::Primitive(amp::Value::Counter(1))
             },
-            MapType::Map
+            amp::MapType::Map
         )
     );
 
@@ -564,7 +562,7 @@ fn handle_counters_inside_lists() {
             hashmap! {
                 "counts".into() => vec![Value::Primitive(amp::Value::Counter(1))].into()
             },
-            MapType::Map
+            amp::MapType::Map
         )
     );
 
@@ -574,7 +572,7 @@ fn handle_counters_inside_lists() {
             hashmap! {
                 "counts".into() => vec![Value::Primitive(amp::Value::Counter(3))].into()
             },
-            MapType::Map
+            amp::MapType::Map
         )
     );
 

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -11,3 +11,7 @@ hex = "^0.4.2"
 uuid = { version = "^0.5.1", features=["v4"] }
 thiserror = "1.0.16"
 serde = { version = "^1.0", features=["derive"] }
+
+[dev-dependencies]
+maplit = "^1.0.2"
+serde_json = "^1.0"

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -33,10 +33,20 @@ impl ActorID {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum ObjType {
+    Map(MapType),
+    Sequence(SequenceType),
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
+pub enum MapType {
     Map,
     Table,
-    Text,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
+pub enum SequenceType {
     List,
+    Text,
 }
 
 #[derive(Eq, PartialEq, Hash, Clone)]
@@ -211,10 +221,10 @@ impl Op {
 
     pub fn obj_type(&self) -> Option<ObjType> {
         match self.action {
-            OpType::MakeMap => Some(ObjType::Map),
-            OpType::MakeTable => Some(ObjType::Table),
-            OpType::MakeList => Some(ObjType::List),
-            OpType::MakeText => Some(ObjType::Text),
+            OpType::MakeMap => Some(ObjType::Map(MapType::Map)),
+            OpType::MakeTable => Some(ObjType::Map(MapType::Table)),
+            OpType::MakeList => Some(ObjType::Sequence(SequenceType::List)),
+            OpType::MakeText => Some(ObjType::Sequence(SequenceType::Text)),
             _ => None,
         }
     }

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -31,19 +31,21 @@ impl ActorID {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", untagged)]
 pub enum ObjType {
     Map(MapType),
     Sequence(SequenceType),
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
+#[serde(rename_all = "camelCase")]
 pub enum MapType {
     Map,
     Table,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
+#[serde(rename_all = "camelCase")]
 pub enum SequenceType {
     List,
     Text,
@@ -298,7 +300,7 @@ pub enum Diff {
 pub struct MapDiff {
     pub object_id: String,
     #[serde(rename = "type")]
-    pub obj_type: ObjType,
+    pub obj_type: MapType,
     pub props: HashMap<String, HashMap<String, Diff>>,
 }
 
@@ -307,7 +309,7 @@ pub struct MapDiff {
 pub struct SeqDiff {
     pub object_id: String,
     #[serde(rename = "type")]
-    pub obj_type: ObjType,
+    pub obj_type: SequenceType,
     pub edits: Vec<DiffEdit>,
     pub props: HashMap<usize, HashMap<String, Diff>>,
 }

--- a/automerge-protocol/src/serde_impls/diff.rs
+++ b/automerge-protocol/src/serde_impls/diff.rs
@@ -87,27 +87,28 @@ impl<'de> Deserialize<'de> for Diff {
                     let object_id = object_id.ok_or_else(|| Error::missing_field("objectId"))?;
                     let obj_type = obj_type.ok_or_else(|| Error::missing_field("type"))?;
                     if let Some(mut props) = props {
-                        if let ObjType::Sequence(_) = obj_type {
-                            let edits = edits.ok_or_else(|| Error::missing_field("edits"))?;
-                            let mut new_props = HashMap::new();
-                            for (k, v) in props.drain() {
-                                let index = k.parse().map_err(|_| {
-                                    Error::invalid_type(Unexpected::Str(&k), &"an integer")
-                                })?;
-                                new_props.insert(index, v);
+                        match obj_type {
+                            ObjType::Sequence(seq_type) => {
+                                let edits = edits.ok_or_else(|| Error::missing_field("edits"))?;
+                                let mut new_props = HashMap::new();
+                                for (k, v) in props.drain() {
+                                    let index = k.parse().map_err(|_| {
+                                        Error::invalid_type(Unexpected::Str(&k), &"an integer")
+                                    })?;
+                                    new_props.insert(index, v);
+                                }
+                                Ok(Diff::Seq(SeqDiff {
+                                    object_id,
+                                    obj_type: seq_type,
+                                    edits,
+                                    props: new_props,
+                                }))
                             }
-                            Ok(Diff::Seq(SeqDiff {
+                            ObjType::Map(map_type) => Ok(Diff::Map(MapDiff {
                                 object_id,
-                                obj_type,
-                                edits,
-                                props: new_props,
-                            }))
-                        } else {
-                            Ok(Diff::Map(MapDiff {
-                                object_id,
-                                obj_type,
+                                obj_type: map_type,
                                 props,
-                            }))
+                            })),
                         }
                     } else {
                         Ok(Diff::Unchanged(ObjDiff {
@@ -139,5 +140,67 @@ fn maybe_add_datatype_to_value(value: Value, datatype: DataType) -> Value {
             }
         }
         _ => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Diff, MapDiff, MapType, SeqDiff, SequenceType};
+    use maplit::hashmap;
+
+    #[test]
+    fn map_diff_serialization_round_trip() {
+        let json = serde_json::json!({
+            "objectId": "1@6121f875-7d5d-4660-9b66-5218b2b3a141",
+            "type": "map",
+            "props": {
+                "key": {
+                    "1@4a093244-de2b-4fd0-a420-3724e15dfc16": {
+                        "value": "value"
+                    }
+                }
+            }
+        });
+        let diff = Diff::Map(MapDiff {
+            object_id: "1@6121f875-7d5d-4660-9b66-5218b2b3a141".to_string(),
+            obj_type: MapType::Map,
+            props: hashmap! {
+                "key".to_string() => hashmap!{
+                    "1@4a093244-de2b-4fd0-a420-3724e15dfc16".to_string() => "value".into()
+                }
+            },
+        });
+
+        assert_eq!(json.clone(), serde_json::to_value(diff.clone()).unwrap());
+        assert_eq!(serde_json::from_value::<Diff>(json).unwrap(), diff);
+    }
+
+    #[test]
+    fn seq_diff_serialization_round_trip() {
+        let json = serde_json::json!({
+            "objectId": "1@6121f875-7d5d-4660-9b66-5218b2b3a141",
+            "type": "list",
+            "edits": [],
+            "props": {
+                "0": {
+                    "1@4a093244-de2b-4fd0-a420-3724e15dfc16": {
+                        "value": "value"
+                    }
+                }
+            }
+        });
+        let diff = Diff::Seq(SeqDiff {
+            object_id: "1@6121f875-7d5d-4660-9b66-5218b2b3a141".to_string(),
+            obj_type: SequenceType::List,
+            edits: Vec::new(),
+            props: hashmap! {
+                0 => hashmap!{
+                    "1@4a093244-de2b-4fd0-a420-3724e15dfc16".to_string() => "value".into()
+                }
+            },
+        });
+
+        assert_eq!(json.clone(), serde_json::to_value(diff.clone()).unwrap());
+        assert_eq!(serde_json::from_value::<Diff>(json).unwrap(), diff);
     }
 }

--- a/automerge-protocol/src/serde_impls/diff.rs
+++ b/automerge-protocol/src/serde_impls/diff.rs
@@ -171,7 +171,7 @@ mod tests {
             },
         });
 
-        assert_eq!(json.clone(), serde_json::to_value(diff.clone()).unwrap());
+        assert_eq!(json, serde_json::to_value(diff.clone()).unwrap());
         assert_eq!(serde_json::from_value::<Diff>(json).unwrap(), diff);
     }
 
@@ -200,7 +200,7 @@ mod tests {
             },
         });
 
-        assert_eq!(json.clone(), serde_json::to_value(diff.clone()).unwrap());
+        assert_eq!(json, serde_json::to_value(diff.clone()).unwrap());
         assert_eq!(serde_json::from_value::<Diff>(json).unwrap(), diff);
     }
 }

--- a/automerge-protocol/src/serde_impls/diff.rs
+++ b/automerge-protocol/src/serde_impls/diff.rs
@@ -87,7 +87,7 @@ impl<'de> Deserialize<'de> for Diff {
                     let object_id = object_id.ok_or_else(|| Error::missing_field("objectId"))?;
                     let obj_type = obj_type.ok_or_else(|| Error::missing_field("type"))?;
                     if let Some(mut props) = props {
-                        if obj_type == ObjType::Text || obj_type == ObjType::List {
+                        if let ObjType::Sequence(_) = obj_type {
                             let edits = edits.ok_or_else(|| Error::missing_field("edits"))?;
                             let mut new_props = HashMap::new();
                             for (k, v) in props.drain() {


### PR DESCRIPTION
This changes the `ObjType` enum from 

```
enum ObjType {
    Map,
    List,
    Table,
    Text
}
```

to 

```
enum ObjType {
    Map(MapType),
    Sequence(SequenceType)
}

enum MapType {
    Map,
    Table,
}

enum SequenceType {
    List
    Text,
}
```
The serde serialization of diffs remains the same so there's no FFI change.

The main reason to do this is that it allows a greater degree of type safety when processing `MapDiff` and `SeqDiff`. This is because we can now set the `obj_type` of each diff to `MapType` and `SequenceType` respectively, which means that we have less panicky match arms in the frontend codebase.