### PR TITLE
Fix alignment error on wasm32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ script:
 - travis_fold start "wasm-build"
 - cd automerge-backend-wasm && yarn release
 - travis_fold end "wasm-build"
+- travis_fold start "wasm-test"
+- wasm-pack test automerge-frontend --node
+- travis_fold end "wasm-test"
 jobs:
   allow_failures:
   - rust: nightly

--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -16,12 +16,17 @@ maplit = "1.0.2"
 thiserror = "1.0.16"
 im-rc = "15.0.0"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2.2", features=["js"] }
+uuid = { version = "0.8.1", features = ["wasm-bindgen", "v4", "serde"] }
+
 [dev-dependencies]
 automerge-backend = { path = "../automerge-backend" }
 criterion = "0.3.3"
 rand = "0.8.2"
 env_logger = "0.8.3"
 log = "0.4.14"
+wasm-bindgen-test = "0.3.22"
 
 [[bench]]
 name = "statetree_apply_diff"

--- a/automerge-frontend/tests/test_wasm.rs
+++ b/automerge-frontend/tests/test_wasm.rs
@@ -1,0 +1,15 @@
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn test_simple_frontend_change_with_set_sequence() {
+    let mut f = automerge_frontend::Frontend::new_with_timestamper(Box::new(|| None));
+    f.change::<_, automerge_frontend::InvalidChangeRequest>(None, |doc| {
+        doc.add_change(automerge_frontend::LocalChange::set(
+            automerge_frontend::Path::root().key(""),
+            automerge_frontend::Value::Sequence(vec![]),
+        ))
+        .unwrap();
+        Ok(())
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Fixes #54.

This makes the contents of the Vector satisfy the alignment rules required by the inner logic on 32 bit architectures.

The test also triggers this issue without the fix so should serve to detect it in future.

While it might not be ideal to have the added layer of indirection here I'm not aware of another alternative without digging further into the dependency but this fixes it nicely.