### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,29 @@ language: rust
 rust:
 - stable
 - beta
-before_script:
+install:
 - rustup self update
-- rustup component add clippy 
+- rustup component add clippy
 - rustup component add rustfmt
+- curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+before_script:
+- export -f travis_fold
 script:
+- travis_fold start "format"
 - cargo fmt --all -- --check
+- travis_fold end "format"
+- travis_fold start "clippy"
 - cargo clippy --all-targets --all-features -- -D warnings
+- travis_fold end "clippy"
+- travis_fold start "build"
 - cargo build --verbose --all
+- travis_fold end "build"
+- travis_fold start "test"
 - cargo test --verbose --all
+- travis_fold end "test"
+- travis_fold start "wasm-build"
+- cd automerge-backend-wasm && yarn release
+- travis_fold end "wasm-build"
 jobs:
   allow_failures:
   - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: xenial
 language: rust
 rust:
 - stable

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![docs](https://docs.rs/automerge/badge.svg)](https://docs.rs/automerge)
 [![crates](https://img.shields.io/crates/v/automerge.svg)](https://crates.io/crates/automerge)
-[![Build Status](https://travis-ci.org/automerge/automerge-rs.svg?branch=master)](https://travis-ci.org/automerge/automerge-rs)
+[![Build Status](https://travis-ci.org/automerge/automerge-rs.svg?branch=main)](https://travis-ci.org/automerge/automerge-rs)
 
 This is a rust implementation of
 [automerge](https://github.com/automerge/automerge). Currently this repo


### PR DESCRIPTION
I've added some extra bits to the travis config for testing the build of the wasm backend and also added some folds to make the output easier to inspect.

I've also updated the build badge in the readme to use the `main` branch instead of `master`.