### PR TITLE
Use grapheme clusters in Text instead of char

### DIFF
--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { version = "^0.8.2", features=["v4"] }
 maplit = "1.0.2"
 thiserror = "1.0.16"
 im-rc = "15.0.0"
+unicode-segmentation = "1.7.1"
 
 [dev-dependencies]
 automerge-backend = { path = "../automerge-backend" }

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -3,6 +3,7 @@ use crate::state_tree::{LocalOperationResult, SetOrInsertPayload, StateTree, Tar
 use crate::value::{Cursor, Primitive, Value};
 use crate::{Path, PathElement};
 use automerge_protocol as amp;
+use unicode_segmentation::UnicodeSegmentation;
 
 pub trait MutableDocument {
     fn value_at_path(&self, path: &Path) -> Option<Value>;
@@ -189,11 +190,11 @@ impl MutableDocument for MutationTracker {
                             }
                             (PathElement::Index(i), Target::Text(ref text)) => match value {
                                 Value::Primitive(Primitive::Str(s)) => {
-                                    if s.len() == 1 {
+                                    if s.graphemes(true).count() == 1 {
                                         let payload = SetOrInsertPayload {
                                             start_op: self.max_op + 1,
                                             actor: &self.actor_id.clone(),
-                                            value: s.chars().next().unwrap(),
+                                            value: s.clone(),
                                         };
                                         self.apply_state_change(text.set(*i, payload)?);
                                         Ok(())
@@ -339,11 +340,11 @@ impl MutableDocument for MutationTracker {
                             }
                             (Target::Text(text_target), val) => match val {
                                 Value::Primitive(Primitive::Str(s)) => {
-                                    if s.len() == 1 {
+                                    if s.graphemes(true).count() == 1 {
                                         let payload = SetOrInsertPayload {
                                             start_op: self.max_op + 1,
                                             actor: &self.actor_id.clone(),
-                                            value: s.chars().next().unwrap(),
+                                            value: s.clone(),
                                         };
                                         self.apply_state_change(
                                             text_target.insert(*index, payload)?,

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -1,4 +1,4 @@
-use super::{DiffApplicationResult, DiffToApply, MultiChar, MultiValue, StateTreeChange};
+use super::{DiffApplicationResult, DiffToApply, MultiGrapheme, MultiValue, StateTreeChange};
 use crate::error::InvalidPatch;
 use automerge_protocol as amp;
 use std::collections::HashMap;
@@ -27,7 +27,7 @@ pub(super) trait DiffableValue: Sized {
     fn default_opid(&self) -> amp::OpId;
 }
 
-impl DiffableValue for MultiChar {
+impl DiffableValue for MultiGrapheme {
     fn construct<K>(
         opid: &amp::OpId,
         diff: DiffToApply<K, &amp::Diff>,
@@ -35,7 +35,7 @@ impl DiffableValue for MultiChar {
     where
         K: Into<amp::Key>,
     {
-        let c = MultiChar::new_from_diff(opid, diff)?;
+        let c = MultiGrapheme::new_from_diff(opid, diff)?;
         Ok(DiffApplicationResult::pure(c))
     }
 
@@ -47,7 +47,7 @@ impl DiffableValue for MultiChar {
     where
         K: Into<amp::Key>,
     {
-        MultiChar::apply_diff(self, opid, diff).map(DiffApplicationResult::pure)
+        MultiGrapheme::apply_diff(self, opid, diff).map(DiffApplicationResult::pure)
     }
 
     fn apply_diff_iter<'a, 'b, 'c, 'd, I, K: 'c>(
@@ -59,7 +59,7 @@ impl DiffableValue for MultiChar {
         I: Iterator<Item = (&'b amp::OpId, DiffToApply<'c, K, &'d amp::Diff>)>,
     {
         self.apply_diff_iter(diff)
-        //MultiChar::apply_diff_iter(self, diff)
+        //MultiGrapheme::apply_diff_iter(self, diff)
     }
 
     fn default_opid(&self) -> amp::OpId {

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -246,7 +246,7 @@ pub(super) struct MultiGrapheme {
 
 impl MultiGrapheme {
     pub(super) fn new_from_grapheme_cluster(opid: amp::OpId, s: String) -> MultiGrapheme {
-        debug_assert!(s.graphemes(true).count() == 1);
+        debug_assert_eq!(s.graphemes(true).count(), 1);
         MultiGrapheme {
             winning_value: (opid, s),
             conflicts: None,

--- a/automerge-frontend/src/value.rs
+++ b/automerge-frontend/src/value.rs
@@ -16,7 +16,8 @@ impl From<HashMap<amp::OpId, Value>> for Conflicts {
 pub enum Value {
     Map(HashMap<String, Value>, amp::MapType),
     Sequence(Vec<Value>),
-    Text(Vec<char>),
+    /// Sequence of grapheme clusters
+    Text(Vec<String>),
     Primitive(Primitive),
 }
 
@@ -164,7 +165,7 @@ impl Value {
             Value::Sequence(elements) => {
                 serde_json::Value::Array(elements.iter().map(|v| v.to_json()).collect())
             }
-            Value::Text(chars) => serde_json::Value::String(chars.iter().collect()),
+            Value::Text(graphemes) => serde_json::Value::String(graphemes.join("")),
             Value::Primitive(v) => match v {
                 Primitive::F64(n) => serde_json::Value::Number(
                     serde_json::Number::from_f64(*n).unwrap_or_else(|| serde_json::Number::from(0)),

--- a/automerge-frontend/tests/test_apply_patch.rs
+++ b/automerge-frontend/tests/test_apply_patch.rs
@@ -2,6 +2,7 @@ use automerge_frontend::{Frontend, Path, Primitive, Value};
 use automerge_protocol as amp;
 use maplit::hashmap;
 use std::convert::TryInto;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[test]
 fn set_object_root_properties() {
@@ -878,7 +879,9 @@ fn test_text_objects() {
 
     assert_eq!(
         frontend.state(),
-        &Into::<Value>::into(hashmap! {"name" => Value::Text("ben".to_string().chars().collect())})
+        &Into::<Value>::into(
+            hashmap! {"name" => Value::Text("ben".graphemes(true).map(|s|s.to_owned()).collect())}
+        )
     );
 
     let patch2 = amp::Patch {
@@ -915,7 +918,9 @@ fn test_text_objects() {
 
     assert_eq!(
         frontend.state(),
-        &Into::<Value>::into(hashmap! {"name" => Value::Text("bi".to_string().chars().collect())})
+        &Into::<Value>::into(
+            hashmap! {"name" => Value::Text("bi".graphemes(true).map(|s|s.to_owned()).collect())}
+        )
     );
 }
 

--- a/automerge-frontend/tests/test_cursor.rs
+++ b/automerge-frontend/tests/test_cursor.rs
@@ -3,6 +3,7 @@ use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Prim
 use automerge_protocol as amp;
 use maplit::hashmap;
 use std::convert::TryInto;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[test]
 fn test_allow_cursor_on_list_element() {
@@ -49,7 +50,7 @@ fn test_allow_cursor_on_text_element() {
         .change::<_, InvalidChangeRequest>(None, |d| {
             d.add_change(LocalChange::set(
                 Path::root().key("list"),
-                Value::Text("123".chars().collect()),
+                Value::Text("123".graphemes(true).map(|s| s.to_owned()).collect()),
             ))?;
             let cursor = d
                 .cursor_to_path(&Path::root().key("list").index(1))
@@ -89,7 +90,7 @@ fn test_do_not_allow_index_past_end_of_list() {
         .change::<_, InvalidChangeRequest>(None, |d| {
             d.add_change(LocalChange::set(
                 Path::root().key("list"),
-                Value::Text("123".chars().collect()),
+                Value::Text("123".graphemes(true).map(|s| s.to_owned()).collect()),
             ))?;
             let cursor = d.cursor_to_path(&Path::root().key("list").index(10));
             assert_eq!(cursor, None);
@@ -105,7 +106,7 @@ fn test_updates_cursor_during_change_function() {
         .change::<_, InvalidChangeRequest>(None, |d| {
             d.add_change(LocalChange::set(
                 Path::root().key("list"),
-                Value::Text("123".chars().collect()),
+                Value::Text("123".graphemes(true).map(|s| s.to_owned()).collect()),
             ))?;
             let cursor = d
                 .cursor_to_path(&Path::root().key("list").index(1))
@@ -222,7 +223,7 @@ fn test_set_cursor_to_new_element_in_local_change() {
         .change::<_, InvalidChangeRequest>(None, |d| {
             d.add_change(LocalChange::set(
                 Path::root().key("list"),
-                Value::Text("123".chars().collect()),
+                Value::Text("123".graphemes(true).map(|s| s.to_owned()).collect()),
             ))?;
             let cursor = d
                 .cursor_to_path(&Path::root().key("list").index(1))
@@ -270,7 +271,7 @@ fn test_delete_cursor_and_adding_again() {
         .change::<_, InvalidChangeRequest>(None, |d| {
             d.add_change(LocalChange::set(
                 Path::root().key("list"),
-                Value::Text("123".chars().collect()),
+                Value::Text("123".graphemes(true).map(|s| s.to_owned()).collect()),
             ))?;
             let cursor = d
                 .cursor_to_path(&Path::root().key("list").index(1))

--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -2,6 +2,7 @@ use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Prim
 use automerge_protocol as amp;
 use maplit::hashmap;
 use std::convert::TryInto;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[test]
 fn test_should_be_empty_after_init() {
@@ -640,7 +641,7 @@ fn test_sets_characters_in_text() {
     doc.change::<_, InvalidChangeRequest>(None, |doc| {
         doc.add_change(LocalChange::set(
             Path::root().key("text"),
-            Value::Text("some".chars().collect()),
+            Value::Text("some".graphemes(true).map(|s| s.to_owned()).collect()),
         ))?;
         Ok(())
     })
@@ -679,7 +680,7 @@ fn test_sets_characters_in_text() {
     let value = doc.get_value(&Path::root()).unwrap();
     let expected_value: Value = Value::Map(
         hashmap! {
-            "text".into() => Value::Text(vec!['s', 'a', 'm', 'e']),
+            "text".into() => Value::Text(vec!["s".to_owned(), "a".to_owned(), "m".to_owned(), "e".to_owned()]),
         },
         amp::MapType::Map,
     );
@@ -692,7 +693,7 @@ fn test_inserts_characters_in_text() {
     doc.change::<_, InvalidChangeRequest>(None, |doc| {
         doc.add_change(LocalChange::set(
             Path::root().key("text"),
-            Value::Text("same".chars().collect()),
+            Value::Text("same".graphemes(true).map(|s| s.to_owned()).collect()),
         ))?;
         Ok(())
     })
@@ -734,7 +735,7 @@ fn test_inserts_characters_in_text() {
     let value = doc.get_value(&Path::root()).unwrap();
     let expected_value: Value = Value::Map(
         hashmap! {
-            "text".into() => Value::Text(vec!['s', 'h', 'a', 'm', 'e']),
+            "text".into() => Value::Text(vec!["s".to_owned(), "h".to_owned(), "a".to_owned(), "m".to_owned(), "e".to_owned()]),
         },
         amp::MapType::Map,
     );
@@ -789,7 +790,7 @@ fn test_inserts_characters_at_start_of_text() {
     let value = doc.get_value(&Path::root()).unwrap();
     let expected_value: Value = Value::Map(
         hashmap! {
-            "text".into() => Value::Text(vec!['i']),
+            "text".into() => Value::Text(vec!["i".to_owned()]),
         },
         amp::MapType::Map,
     );

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.8.2"
 test-env-log = { version = "0.2.6", features = ["trace"], default-features = false }
 tracing = "0.1.25"
 tracing-subscriber = {version = "0.2", features = ["chrono", "env-filter", "fmt"]}
+unicode-segmentation = "1.7.1"
 
 [[bench]]
 name = "crdt_benchmarks"

--- a/automerge/tests/text_grapheme_clusters.rs
+++ b/automerge/tests/text_grapheme_clusters.rs
@@ -1,0 +1,18 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+#[test]
+fn create_frontend_with_grapheme_clusters() {
+    let mut hm = std::collections::HashMap::new();
+    hm.insert(
+        String::new(),
+        automerge::Value::Text("\u{80}".graphemes(true).map(|s| s.to_owned()).collect()),
+    );
+    let (mut f, c) = automerge::Frontend::new_with_initial_state(automerge::Value::Map(
+        hm,
+        automerge::MapType::Map,
+    ))
+    .unwrap();
+    let mut b = automerge::Backend::init();
+    let (p, _) = b.apply_local_change(c).unwrap();
+    f.apply_patch(p).unwrap();
+}


### PR DESCRIPTION
`char` is not what users typically expect as a 'letter' so we should use
grapheme clusters instead. These can't always be represented as single
rust `char` types so the `Text` now stores a `Vec` of single grapheme `String`s.

Fixes #44 

While this makes sense from the rust side I'm not sure if it has an effect on the javascript implementation compatability. Also, not sure of its affect on the binary encoding from the javascript side again.