### PR TITLE
Refactored javascript into JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ contains an implementation of the "backend" of the Automerge library, designed
 to be used via FFI from many different platforms. Very soon there will also be
 a frontend which will be designed for Rust application developers to use.
 
-This project is tracking the `performance` branch of the javascript reference implementation of Automerge. The `performance` branch contains a lot of backwards incompatible changes and is intended to become a 1.0 release of the library, you can find more information about that [here](https://github.com/automerge/automerge/pull/253). Our goal is to release a pre 1.0 version of the rust library once the javascript library hits 1.0. As such we are keeping this project up to date with the frequent and often quite large changes in the `performance` branch of the javascript repo - that is to say, don't depend on anything in this repo to stay constant right now.
+This project is tracking the `performance` branch of the JavaScript reference implementation of Automerge. The `performance` branch contains a lot of backwards incompatible changes and is intended to become a 1.0 release of the library, you can find more information about that [here](https://github.com/automerge/automerge/pull/253). Our goal is to release a pre 1.0 version of the rust library once the JavaScript library hits 1.0. As such we are keeping this project up to date with the frequent and often quite large changes in the `performance` branch of the JavaScript repo - that is to say, don't depend on anything in this repo to stay constant right now.
 
 
 ## Using automerge-backend-wasm with automerge


### PR DESCRIPTION
This PR refactors the javascript word to the Upper Camel case, making it more precise.