### PR TITLE
Fix issue in RleDecoder with null runs

### DIFF
--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -1190,3 +1190,97 @@ const DOCUMENT_COLUMNS = {
   extraRaw:  5 << 3 | COLUMN_TYPE.VALUE_RAW
 }
 */
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rle_encoder_for_strings_from_key() {
+        // this seems like a strange case but checks that we write nulls into the encoder as usize and read them out the same.
+        // if we don't then the 64 nulls gets interpreted as -64 and causes the rle decoder to never read the next values.
+        let ops = vec![
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("a".to_owned()),
+        ];
+        let mut encoder = RleEncoder::new();
+        for op in &ops {
+            if let Some(v) = op {
+                encoder.append_value(v.clone())
+            } else {
+                encoder.append_null()
+            }
+        }
+        let encoded = encoder.finish(0).data;
+
+        assert_eq!(encoded, vec![0, 64, 127, 1, 97]);
+
+        let decoder: RleDecoder<String> = RleDecoder::from(&encoded[..]);
+
+        let decoded = decoder.take(ops.len()).collect::<Vec<_>>();
+        assert_eq!(decoded, ops);
+    }
+}

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -340,7 +340,8 @@ where
                     self.literal = true;
                 }
                 _ => {
-                    self.count = self.decoder.read().unwrap_or_default();
+                    // FIXME(jeffa5): handle usize > isize here somehow
+                    self.count = self.decoder.read::<usize>().unwrap_or_default() as isize;
                     self.last_value = None;
                     self.literal = false;
                 }

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -329,14 +329,14 @@ where
             if self.decoder.done() {
                 return Some(None);
             }
