### PR TITLE
Move automerge_backend::UnencodedChange -> automerge_protocol::Uncomp…

### DIFF
--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 //#![feature(set_stdio)]
 
-use automerge_backend::{Backend, Change, UncompressedChange};
-use automerge_protocol::{ActorID, ChangeHash};
+use automerge_backend::{Backend, Change};
+use automerge_protocol::{ActorID, ChangeHash, UncompressedChange};
 use js_sys::{Array, Uint8Array};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 //#![feature(set_stdio)]
 
-use automerge_backend::{Backend, Change, UnencodedChange };
-use automerge_protocol::{ActorID, ChangeHash };
+use automerge_backend::{Backend, Change, UncompressedChange};
+use automerge_protocol::{ActorID, ChangeHash};
 use js_sys::{Array, Uint8Array};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -69,7 +69,7 @@ impl State {
 
     #[wasm_bindgen(js_name = applyLocalChange)]
     pub fn apply_local_change(&mut self, change: JsValue) -> Result<Array, JsValue> {
-        let c: UnencodedChange = js_to_rust(change)?;
+        let c: UncompressedChange = js_to_rust(change)?;
         let (patch, change) = self.backend.apply_local_change(c).map_err(to_js_err)?;
         let heads = self.backend.get_heads();
         let result = Array::new();

--- a/automerge-backend/Cargo.toml
+++ b/automerge-backend/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = "^0.8.1"
 leb128 = "^0.2.4"
 automerge-protocol = { path = "../automerge-protocol" }
 fxhash = "^0.2.1"
+thiserror = "1.0.16"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/automerge-backend/src/actor_map.rs
+++ b/automerge-backend/src/actor_map.rs
@@ -1,6 +1,4 @@
-use crate::internal::{
-    ActorID, ElementID, InternalOp, InternalOpType, Key, ObjectID, OpID,
-};
+use crate::internal::{ActorID, ElementID, InternalOp, InternalOpType, Key, ObjectID, OpID};
 use crate::op_type::OpType;
 use crate::Operation;
 use automerge_protocol as amp;
@@ -66,7 +64,6 @@ impl ActorMap {
         match optype {
             OpType::Make(val) => InternalOpType::Make(*val),
             OpType::Del => InternalOpType::Del,
-            OpType::Link(obj) => InternalOpType::Link(self.import_obj(&obj)),
             OpType::Inc(val) => InternalOpType::Inc(*val),
             OpType::Set(val) => InternalOpType::Set(val.clone()),
         }

--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -60,7 +60,6 @@ impl Encodable for &[u8] {
 pub struct OperationIterator<'a> {
     pub(crate) action: RLEDecoder<'a, Action>,
     pub(crate) objs: ObjIterator<'a>,
-    pub(crate) chld: ObjIterator<'a>,
     pub(crate) keys: KeyIterator<'a>,
     pub(crate) insert: BooleanDecoder<'a>,
     pub(crate) value: ValueIterator<'a>,
@@ -226,7 +225,6 @@ impl<'a> Iterator for OperationIterator<'a> {
         let key = self.keys.next()?;
         let pred = self.pred.next()?;
         let value = self.value.next()?;
-        let child = self.chld.next()?;
         let action = match action {
             Action::Set => OpType::Set(value),
             Action::MakeList => OpType::Make(amp::ObjType::list()),
@@ -235,7 +233,6 @@ impl<'a> Iterator for OperationIterator<'a> {
             Action::MakeTable => OpType::Make(amp::ObjType::table()),
             Action::Del => OpType::Del,
             Action::Inc => OpType::Inc(value.to_i64()?),
-            Action::Link => OpType::Link(child),
         };
         Some(Operation {
             action,
@@ -454,16 +451,6 @@ impl ChildEncoder {
         self.ctr.append_null();
     }
 
-    fn append(&mut self, obj: &amp::ObjectID, actors: &mut Vec<amp::ActorID>) {
-        match obj {
-            amp::ObjectID::Root => self.append_null(),
-            amp::ObjectID::ID(amp::OpID(ctr, actor)) => {
-                self.actor.append_value(map_actor(&actor, actors));
-                self.ctr.append_value(*ctr);
-            }
-        }
-    }
-
     fn finish(self) -> Vec<ColData> {
         vec![
             self.actor.finish(COL_CHILD_ACTOR),
@@ -483,7 +470,10 @@ pub(crate) struct ColumnEncoder {
 }
 
 impl ColumnEncoder {
-    pub fn encode_ops(ops: &[Operation], actors: &mut Vec<amp::ActorID>) -> Vec<u8> {
+    pub fn encode_ops<'a, 'b, I>(ops: I, actors: &'a mut Vec<amp::ActorID>) -> Vec<u8>
+    where
+        I: IntoIterator<Item = &'b Operation>,
+    {
         let mut e = Self::new();
         e.encode(ops, actors);
         e.finish()
@@ -501,7 +491,10 @@ impl ColumnEncoder {
         }
     }
 
-    fn encode(&mut self, ops: &[Operation], actors: &mut Vec<amp::ActorID>) {
+    fn encode<'a, 'b, 'c, I>(&'a mut self, ops: I, actors: &'b mut Vec<amp::ActorID>)
+    where
+        I: IntoIterator<Item = &'c Operation>,
+    {
         for op in ops {
             self.append(op, actors)
         }
@@ -527,11 +520,6 @@ impl ColumnEncoder {
                 self.val.append_null();
                 self.chld.append_null();
                 Action::Del
-            }
-            OpType::Link(child) => {
-                self.val.append_null();
-                self.chld.append(child, actors);
-                Action::Link
             }
             OpType::Make(kind) => {
                 self.val.append_null();
@@ -598,9 +586,8 @@ pub(crate) enum Action {
     MakeText,
     Inc,
     MakeTable,
-    Link,
 }
-const ACTIONS: [Action; 8] = [
+const ACTIONS: [Action; 7] = [
     Action::MakeMap,
     Action::Set,
     Action::MakeList,
@@ -608,7 +595,6 @@ const ACTIONS: [Action; 8] = [
     Action::MakeText,
     Action::Inc,
     Action::MakeTable,
-    Action::Link,
 ];
 
 impl Decodable for Action {

--- a/automerge-backend/src/concurrent_operations.rs
+++ b/automerge-backend/src/concurrent_operations.rs
@@ -59,7 +59,7 @@ impl ConcurrentOperations {
         }
 
         match new_op.action {
-            InternalOpType::Set(_) | InternalOpType::Link(_) | InternalOpType::Make(_) => {
+            InternalOpType::Set(_) | InternalOpType::Make(_) => {
                 self.ops.push(new_op.clone());
             }
             _ => {}

--- a/automerge-backend/src/error.rs
+++ b/automerge-backend/src/error.rs
@@ -1,63 +1,73 @@
 use automerge_protocol as amp;
-use std::error::Error;
-use std::fmt;
+//use std::error::Error;
+use std::fmt::Debug;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum AutomergeError {
+    #[error("Missing object ID")]
     MissingObjectError,
+    #[error("Missing index in op {0}")]
     MissingIndex(amp::OpID),
-    MissingChildID(String),
-    MissingElement(amp::ObjectID, amp::OpID),
+    #[error("Missing element ID: {0}")]
+    MissingElement(amp::ObjectID, amp::ElementID),
+    #[error("No path to object: {0}")]
     NoPathToObject(amp::ObjectID),
+    #[error("Cant extract object: {0}")]
     CantExtractObject(amp::ObjectID),
-    LinkMissingChild,
+    #[error("Skiplist error: {0}")]
     SkipListError(String),
+    #[error("Index out of bounds: {0}")]
     IndexOutOfBounds(usize),
+    #[error("Invalid op id: {0}")]
     InvalidOpID(String),
+    #[error("Invalid object ID: {0}")]
     InvalidObjectID(String),
+    #[error("Missing value")]
     MissingValue,
+    #[error("Unknown error: {0}")]
     GeneralError(String),
+    #[error("Missing number value")]
     MissingNumberValue,
+    #[error("Unknown version: {0}")]
     UnknownVersion(u64),
+    #[error("Duplicate change {0}")]
     DuplicateChange(String),
+    #[error("Diverged state {0}")]
     DivergedState(String),
+    #[error("Change decompression error: {0}")]
     ChangeDecompressError(String),
+    #[error("Invalid seq {0}")]
     InvalidSeq(u64),
+    #[error("Map key in seq")]
     MapKeyInSeq,
+    #[error("Head to opid")]
     HeadToOpID,
+    #[error("Doc format not implemented yet")]
     DocFormatUnimplemented,
+    #[error("Divergeentchange {0}")]
     DivergentChange(String),
+    #[error("Encode failed")]
     EncodeFailed,
+    #[error("Decode failed")]
     DecodeFailed,
-    InvalidChange,
-    ChangeBadFormat,
+    #[error("Invalid change")]
+    InvalidChange {
+        #[from]
+        source: InvalidChangeError,
+    },
+    #[error("Change bad format: {source}")]
+    ChangeBadFormat {
+        #[source]
+        source: amp::error::InvalidChangeHashSlice,
+    },
+    #[error("Encoding error")]
     EncodingError,
 }
 
-impl From<amp::error::InvalidChangeHashSlice> for AutomergeError {
-    fn from(_: amp::error::InvalidChangeHashSlice) -> AutomergeError {
-        AutomergeError::ChangeBadFormat
-    }
-}
-
-impl fmt::Display for AutomergeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl Error for AutomergeError {}
-
-#[derive(Debug)]
+#[derive(Error, Debug)]
+#[error("Invalid element ID: {0}")]
 pub struct InvalidElementID(pub String);
-
-impl fmt::Display for InvalidElementID {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl Error for InvalidElementID {}
 
 impl From<leb128::read::Error> for AutomergeError {
     fn from(_err: leb128::read::Error) -> Self {
@@ -69,4 +79,22 @@ impl From<std::io::Error> for AutomergeError {
     fn from(_err: std::io::Error) -> Self {
         AutomergeError::EncodingError
     }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum InvalidChangeError {
+    #[error("Change contained an operation with action 'set' which did not have a 'value'")]
+    SetOpWithoutValue,
+    #[error("Received an inc operation which had an invalid value, value was: {op_value:?}")]
+    IncOperationWithInvalidValue { op_value: Option<amp::ScalarValue> },
+    #[error("Change contained an invalid object id: {}", source.0)]
+    InvalidObjectID {
+        #[from]
+        source: amp::error::InvalidObjectID,
+    },
+    #[error("Change contained an invalid hash: {:?}", source.0)]
+    InvalidChangeHash {
+        #[from]
+        source: amp::error::InvalidChangeHashSlice,
+    },
 }

--- a/automerge-backend/src/internal.rs
+++ b/automerge-backend/src/internal.rs
@@ -44,14 +44,12 @@ impl InternalOp {
     pub fn is_inc(&self) -> bool {
         matches!(self.action, InternalOpType::Inc(_))
     }
-
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum InternalOpType {
     Make(amp::ObjType),
     Del,
-    Link(ObjectID),
     Inc(i64),
     Set(amp::ScalarValue),
 }

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -31,7 +31,7 @@ mod pending_diff;
 mod time;
 
 pub use backend::Backend;
-pub use change::{Change, UnencodedChange};
+pub use change::Change;
 pub use error::AutomergeError;
 pub use op::Operation;
 pub use op_type::OpType;

--- a/automerge-backend/src/op.rs
+++ b/automerge-backend/src/op.rs
@@ -1,4 +1,5 @@
 // FIXME
+use crate::error::InvalidChangeError;
 use crate::op_type::OpType;
 use automerge_protocol as amp;
 use serde::ser::SerializeStruct;
@@ -6,6 +7,8 @@ use serde::{
     de::{Error, MapAccess, Unexpected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
+use std::convert::TryFrom;
+use std::str::FromStr;
 
 fn read_field<'de, T, M>(
     name: &'static str,
@@ -106,7 +109,7 @@ impl Serialize for Operation {
         match &self.action {
             OpType::Set(amp::ScalarValue::Timestamp(_)) => fields += 2,
             OpType::Set(amp::ScalarValue::Counter(_)) => fields += 2,
-            OpType::Link(_) | OpType::Inc(_) | OpType::Set(_) => fields += 1,
+            OpType::Inc(_) | OpType::Set(_) => fields += 1,
             _ => {}
         }
 
@@ -118,7 +121,6 @@ impl Serialize for Operation {
             op.serialize_field("insert", &self.insert)?;
         }
         match &self.action {
-            OpType::Link(child) => op.serialize_field("child", &child)?,
             OpType::Inc(n) => op.serialize_field("value", &n)?,
             OpType::Set(amp::ScalarValue::Counter(value)) => {
                 op.serialize_field("value", &value)?;
@@ -161,7 +163,6 @@ impl<'de> Deserialize<'de> for Operation {
                 let mut insert: Option<bool> = None;
                 let mut datatype: Option<amp::DataType> = None;
                 let mut value: Option<Option<amp::ScalarValue>> = None;
-                let mut child: Option<amp::ObjectID> = None;
                 while let Some(field) = map.next_key::<String>()? {
                     match field.as_ref() {
                         "action" => read_field("action", &mut action, &mut map)?,
@@ -171,7 +172,6 @@ impl<'de> Deserialize<'de> for Operation {
                         "insert" => read_field("insert", &mut insert, &mut map)?,
                         "datatype" => read_field("datatype", &mut datatype, &mut map)?,
                         "value" => read_field("value", &mut value, &mut map)?,
-                        "child" => read_field("child", &mut child, &mut map)?,
                         _ => return Err(Error::unknown_field(&field, FIELDS)),
                     }
                 }
@@ -191,9 +191,6 @@ impl<'de> Deserialize<'de> for Operation {
                         OpType::Make(amp::ObjType::Sequence(amp::SequenceType::Text))
                     }
                     amp::OpType::Del => OpType::Del,
-                    amp::OpType::Link => {
-                        OpType::Link(child.ok_or_else(|| Error::missing_field("pred"))?)
-                    }
                     amp::OpType::Set => OpType::Set(value.unwrap_or(amp::ScalarValue::Null)),
                     amp::OpType::Inc => match value {
                         Some(amp::ScalarValue::Int(n)) => Ok(OpType::Inc(n)),
@@ -227,3 +224,56 @@ impl<'de> Deserialize<'de> for Operation {
     }
 }
 
+impl TryFrom<&amp::Op> for Operation {
+    type Error = InvalidChangeError;
+    fn try_from(op: &amp::Op) -> Result<Self, Self::Error> {
+        let op_type = OpType::try_from(op)?;
+        let obj_id = amp::ObjectID::from_str(&op.obj)?;
+        Ok(Operation {
+            action: op_type,
+            obj: obj_id,
+            key: op.key.clone(),
+            pred: op.pred.clone(),
+            insert: op.insert,
+        })
+    }
+}
+
+impl Into<amp::Op> for &Operation {
+    fn into(self) -> amp::Op {
+        let value = match &self.action {
+            OpType::Del => None,
+            OpType::Set(v) => Some(v.clone()),
+            OpType::Make(_) => None,
+            OpType::Inc(i) => Some(amp::ScalarValue::Counter(*i)),
+        };
+        let datatype = value
+            .as_ref()
+            .and_then(|v| match (v.datatype(), &self.action) {
+                (Some(d), _) => Some(d),
+                (None, OpType::Set(..)) => Some(amp::DataType::Undefined),
+                _ => None,
+            });
+        amp::Op {
+            obj: self.obj.to_string(),
+            value,
+            action: match self.action {
+                OpType::Inc(_) => amp::OpType::Inc,
+                OpType::Make(amp::ObjType::Map(amp::MapType::Map)) => amp::OpType::MakeMap,
+                OpType::Make(amp::ObjType::Map(amp::MapType::Table)) => amp::OpType::MakeTable,
+                OpType::Make(amp::ObjType::Sequence(amp::SequenceType::List)) => {
+                    amp::OpType::MakeList
+                }
+                OpType::Make(amp::ObjType::Sequence(amp::SequenceType::Text)) => {
+                    amp::OpType::MakeText
+                }
+                OpType::Set(..) => amp::OpType::Set,
+                OpType::Del => amp::OpType::Del,
+            },
+            pred: self.pred.clone(),
+            insert: self.insert,
+            key: self.key.clone(),
+            datatype,
+        }
+    }
+}

--- a/automerge-backend/src/op_handle.rs
+++ b/automerge-backend/src/op_handle.rs
@@ -44,7 +44,6 @@ impl OpHandle {
     pub fn child(&self) -> Option<ObjectID> {
         match &self.action {
             InternalOpType::Make(_) => Some(self.id.into()),
-            InternalOpType::Link(obj) => Some(*obj),
             _ => None,
         }
     }

--- a/automerge-backend/src/op_set.rs
+++ b/automerge-backend/src/op_set.rs
@@ -75,9 +75,9 @@ impl OpSet {
     }
 
     pub fn heads(&self) -> Vec<amp::ChangeHash> {
-      let mut deps: Vec<_> = self.deps.iter().cloned().collect();
-      deps.sort_unstable();
-      deps
+        let mut deps: Vec<_> = self.deps.iter().cloned().collect();
+        deps.sort_unstable();
+        deps
     }
 
     pub fn apply_op(
@@ -122,9 +122,9 @@ impl OpSet {
                         .operation_key()
                         .to_opid()
                         .ok_or(AutomergeError::HeadToOpID)?;
-                    let index = object.index_of(id)?;
+                    let index = object.index_of(id).unwrap_or(0);
                     object.seq.insert_index(index, id);
-                    Some(PendingDiff::SeqInsert(op.clone(), index, op.id ))
+                    Some(PendingDiff::SeqInsert(op.clone(), index, op.id))
                 }
                 (false, false) => None,
             };
@@ -314,7 +314,6 @@ impl OpSet {
                     InternalOpType::Make(_) => {
                         self.gen_obj_diff(&op.id.into(), pending_diffs, actors)?
                     }
-                    InternalOpType::Link(ref child) => self.construct_object(&child, actors)?,
                     _ => panic!("del or inc found in field_operations"),
                 };
                 opid_to_value.insert(actors.export_opid(&op.id), link);
@@ -356,9 +355,6 @@ impl OpSet {
                     InternalOpType::Make(_) => {
                         // FIXME
                         self.gen_obj_diff(&op.id.into(), pending_diffs, actors)?
-                    }
-                    InternalOpType::Link(ref child_id) => {
-                        self.construct_object(&child_id, actors)?
                     }
                     _ => panic!("del or inc found in field_operations"),
                 };

--- a/automerge-backend/src/op_type.rs
+++ b/automerge-backend/src/op_type.rs
@@ -1,11 +1,12 @@
+use crate::error;
 use automerge_protocol as amp;
 use serde::{Serialize, Serializer};
+use std::convert::TryFrom;
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum OpType {
     Make(amp::ObjType),
     Del,
-    Link(amp::ObjectID),
     Inc(i64),
     Set(amp::ScalarValue),
 }
@@ -21,10 +22,39 @@ impl Serialize for OpType {
             OpType::Make(amp::ObjType::Sequence(amp::SequenceType::List)) => "makeList",
             OpType::Make(amp::ObjType::Sequence(amp::SequenceType::Text)) => "makeText",
             OpType::Del => "del",
-            OpType::Link(_) => "link",
             OpType::Inc(_) => "inc",
             OpType::Set(_) => "set",
         };
         serializer.serialize_str(s)
+    }
+}
+
+impl TryFrom<&amp::Op> for OpType {
+    type Error = error::InvalidChangeError;
+    fn try_from(op: &amp::Op) -> Result<Self, Self::Error> {
+        match op.action {
+            amp::OpType::MakeMap => Ok(OpType::Make(amp::ObjType::Map(amp::MapType::Map))),
+            amp::OpType::MakeTable => Ok(OpType::Make(amp::ObjType::Map(amp::MapType::Table))),
+            amp::OpType::MakeList => Ok(OpType::Make(amp::ObjType::Sequence(
+                amp::SequenceType::List,
+            ))),
+            amp::OpType::MakeText => Ok(OpType::Make(amp::ObjType::Sequence(
+                amp::SequenceType::Text,
+            ))),
+            amp::OpType::Del => Ok(OpType::Del),
+            amp::OpType::Set => op
+                .value
+                .as_ref()
+                .map(|v| OpType::Set(v.clone()))
+                .ok_or(error::InvalidChangeError::SetOpWithoutValue),
+            amp::OpType::Inc => match &op.value {
+                Some(amp::ScalarValue::Int(i)) => Ok(OpType::Inc(*i)),
+                Some(amp::ScalarValue::Uint(u)) => Ok(OpType::Inc(*u as i64)),
+                Some(amp::ScalarValue::Counter(i)) => Ok(OpType::Inc(*i)),
+                val => Err(error::InvalidChangeError::IncOperationWithInvalidValue {
+                    op_value: val.clone(),
+                }),
+            },
+        }
     }
 }

--- a/automerge-backend/src/ordered_set.rs
+++ b/automerge-backend/src/ordered_set.rs
@@ -2,10 +2,10 @@
 
 use fxhash::FxBuildHasher;
 //use im_rc::HashMap;
-use std::collections::HashMap;
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::cmp::{max, min};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::iter::Iterator;
@@ -822,25 +822,33 @@ mod tests {
 
     #[test]
     fn test_remove_key_big() {
-        let mut s = SkipList::<String>::new();
+        let mut strings: Vec<String> = Vec::new();
         for i in 0..10000 {
             let j = 9999 - i;
-            s.insert_head(format!("a{}", j));
+            strings.push(format!("a{}", j));
         }
+        let mut s = SkipList::<&str>::new();
+        for string in strings.iter() {
+            s.insert_head(string);
+        }
+        //for i in 0..10000 {
+        //let j = 9999 - i;
+        //s.insert_head(format!("a{}", j));
+        //}
 
-        assert_eq!(s.index_of(&"a20".to_string()), Some(20));
-        assert_eq!(s.index_of(&"a500".to_string()), Some(500));
-        assert_eq!(s.index_of(&"a1000".to_string()), Some(1000));
+        assert_eq!(s.index_of(&"a20"), Some(20));
+        assert_eq!(s.index_of(&"a500"), Some(500));
+        assert_eq!(s.index_of(&"a1000"), Some(1000));
 
         for i in 0..5000 {
             let j = (4999 - i) * 2 + 1;
             s.remove_index(j);
         }
 
-        assert_eq!(s.index_of(&"a4000".to_string()), Some(2000));
-        assert_eq!(s.index_of(&"a1000".to_string()), Some(500));
-        assert_eq!(s.index_of(&"a500".to_string()), Some(250));
-        assert_eq!(s.index_of(&"a20".to_string()), Some(10));
+        assert_eq!(s.index_of(&"a4000"), Some(2000));
+        assert_eq!(s.index_of(&"a1000"), Some(500));
+        assert_eq!(s.index_of(&"a500"), Some(250));
+        assert_eq!(s.index_of(&"a20"), Some(10));
     }
 
     #[test]

--- a/automerge-backend/src/pending_diff.rs
+++ b/automerge-backend/src/pending_diff.rs
@@ -1,6 +1,6 @@
+use crate::actor_map::ActorMap;
 use crate::internal::{Key, OpID};
 use crate::op_handle::OpHandle;
-use crate::actor_map::ActorMap;
 use automerge_protocol as amp;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,7 +21,10 @@ impl PendingDiff {
 
     pub fn edit(&self, actors: &ActorMap) -> Option<amp::DiffEdit> {
         match *self {
-            Self::SeqInsert(_, index, opid ) => Some(amp::DiffEdit::Insert { index , elem_id: actors.export_opid(&opid).into() }),
+            Self::SeqInsert(_, index, opid) => Some(amp::DiffEdit::Insert {
+                index,
+                elem_id: actors.export_opid(&opid).into(),
+            }),
             Self::SeqRemove(_, index) => Some(amp::DiffEdit::Remove { index }),
             _ => None,
         }

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -3,7 +3,7 @@ extern crate errno;
 extern crate libc;
 extern crate serde;
 
-use automerge_backend::{AutomergeError, Change, UnencodedChange};
+use automerge_backend::{AutomergeError, Change, UncompressedChange};
 use automerge_protocol::Request;
 use errno::{set_errno, Errno};
 use serde::ser::Serialize;
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn automerge_apply_local_change(
     let request: Result<Request, _> = serde_json::from_str(&request);
     if let Ok(request) = request {
         // FIXME - need to update the c api to all receiving the binary change here
-        if let Ok((patch,_change)) = (*backend).apply_local_change(request) {
+        if let Ok((patch, _change)) = (*backend).apply_local_change(request) {
             (*backend).generate_json(Ok(patch))
         } else {
             -1
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn automerge_encode_change(
 ) -> isize {
     let change: &CStr = CStr::from_ptr(change);
     let change = change.to_string_lossy();
-    let change: Result<UnencodedChange, _> = serde_json::from_str(&change);
+    let change: Result<UncompressedChange, _> = serde_json::from_str(&change);
     let change = change.unwrap().encode();
     (*backend).handle_binary(Ok(change.bytes))
 }

--- a/automerge-protocol/src/error.rs
+++ b/automerge-protocol/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 #[error("Invalid OpID: {0}")]
 pub struct InvalidOpID(pub String);
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 #[error("Invalid object ID: {0}")]
 pub struct InvalidObjectID(pub String);
 
@@ -16,6 +16,6 @@ pub struct InvalidElementID(pub String);
 #[error("Invalid actor ID: {0}")]
 pub struct InvalidActorID(pub String);
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 #[error("Invalid change hash slice: {0:?}")]
 pub struct InvalidChangeHashSlice(pub Vec<u8>);

--- a/automerge-protocol/src/serde_impls/mod.rs
+++ b/automerge-protocol/src/serde_impls/mod.rs
@@ -18,11 +18,6 @@ pub(crate) fn make_false() -> bool {
     false
 }
 
-// Factory method for use in #[serde(default=..)] annotations
-pub(crate) fn make_true() -> bool {
-    true
-}
-
 // Helper method for use in custom deserialize impls
 pub(crate) fn read_field<'de, T, M>(
     name: &'static str,

--- a/automerge-protocol/src/utility_impls/scalar_value.rs
+++ b/automerge-protocol/src/utility_impls/scalar_value.rs
@@ -1,4 +1,5 @@
 use crate::ScalarValue;
+use std::fmt;
 
 impl From<&str> for ScalarValue {
     fn from(s: &str) -> Self {
@@ -18,8 +19,30 @@ impl From<u64> for ScalarValue {
     }
 }
 
+impl From<i32> for ScalarValue {
+    fn from(n: i32) -> Self {
+        ScalarValue::Int(n as i64)
+    }
+}
+
 impl From<bool> for ScalarValue {
     fn from(b: bool) -> Self {
         ScalarValue::Boolean(b)
+    }
+}
+
+impl fmt::Display for ScalarValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScalarValue::Str(s) => write!(f, "\"{}\"", s),
+            ScalarValue::Int(i) => write!(f, "{}", i),
+            ScalarValue::Uint(i) => write!(f, "{}", i),
+            ScalarValue::F32(n) => write!(f, "{:.32}", n),
+            ScalarValue::F64(n) => write!(f, "{:.324}", n),
+            ScalarValue::Counter(c) => write!(f, "Counter: {}", c),
+            ScalarValue::Timestamp(i) => write!(f, "Timestamp: {}", i),
+            ScalarValue::Boolean(b) => write!(f, "{}", b),
+            ScalarValue::Null => write!(f, "null"),
+        }
     }
 }


### PR DESCRIPTION
This moves automerge_backend::UnencodedChange to 'automerge_protocol::UncompressedChange. Unfortunately this change touches a lot of files. The primary meaningful difference is that the UnencodedChangereferred toautomerge_backend::Operationwhereas theUncompressedChangeusesautomerge_frontend::Op. This neccessitates a fallible conversion from UncompressedChangetoautomerge_backend::Change, which is implemented here as impl TryFrom for Changeinchange.rs, which replaces Change::decode`.