### PR TITLE
Tweaks to data formats

### DIFF
--- a/automerge-backend-wasm/index.js
+++ b/automerge-backend-wasm/index.js
@@ -1,11 +1,5 @@
 let Backend = require('./pkg')
-let encodeChange, decodeChanges // initialized by initCodecFunctions
 const util = require('util');
-
-function initCodecFunctions(functions) {
-  encodeChange = functions.encodeChange
-  decodeChanges = functions.decodeChanges
-}
 
 function init() {
   return { state: Backend.State.new(), heads: [], frozen: false }
@@ -85,7 +79,6 @@ function getHeads(backend) {
 }
 
 module.exports = {
-  initCodecFunctions,
   init, clone, save, load, free, applyChanges, applyLocalChange, loadChanges, getPatch,
   getChanges, getChangesForActor, getMissingDeps, getHeads
 }

--- a/automerge-backend-wasm/test/backend_test.js
+++ b/automerge-backend-wasm/test/backend_test.js
@@ -15,7 +15,7 @@ describe('Automerge.Backend', () => {
             ops: [
                   {
                           action: 'makeText',
-                          obj: '00000000-0000-0000-0000-000000000000',
+                          obj: '_root',
                           key: 'text',
                           insert: false,
                           pred: []

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -181,7 +181,7 @@ impl Change {
         let mut last_id = 0;
         while !bytes[cursor.clone()].is_empty() {
             let id = read_slice(&bytes, &mut cursor)?;
-            if id < last_id {
+            if id <= last_id {
                 return Err(AutomergeError::EncodingError);
             }
             last_id = id;

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -33,7 +33,7 @@ pub struct UnencodedChange {
     pub time: i64,
     pub message: Option<String>,
     pub deps: Vec<amp::ChangeHash>,
-    #[serde(rename = "extraBytes")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Default::default")]
     pub extra_bytes: Vec<u8>,
 }
 
@@ -242,7 +242,7 @@ impl Change {
             actor_id: self.actors[0].clone(),
             deps: self.deps.clone(),
             operations: self.iter_ops().collect(),
-            extra_bytes: Vec::new(),
+            extra_bytes: self.bytes[self.extra_bytes.clone()].to_vec()
         }
     }
 

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -33,6 +33,8 @@ pub struct UnencodedChange {
     pub time: i64,
     pub message: Option<String>,
     pub deps: Vec<amp::ChangeHash>,
+    #[serde(rename = "extraBytes")]
+    pub extra_bytes: Vec<u8>,
 }
 
 impl UnencodedChange {
@@ -91,6 +93,7 @@ impl UnencodedChange {
         actors[1..].encode(&mut buf)?;
 
         buf.write_all(&ops_buf)?;
+        buf.write_all(&self.extra_bytes)?;
 
         Ok(buf)
     }
@@ -108,6 +111,7 @@ pub struct Change {
     actors: Vec<amp::ActorID>,
     pub deps: Vec<amp::ChangeHash>,
     ops: HashMap<u32, Range<usize>>,
+    extra_bytes: Range<usize>,
 }
 
 impl Change {
@@ -210,6 +214,7 @@ impl Change {
             message,
             deps,
             ops,
+            extra_bytes: cursor,
         })
     }
 
@@ -237,6 +242,7 @@ impl Change {
             actor_id: self.actors[0].clone(),
             deps: self.deps.clone(),
             operations: self.iter_ops().collect(),
+            extra_bytes: Vec::new(),
         }
     }
 
@@ -356,6 +362,7 @@ mod tests {
             actor_id: amp::ActorID::from_str("deadbeefdeadbeef").unwrap(),
             deps: vec![],
             operations: vec![],
+            extra_bytes: vec![],
         };
         let bin1 = change1.encode();
         let change2 = bin1.decode();
@@ -470,6 +477,7 @@ mod tests {
                     pred: vec![opid4, opid5],
                 },
             ],
+            extra_bytes: vec![],
         };
         let bin1 = change1.encode();
         let change2 = bin1.decode();

--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -559,8 +559,12 @@ impl ColumnEncoder {
         coldata.sort_by(|a, b| a.col.cmp(&b.col));
 
         let mut result = Vec::new();
+        coldata.iter().filter(|&d| !d.data.is_empty()).count().encode(&mut result).ok();
         for d in coldata.iter() {
-            d.encode(&mut result).ok();
+            d.encode_col_len(&mut result).ok();
+        }
+        for d in coldata.iter() {
+            result.write_all(d.data.as_slice()).ok();
         }
         result
     }

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -621,12 +621,12 @@ pub(crate) struct ColData {
     pub data: Vec<u8>,
 }
 
-impl Encodable for ColData {
-    fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize> {
+impl ColData {
+    pub fn encode_col_len<R: Write>(&self, buf: &mut R) -> io::Result<usize> {
         let mut len = 0;
         if !self.data.is_empty() {
             len += self.col.encode(buf)?;
-            len += self.data.as_slice().encode(buf)?;
+            len += self.data.len().encode(buf)?;
         }
         Ok(len)
     }

--- a/automerge-backend/src/op.rs
+++ b/automerge-backend/src/op.rs
@@ -113,7 +113,7 @@ impl Serialize for Operation {
         let mut op = serializer.serialize_struct("Operation", fields)?;
         op.serialize_field("action", &self.action)?;
         op.serialize_field("obj", &self.obj)?;
-        op.serialize_field("key", &self.key)?;
+        op.serialize_field(if self.key.is_map_key() { "key" } else { "elemId" }, &self.key)?;
         if self.insert {
             op.serialize_field("insert", &self.insert)?;
         }
@@ -167,6 +167,7 @@ impl<'de> Deserialize<'de> for Operation {
                         "action" => read_field("action", &mut action, &mut map)?,
                         "obj" => read_field("obj", &mut obj, &mut map)?,
                         "key" => read_field("key", &mut key, &mut map)?,
+                        "elemId" => read_field("elemId", &mut key, &mut map)?,
                         "pred" => read_field("pred", &mut pred, &mut map)?,
                         "insert" => read_field("insert", &mut insert, &mut map)?,
                         "datatype" => read_field("datatype", &mut datatype, &mut map)?,

--- a/automerge-c/automerge.c
+++ b/automerge-c/automerge.c
@@ -26,10 +26,10 @@ int main() {
   Backend * dbA = automerge_init();
   Backend * dbB = automerge_init();
 
-  const char * requestA1 = R"({"actor":"111111","seq":1,"time":0,"version":0,"ops":[{"action":"set","obj":"00000000-0000-0000-0000-000000000000","key":"bird","value":"magpie"}]})";
-  const char * requestA2 = R"({"actor":"111111","seq":2,"time":0,"version":1,"ops":[{"action":"set","obj":"00000000-0000-0000-0000-000000000000","key":"dog","value":"mastiff"}]})";
-  const char * requestB1 = R"({"actor":"222222","seq":1,"time":0,"version":0,"ops":[{"action":"set","obj":"00000000-0000-0000-0000-000000000000","key":"bird","value":"crow"}]})";
-  const char * requestB2 = R"({"actor":"222222","seq":2,"time":0,"version":1,"ops":[{"action":"set","obj":"00000000-0000-0000-0000-000000000000","key":"cat","value":"tabby"}]})";
+  const char * requestA1 = R"({"actor":"111111","seq":1,"time":0,"version":0,"ops":[{"action":"set","obj":"_root","key":"bird","value":"magpie"}]})";
+  const char * requestA2 = R"({"actor":"111111","seq":2,"time":0,"version":1,"ops":[{"action":"set","obj":"_root","key":"dog","value":"mastiff"}]})";
+  const char * requestB1 = R"({"actor":"222222","seq":1,"time":0,"version":0,"ops":[{"action":"set","obj":"_root","key":"bird","value":"crow"}]})";
+  const char * requestB2 = R"({"actor":"222222","seq":2,"time":0,"version":1,"ops":[{"action":"set","obj":"_root","key":"cat","value":"tabby"}]})";
 
   printf("*** requestA1 ***\n\n%s\n\n",requestA1);
 

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -211,7 +211,7 @@ impl<'a, 'b> MutationTracker<'a, 'b> {
     ///
     /// ```json
     /// {
-    ///     objectId: <ROOT>,
+    ///     objectId: '_root',
     ///     type: 'object',
     ///     props: {
     ///         birds: {

--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -2,8 +2,6 @@ use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Valu
 use automerge_protocol as amp;
 use maplit::hashmap;
 
-const ROOT_ID: &str = "00000000-0000-0000-0000-000000000000";
-
 #[test]
 fn test_should_be_empty_after_init() {
     let frontend = Frontend::new();
@@ -68,7 +66,7 @@ fn test_set_root_object_properties() {
         deps: None,
         ops: Some(vec![amp::Op {
             action: amp::OpType::Set,
-            obj: ROOT_ID.to_string(),
+            obj: "_root".to_string(),
             key: amp::RequestKey::Str("bird".to_string()),
             child: None,
             value: Some(amp::ScalarValue::Str("magpie".to_string())),

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -130,6 +130,13 @@ impl Key {
         Key::Seq(ElementID::Head)
     }
 
+    pub fn is_map_key(&self) -> bool {
+        match self {
+            Key::Map(_) => true,
+            Key::Seq(_) => false
+        }
+    }
+
     pub fn as_element_id(&self) -> Option<ElementID> {
         match self {
             Key::Map(_) => None,

--- a/automerge-protocol/src/serde_impls/object_id.rs
+++ b/automerge-protocol/src/serde_impls/object_id.rs
@@ -9,7 +9,7 @@ impl Serialize for ObjectID {
     {
         match self {
             ObjectID::ID(id) => id.serialize(serializer),
-            ObjectID::Root => serializer.serialize_str("00000000-0000-0000-0000-000000000000"),
+            ObjectID::Root => serializer.serialize_str("_root"),
         }
     }
 }
@@ -20,7 +20,7 @@ impl<'de> Deserialize<'de> for ObjectID {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        if s == "00000000-0000-0000-0000-000000000000" {
+        if s == "_root" {
             Ok(ObjectID::Root)
         } else if let Ok(id) = OpID::from_str(&s) {
             Ok(ObjectID::ID(id))

--- a/automerge-protocol/src/utility_impls/object_id.rs
+++ b/automerge-protocol/src/utility_impls/object_id.rs
@@ -13,7 +13,7 @@ impl FromStr for ObjectID {
     type Err = InvalidObjectID;
 
     fn from_str(s: &str) -> Result<ObjectID, Self::Err> {
-        if s == "00000000-0000-0000-0000-000000000000" {
+        if s == "_root" {
             Ok(ObjectID::Root)
         } else if let Ok(id) = OpID::from_str(s) {
             Ok(ObjectID::ID(id))
@@ -32,7 +32,7 @@ impl From<OpID> for ObjectID {
 impl fmt::Display for ObjectID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ObjectID::Root => write!(f, "00000000-0000-0000-0000-000000000000"),
+            ObjectID::Root => write!(f, "_root"),
             ObjectID::ID(oid) => write!(f, "{}", oid),
         }
     }


### PR DESCRIPTION
This PR is the Rust counterpart to automerge/automerge#296. The individual commits on this PR link to their counterparts in the JS implementation.

Due to my poor Rust skills I couldn't figure out how to write the Rust counterpart for automerge/automerge@6fa8b5a5b9bbfb178750c629fc6107b30b9c35a3, so that change is missing from this PR. Could one of you please help with that? If you check out the predecessor commit automerge/automerge@7f2e9f4897a420ca6ebd36421e935dc09484d1d4 on the JS repo, and compile d320ba8b23fc7e0aa2501f4ff98feffcd32d4e98 on this repo, the JS-Wasm tests should be passing, so this PR should only be missing the Rust counterpart to automerge/automerge@6fa8b5a5b9bbfb178750c629fc6107b30b9c35a3.

Commit d320ba8b23fc7e0aa2501f4ff98feffcd32d4e98 is incomplete: although `yarn release` is able to build the wasm, I have not finished updating the Rust tests. I'm not sure what the status of the Rust tests is: running `cargo test` on the current HEAD 83145b82c49809aaccf7e6463e164de59225045d does not even compile, let alone run the tests. Maybe we should first fix those tests, and then finish the changes in d320ba8b23fc7e0aa2501f4ff98feffcd32d4e98.

@orionz @alexjg help please :)