-            match self.decoder.read() {
+            match self.decoder.read::<i64>() {
                 Ok(count) if count > 0 => {
-                    self.count = count;
+                    self.count = count as isize;
                     self.last_value = self.decoder.read().ok();
                     self.literal = false;
                 }
                 Ok(count) if count < 0 => {
-                    self.count = count.abs();
+                    self.count = count.abs() as isize;
                     self.literal = true;
                 }
                 _ => {

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -23,8 +23,12 @@ automerge-protocol = { path = "../automerge-protocol" }
 
 [dev-dependencies]
 criterion = "0.3.3"
+hex = "0.4.3"
 pretty_assertions = "0.7.1"
 rand = "0.8.2"
+test-env-log = { version = "0.2.6", features = ["trace"], default-features = false }
+tracing = "0.1.25"
+tracing-subscriber = {version = "0.2", features = ["chrono", "env-filter", "fmt"]}
 
 [[bench]]
 name = "crdt_benchmarks"

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -23,8 +23,8 @@ automerge-protocol = { path = "../automerge-protocol" }
 
 [dev-dependencies]
 criterion = "0.3.3"
+pretty_assertions = "0.7.1"
 rand = "0.8.2"
-
 
 [[bench]]
 name = "crdt_benchmarks"

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -1,0 +1,182 @@
+use automerge::Backend;
+use automerge::Frontend;
+use automerge::LocalChange;
+use automerge::MapType;
+use automerge::Path;
+use automerge::Value;
+use automerge::{InvalidChangeRequest, Primitive};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn missing_object_error() {
+    let mut change1s = Vec::new();
+    let mut change2s = Vec::new();
+
+    let actor_id = uuid::Uuid::new_v4();
+
+    for _ in 0..100 {
+        let changes1 = vec![LocalChange::set(
+            Path::root(),
+            Value::Map(
+                vec![
+                    (
+                        "\u{0}\u{0}".to_owned(),
+                        Value::Sequence(vec![
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                        ]),
+                    ),
+                    (
+                        "\u{2}".to_owned(),
+                        Value::Sequence(vec![
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                        ]),
+                    ),
+                    (
+                        "\u{0}".to_owned(),
+                        Value::Sequence(vec![
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::F32(0.0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::F32(0.0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                        ]),
+                    ),
+                    (
+                        "".to_owned(),
+                        Value::Sequence(vec![
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::F32(0.0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Boolean(false)),
+                        ]),
+                    ),
+                    (
+                        "\u{1}".to_owned(),
+                        Value::Map(
+                            vec![("".to_owned(), Value::Primitive(Primitive::F64(0.0)))]
+                                .into_iter()
+                                .collect(),
+                            MapType::Table,
+                        ),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                MapType::Map,
+            ),
+        )];
+        let changes2 = vec![
+            LocalChange::delete(Path::root().key("\u{0}\u{0}")),
+            LocalChange::delete(Path::root().key("\u{2}")),
+            LocalChange::delete(Path::root().key("\u{0}")),
+            LocalChange::delete(Path::root().key("")),
+            LocalChange::delete(Path::root().key("\u{1}")),
+        ];
+
+        let mut backend = Backend::init();
+        let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+        let patch = backend.get_patch().unwrap();
+        frontend.apply_patch(patch).unwrap();
+
+        let c = frontend
+            .change::<_, InvalidChangeRequest>(None, |d| {
+                for change in &changes1 {
+                    d.add_change(change.clone())?
+                }
+                Ok(())
+            })
+            .unwrap();
+        if let Some(change) = c {
+            change1s.push(change.clone());
+            backend.apply_local_change(change).unwrap();
+        }
+
+        let backend_bytes = backend.save().unwrap();
+        println!("{:?}", backend_bytes);
+
+        let backend = Backend::load(backend_bytes);
+        if change1s.len() >= 2 {
+            assert_eq!(change1s[change1s.len() - 2], change1s[change1s.len() - 1])
+        }
+        match backend {
+            Err(e) => {
+                panic!("failed loading backend: {:?}", e)
+            }
+            Ok(mut backend) => {
+                let mut frontend =
+                    Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+                let patch = backend.get_patch().unwrap();
+                frontend.apply_patch(patch).unwrap();
+
+                let c = frontend
+                    .change::<_, InvalidChangeRequest>(None, |d| {
+                        for change in &changes2 {
+                            d.add_change(change.clone())?
+                        }
+                        Ok(())
+                    })
+                    .unwrap();
+                if let Some(change) = c {
+                    change2s.push(change.clone());
+                    backend.apply_local_change(change).unwrap();
+                }
+            }
+        }
+        if change2s.len() >= 2 {
+            assert_eq!(change2s[change2s.len() - 2], change2s[change2s.len() - 1])
+        }
+    }
+}

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -12,281 +12,107 @@ use automerge_protocol::{
 use test_env_log::test;
 
 #[test]
-fn missing_object_error() {
+fn missing_object_error_flaky_null_rle_decoding() {
     let mut change1s = Vec::new();
     let mut change2s = Vec::new();
 
     let actor_id = uuid::Uuid::new_v4();
 
-    for _ in 0..100 {
-        let changes1 = vec![LocalChange::set(
-            Path::root(),
-            Value::Map(
-                vec![
-                    (
-                        "\u{0}\u{0}".to_owned(),
-                        Value::Sequence(vec![
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                        ]),
-                    ),
-                    (
-                        "\u{2}".to_owned(),
-                        Value::Sequence(vec![
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                        ]),
-                    ),
-                    (
-                        "\u{0}".to_owned(),
-                        Value::Sequence(vec![
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::F32(0.0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::F32(0.0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                        ]),
-                    ),
-                    (
-                        "".to_owned(),
-                        Value::Sequence(vec![
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::F32(0.0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Boolean(false)),
-                        ]),
-                    ),
-                    (
-                        "\u{1}".to_owned(),
-                        Value::Map(
-                            vec![("".to_owned(), Value::Primitive(Primitive::F64(0.0)))]
-                                .into_iter()
-                                .collect(),
-                            MapType::Table,
-                        ),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-                MapType::Map,
-            ),
-        )];
-        let changes2 = vec![
-            LocalChange::delete(Path::root().key("\u{0}\u{0}")),
-            LocalChange::delete(Path::root().key("\u{2}")),
-            LocalChange::delete(Path::root().key("\u{0}")),
-            LocalChange::delete(Path::root().key("")),
-            LocalChange::delete(Path::root().key("\u{1}")),
-        ];
-
-        let mut backend = Backend::init();
-        let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
-        let patch = backend.get_patch().unwrap();
-        frontend.apply_patch(patch).unwrap();
-
-        let c = frontend
-            .change::<_, InvalidChangeRequest>(None, |d| {
-                for change in &changes1 {
-                    d.add_change(change.clone())?
-                }
-                Ok(())
-            })
-            .unwrap();
-        if let Some(change) = c {
-            change1s.push(change.clone());
-            backend.apply_local_change(change).unwrap();
-        }
-        if change1s.len() >= 2 {
-            println!(
-                "{}",
-                pretty_assertions::Comparison::new(
-                    &change1s[change1s.len() - 2],
-                    &change1s[change1s.len() - 1],
-                )
-            )
-        }
-
-        let backend_bytes = backend.save().unwrap();
-        println!("{:?}", backend_bytes);
-
-        let backend = Backend::load(backend_bytes);
-        match backend {
-            Err(e) => {
-                panic!("failed loading backend: {:?}", e)
-            }
-            Ok(mut backend) => {
-                let mut frontend =
-                    Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
-                let patch = backend.get_patch().unwrap();
-                frontend.apply_patch(patch).unwrap();
-
-                let c = frontend
-                    .change::<_, InvalidChangeRequest>(None, |d| {
-                        for change in &changes2 {
-                            d.add_change(change.clone())?
-                        }
-                        Ok(())
-                    })
-                    .unwrap();
-                if let Some(change) = c {
-                    change2s.push(change.clone());
-                    if change2s.len() >= 2 {
-                        println!(
-                            "{}",
-                            pretty_assertions::Comparison::new(
-                                &change2s[change2s.len() - 2],
-                                &change2s[change2s.len() - 1]
-                            )
-                        )
-                    }
-                    backend.apply_local_change(change).unwrap();
-                }
-            }
-        }
-    }
-}
-
-#[test]
-fn missing_object_error_2() {
-    let actor_uuid = uuid::Uuid::new_v4();
-    let actor_id = ActorId::from_bytes(actor_uuid.as_bytes());
-
-    let _changes = vec![LocalChange::set(
+    let changes1 = vec![LocalChange::set(
         Path::root(),
         Value::Map(
             vec![
                 (
+                    "\u{0}\u{0}".to_owned(),
+                    Value::Sequence(vec![
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Int(0)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                    ]),
+                ),
+                (
+                    "\u{2}".to_owned(),
+                    Value::Sequence(vec![
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                    ]),
+                ),
+                (
                     "\u{0}".to_owned(),
                     Value::Sequence(vec![
-                        Value::Primitive(Primitive::Boolean(false)),
-                        Value::Primitive(Primitive::Timestamp(0)),
                         Value::Primitive(Primitive::Counter(0)),
-                        Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Uint(0)),
-                        Value::Primitive(Primitive::Timestamp(0)),
                         Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::F64(0.0)),
-                        Value::Primitive(Primitive::F64(0.0)),
-                        Value::Primitive(Primitive::Counter(0)),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Uint(0)),
-                        Value::Primitive(Primitive::Int(0)),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Counter(0)),
-                        Value::Primitive(Primitive::Int(0)),
-                        Value::Primitive(Primitive::Null),
                         Value::Primitive(Primitive::Uint(0)),
                         Value::Primitive(Primitive::Timestamp(0)),
                         Value::Primitive(Primitive::Int(0)),
-                        Value::Primitive(Primitive::Null),
                         Value::Primitive(Primitive::Uint(0)),
                         Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Boolean(false)),
-                        Value::Primitive(Primitive::F32(0.0)),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::Null),
                         Value::Primitive(Primitive::F32(0.0)),
                         Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::F64(0.0)),
-                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Uint(0)),
                         Value::Primitive(Primitive::Str("".to_owned())),
                         Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Null),
                         Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Str("".to_owned())),
                         Value::Primitive(Primitive::Timestamp(0)),
                         Value::Primitive(Primitive::Uint(0)),
-                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Counter(0)),
                         Value::Primitive(Primitive::Uint(0)),
-                        Value::Primitive(Primitive::Boolean(false)),
-                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::F32(0.0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
                     ]),
                 ),
                 (
                     "".to_owned(),
                     Value::Sequence(vec![
                         Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Int(0)),
                         Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Timestamp(0)),
-                        Value::Primitive(Primitive::Boolean(false)),
-                        Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Null),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Boolean(false)),
-                        Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::F32(0.0)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::F64(0.0)),
                         Value::Primitive(Primitive::Timestamp(0)),
                         Value::Primitive(Primitive::Str("".to_owned())),
-                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Int(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Boolean(false)),
                     ]),
                 ),
                 (
                     "\u{1}".to_owned(),
                     Value::Map(
-                        vec![("".to_owned(), Value::Primitive(Primitive::Null))]
+                        vec![("".to_owned(), Value::Primitive(Primitive::F64(0.0)))]
                             .into_iter()
                             .collect(),
-                        MapType::Map,
+                        MapType::Table,
                     ),
                 ),
             ]
@@ -295,6 +121,84 @@ fn missing_object_error_2() {
             MapType::Map,
         ),
     )];
+    let changes2 = vec![
+        LocalChange::delete(Path::root().key("\u{0}\u{0}")),
+        LocalChange::delete(Path::root().key("\u{2}")),
+        LocalChange::delete(Path::root().key("\u{0}")),
+        LocalChange::delete(Path::root().key("")),
+        LocalChange::delete(Path::root().key("\u{1}")),
+    ];
+
+    let mut backend = Backend::init();
+    let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+    let patch = backend.get_patch().unwrap();
+    frontend.apply_patch(patch).unwrap();
+
+    let c = frontend
+        .change::<_, InvalidChangeRequest>(None, |d| {
+            for change in &changes1 {
+                d.add_change(change.clone())?
+            }
+            Ok(())
+        })
+        .unwrap();
+    if let Some(change) = c {
+        change1s.push(change.clone());
+        backend.apply_local_change(change).unwrap();
+    }
+    if change1s.len() >= 2 {
+        println!(
+            "{}",
+            pretty_assertions::Comparison::new(
+                &change1s[change1s.len() - 2],
+                &change1s[change1s.len() - 1],
+            )
+        )
+    }
+
+    let backend_bytes = backend.save().unwrap();
+    println!("{:?}", backend_bytes);
+
+    let backend = Backend::load(backend_bytes);
+    match backend {
+        Err(e) => {
+            panic!("failed loading backend: {:?}", e)
+        }
+        Ok(mut backend) => {
+            let mut frontend =
+                Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+            let patch = backend.get_patch().unwrap();
+            frontend.apply_patch(patch).unwrap();
+
+            let c = frontend
+                .change::<_, InvalidChangeRequest>(None, |d| {
+                    for change in &changes2 {
+                        d.add_change(change.clone())?
+                    }
+                    Ok(())
+                })
+                .unwrap();
+            if let Some(change) = c {
+                change2s.push(change.clone());
+                if change2s.len() >= 2 {
+                    println!(
+                        "{}",
+                        pretty_assertions::Comparison::new(
+                            &change2s[change2s.len() - 2],
+                            &change2s[change2s.len() - 1]
+                        )
+                    )
+                }
+                backend.apply_local_change(change).unwrap();
+            }
+        }
+    }
+}
+
+#[test]
+fn missing_object_error_null_rle_decoding() {
+    let actor_uuid = uuid::Uuid::new_v4();
+    let actor_id = ActorId::from_bytes(actor_uuid.as_bytes());
 
     let raw_change = UncompressedChange {
         operations: vec![

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -5,7 +5,6 @@ use automerge::MapType;
 use automerge::Path;
 use automerge::Value;
 use automerge::{InvalidChangeRequest, Primitive};
-use pretty_assertions::assert_eq;
 
 #[test]
 fn missing_object_error() {
@@ -143,14 +142,20 @@ fn missing_object_error() {
             change1s.push(change.clone());
             backend.apply_local_change(change).unwrap();
         }
+        if change1s.len() >= 2 {
+            println!(
+                "{}",
+                pretty_assertions::Comparison::new(
+                    &change1s[change1s.len() - 2],
+                    &change1s[change1s.len() - 1],
+                )
+            )
+        }
 
         let backend_bytes = backend.save().unwrap();
         println!("{:?}", backend_bytes);
 
         let backend = Backend::load(backend_bytes);
-        if change1s.len() >= 2 {
-            assert_eq!(change1s[change1s.len() - 2], change1s[change1s.len() - 1])
-        }
         match backend {
             Err(e) => {
                 panic!("failed loading backend: {:?}", e)
@@ -171,12 +176,18 @@ fn missing_object_error() {
                     .unwrap();
                 if let Some(change) = c {
                     change2s.push(change.clone());
+                    if change2s.len() >= 2 {
+                        println!(
+                            "{}",
+                            pretty_assertions::Comparison::new(
+                                &change2s[change2s.len() - 2],
+                                &change2s[change2s.len() - 1]
+                            )
+                        )
+                    }
                     backend.apply_local_change(change).unwrap();
                 }
             }
-        }
-        if change2s.len() >= 2 {
-            assert_eq!(change2s[change2s.len() - 2], change2s[change2s.len() - 1])
         }
     }
 }

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -194,174 +194,124 @@ fn missing_object_error() {
 
 #[test]
 fn missing_object_error_2() {
-    let mut change1s = Vec::new();
-    let mut change2s = Vec::new();
-
     let actor_id = uuid::Uuid::new_v4();
 
-    for _ in 0..100 {
-        let changes1 = vec![LocalChange::set(
-            Path::root(),
-            Value::Map(
-                vec![
-                    (
-                        "\u{0}".to_owned(),
-                        Value::Sequence(vec![
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Counter(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Int(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::F32(0.0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::F32(0.0)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::F64(0.0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Uint(0)),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::F64(0.0)),
-                        ]),
+    let changes1 = vec![LocalChange::set(
+        Path::root(),
+        Value::Map(
+            vec![
+                (
+                    "\u{0}".to_owned(),
+                    Value::Sequence(vec![
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Int(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Counter(0)),
+                        Value::Primitive(Primitive::Int(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Int(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::F32(0.0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::F32(0.0)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::F64(0.0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Uint(0)),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::F64(0.0)),
+                    ]),
+                ),
+                (
+                    "".to_owned(),
+                    Value::Sequence(vec![
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Boolean(false)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Null),
+                        Value::Primitive(Primitive::Timestamp(0)),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                        Value::Primitive(Primitive::Str("".to_owned())),
+                    ]),
+                ),
+                (
+                    "\u{1}".to_owned(),
+                    Value::Map(
+                        vec![("".to_owned(), Value::Primitive(Primitive::Null))]
+                            .into_iter()
+                            .collect(),
+                        MapType::Map,
                     ),
-                    (
-                        "".to_owned(),
-                        Value::Sequence(vec![
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Boolean(false)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Null),
-                            Value::Primitive(Primitive::Timestamp(0)),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                            Value::Primitive(Primitive::Str("".to_owned())),
-                        ]),
-                    ),
-                    (
-                        "\u{1}".to_owned(),
-                        Value::Map(
-                            vec![("".to_owned(), Value::Primitive(Primitive::Null))]
-                                .into_iter()
-                                .collect(),
-                            MapType::Map,
-                        ),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-                MapType::Map,
-            ),
-        )];
-        let changes2 = vec![
-            LocalChange::delete(Path::root().key("\u{0}")),
-            LocalChange::delete(Path::root().key("")),
-            LocalChange::delete(Path::root().key("\u{1}")),
-        ];
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            MapType::Map,
+        ),
+    )];
 
-        let mut backend = Backend::init();
-        let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
-        let patch = backend.get_patch().unwrap();
-        frontend.apply_patch(patch).unwrap();
+    let mut backend = Backend::init();
+    let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+    let patch = backend.get_patch().unwrap();
+    frontend.apply_patch(patch).unwrap();
 
-        let c = frontend
-            .change::<_, InvalidChangeRequest>(None, |d| {
-                for change in &changes1 {
-                    d.add_change(change.clone())?
-                }
-                Ok(())
-            })
-            .unwrap();
-        if let Some(change) = c {
-            change1s.push(change.clone());
-            backend.apply_local_change(change).unwrap();
-        }
-        if change1s.len() >= 2 {
-            println!(
-                "{}",
-                pretty_assertions::Comparison::new(
-                    &change1s[change1s.len() - 2],
-                    &change1s[change1s.len() - 1],
-                )
-            )
-        }
-
-        let backend_bytes = backend.save().unwrap();
-        println!("{:?}", backend_bytes);
-
-        let backend = Backend::load(backend_bytes);
-        match backend {
-            Err(e) => {
-                panic!("failed loading backend: {:?}", e)
+    let c = frontend
+        .change::<_, InvalidChangeRequest>(None, |d| {
+            for change in &changes1 {
+                d.add_change(change.clone())?
             }
-            Ok(mut backend) => {
-                let mut frontend =
-                    Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
-                let patch = backend.get_patch().unwrap();
-                frontend.apply_patch(patch).unwrap();
+            Ok(())
+        })
+        .unwrap();
+    if let Some(change) = c {
+        backend.apply_local_change(change).unwrap();
+    }
 
-                let c = frontend
-                    .change::<_, InvalidChangeRequest>(None, |d| {
-                        for change in &changes2 {
-                            d.add_change(change.clone())?
-                        }
-                        Ok(())
-                    })
-                    .unwrap();
-                if let Some(change) = c {
-                    change2s.push(change.clone());
-                    if change2s.len() >= 2 {
-                        println!(
-                            "{}",
-                            pretty_assertions::Comparison::new(
-                                &change2s[change2s.len() - 2],
-                                &change2s[change2s.len() - 1]
-                            )
-                        )
-                    }
-                    backend.apply_local_change(change).unwrap();
-                }
-            }
-        }
+    let backend_bytes = backend.save().unwrap();
+    println!("{:?}", backend_bytes);
+
+    let backend = Backend::load(backend_bytes);
+    if let Err(e) = backend {
+        panic!("failed loading backend: {:?}", e)
     }
 }

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -5,6 +5,11 @@ use automerge::MapType;
 use automerge::Path;
 use automerge::Value;
 use automerge::{InvalidChangeRequest, Primitive};
+use automerge_protocol::{
+    ActorId, ElementId, Key, ObjType, ObjectId, Op, OpId, OpType, ScalarValue, SequenceType,
+    UncompressedChange,
+};
+use test_env_log::test;
 
 #[test]
 fn missing_object_error() {
@@ -194,9 +199,10 @@ fn missing_object_error() {
 
 #[test]
 fn missing_object_error_2() {
-    let actor_id = uuid::Uuid::new_v4();
+    let actor_uuid = uuid::Uuid::new_v4();
+    let actor_id = ActorId::from_bytes(actor_uuid.as_bytes());
 
-    let changes1 = vec![LocalChange::set(
+    let _changes = vec![LocalChange::set(
         Path::root(),
         Value::Map(
             vec![
@@ -290,22 +296,497 @@ fn missing_object_error_2() {
         ),
     )];
 
-    let mut backend = Backend::init();
-    let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
-    let patch = backend.get_patch().unwrap();
-    frontend.apply_patch(patch).unwrap();
+    let raw_change = UncompressedChange {
+        operations: vec![
+            Op {
+                action: OpType::Make(ObjType::Sequence(SequenceType::List)),
+                obj: ObjectId::Root,
+                key: Key::Map("".to_owned()),
+                pred: vec![],
+                insert: false,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Head),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(2, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(3, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(4, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(5, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(6, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(7, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(8, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(9, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(10, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(11, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(12, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(13, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(14, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(1, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(15, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Make(ObjType::Sequence(SequenceType::List)),
+                obj: ObjectId::Root,
+                key: Key::Map("\u{0}".to_owned()),
+                pred: vec![],
+                insert: false,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Head),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(18, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(19, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(20, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(21, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(22, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(23, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(24, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(25, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(26, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(27, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(28, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(29, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(30, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(31, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(32, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(33, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(34, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(35, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(36, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(37, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(38, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(39, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(40, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(41, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(42, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(43, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(44, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(45, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(46, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(47, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(48, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(49, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(50, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(51, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(52, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(53, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(54, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(55, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(56, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(57, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(58, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(59, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(60, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(61, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(62, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(63, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(64, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(17, actor_id.clone())),
+                key: Key::Seq(ElementId::Id(OpId(65, actor_id.clone()))),
+                pred: vec![],
+                insert: true,
+            },
+            Op {
+                action: OpType::Make(ObjType::Map(MapType::Map)),
+                obj: ObjectId::Root,
+                key: Key::Map("\u{1}".to_owned()),
+                pred: vec![],
+                insert: false,
+            },
+            Op {
+                action: OpType::Set(ScalarValue::Null),
+                obj: ObjectId::Id(OpId(67, actor_id.clone())),
+                key: Key::Map("".to_owned()),
+                pred: vec![],
+                insert: false,
+            },
+        ],
+        actor_id,
+        hash: None,
+        seq: 1,
+        start_op: 1,
+        time: 0,
+        message: None,
+        deps: vec![],
+        extra_bytes: vec![],
+    };
 
-    let c = frontend
-        .change::<_, InvalidChangeRequest>(None, |d| {
-            for change in &changes1 {
-                d.add_change(change.clone())?
-            }
-            Ok(())
-        })
-        .unwrap();
-    if let Some(change) = c {
-        backend.apply_local_change(change).unwrap();
-    }
+    let mut backend = Backend::init();
+    backend.apply_local_change(raw_change).unwrap();
 
     let backend_bytes = backend.save().unwrap();
     println!("{:?}", backend_bytes);

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -191,3 +191,177 @@ fn missing_object_error() {
         }
     }
 }
+
+#[test]
+fn missing_object_error_2() {
+    let mut change1s = Vec::new();
+    let mut change2s = Vec::new();
+
+    let actor_id = uuid::Uuid::new_v4();
+
+    for _ in 0..100 {
+        let changes1 = vec![LocalChange::set(
+            Path::root(),
+            Value::Map(
+                vec![
+                    (
+                        "\u{0}".to_owned(),
+                        Value::Sequence(vec![
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Counter(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Int(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::F32(0.0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::F32(0.0)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::F64(0.0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Uint(0)),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::F64(0.0)),
+                        ]),
+                    ),
+                    (
+                        "".to_owned(),
+                        Value::Sequence(vec![
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Boolean(false)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Null),
+                            Value::Primitive(Primitive::Timestamp(0)),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                            Value::Primitive(Primitive::Str("".to_owned())),
+                        ]),
+                    ),
+                    (
+                        "\u{1}".to_owned(),
+                        Value::Map(
+                            vec![("".to_owned(), Value::Primitive(Primitive::Null))]
+                                .into_iter()
+                                .collect(),
+                            MapType::Map,
+                        ),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                MapType::Map,
+            ),
+        )];
+        let changes2 = vec![
+            LocalChange::delete(Path::root().key("\u{0}")),
+            LocalChange::delete(Path::root().key("")),
+            LocalChange::delete(Path::root().key("\u{1}")),
+        ];
+
+        let mut backend = Backend::init();
+        let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+        let patch = backend.get_patch().unwrap();
+        frontend.apply_patch(patch).unwrap();
+
+        let c = frontend
+            .change::<_, InvalidChangeRequest>(None, |d| {
+                for change in &changes1 {
+                    d.add_change(change.clone())?
+                }
+                Ok(())
+            })
+            .unwrap();
+        if let Some(change) = c {
+            change1s.push(change.clone());
+            backend.apply_local_change(change).unwrap();
+        }
+        if change1s.len() >= 2 {
+            println!(
+                "{}",
+                pretty_assertions::Comparison::new(
+                    &change1s[change1s.len() - 2],
+                    &change1s[change1s.len() - 1],
+                )
+            )
+        }
+
+        let backend_bytes = backend.save().unwrap();
+        println!("{:?}", backend_bytes);
+
+        let backend = Backend::load(backend_bytes);
+        match backend {
+            Err(e) => {
+                panic!("failed loading backend: {:?}", e)
+            }
+            Ok(mut backend) => {
+                let mut frontend =
+                    Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
+                let patch = backend.get_patch().unwrap();
+                frontend.apply_patch(patch).unwrap();
+
+                let c = frontend
+                    .change::<_, InvalidChangeRequest>(None, |d| {
+                        for change in &changes2 {
+                            d.add_change(change.clone())?
+                        }
+                        Ok(())
+                    })
+                    .unwrap();
+                if let Some(change) = c {
+                    change2s.push(change.clone());
+                    if change2s.len() >= 2 {
+                        println!(
+                            "{}",
+                            pretty_assertions::Comparison::new(
+                                &change2s[change2s.len() - 2],
+                                &change2s[change2s.len() - 1]
+                            )
+                        )
+                    }
+                    backend.apply_local_change(change).unwrap();
+                }
+            }
+        }
+    }
+}

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -301,7 +301,7 @@ fn missing_object_error_2() {
             Op {
                 action: OpType::Make(ObjType::Sequence(SequenceType::List)),
                 obj: ObjectId::Root,
-                key: Key::Map("".to_owned()),
+                key: Key::Map("b".to_owned()),
                 pred: vec![],
                 insert: false,
             },
@@ -770,7 +770,7 @@ fn missing_object_error_2() {
             Op {
                 action: OpType::Set(ScalarValue::Null),
                 obj: ObjectId::Id(OpId(67, actor_id.clone())),
-                key: Key::Map("".to_owned()),
+                key: Key::Map("a".to_owned()),
                 pred: vec![],
                 insert: false,
             },
@@ -780,7 +780,7 @@ fn missing_object_error_2() {
         seq: 1,
         start_op: 1,
         time: 0,
-        message: None,
+        message: Some("".to_owned()),
         deps: vec![],
         extra_bytes: vec![],
     };


### PR DESCRIPTION
I've managed to hunt down this bug with another more reliable test case and found that the RLE decoder was reading the length of the null run as `isize` when it is encoded as `usize`. This becomes an issue when the length is above a certain value (64 here). Then the length gets read as negative and the decoder enters an infinite loop of repeating the null value, even when there is more input.

Maybe in future we shouldn't use `*size` either but `*64` or `*32` explicitly so different platforms don't have issues saving/loading shared documents. I'll leave that for another time.

Fixes #57 