### PR TITLE
Remove Rc from the backend

### DIFF
--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -29,3 +29,21 @@ mod pending_diff;
 pub use backend::Backend;
 pub use change::Change;
 pub use error::AutomergeError;
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        thread,
+    };
+
+    #[test]
+    fn sync_and_send_backend() {
+        let b = crate::Backend::init();
+        let mb = Arc::new(Mutex::new(b));
+        thread::spawn(move || {
+            let b = mb.lock().unwrap();
+            b.get_changes(&[]);
+        });
+    }
+}

--- a/automerge-backend/src/object_store.rs
+++ b/automerge-backend/src/object_store.rs
@@ -5,7 +5,6 @@ use crate::op_handle::OpHandle;
 use crate::ordered_set::{OrderedSet, SkipList};
 use automerge_protocol as amp;
 use fxhash::FxBuildHasher;
-//use im_rc::{HashMap, HashSet};
 use std::collections::{HashMap, HashSet};
 
 /// ObjectHistory is what the OpSet uses to store operations for a particular

--- a/automerge-backend/src/op_handle.rs
+++ b/automerge-backend/src/op_handle.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use std::rc::Rc;
 
 use crate::actor_map::ActorMap;
 use crate::internal::{InternalOp, InternalOpType, Key, ObjectId, OpId};
@@ -16,7 +15,7 @@ pub(crate) struct OpHandle {
 }
 
 impl OpHandle {
-    pub fn extract(change: Rc<Change>, actors: &mut ActorMap) -> Vec<OpHandle> {
+    pub fn extract(change: Change, actors: &mut ActorMap) -> Vec<OpHandle> {
         change
             .iter_ops()
             .enumerate()

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -13,13 +13,12 @@ use std::ffi::{CStr, CString};
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_char;
 use std::ptr;
-use std::rc::Rc;
 
 #[derive(Clone)]
 pub struct Backend {
     handle: automerge_backend::Backend,
     text: Option<String>,
-    last_local_change: Option<Rc<Change>>,
+    last_local_change: Option<Change>,
     binary: Vec<Vec<u8>>,
     queue: Option<Vec<Vec<u8>>>,
     error: Option<CString>,

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -115,9 +115,7 @@ where
     T: DiffableValue,
     T: Clone,
 {
-    // TODO: figure out why we need this box. From my understanding of im_rc::Vector we shouldn't
-    // need it, but without it we get recursive type errors in StateTreeList
-    underlying: Box<im_rc::Vector<Box<(amp::OpId, Option<T>)>>>,
+    underlying: im_rc::Vector<Box<(amp::OpId, Option<T>)>>,
 }
 
 impl<T> DiffableSequence<T>
@@ -127,7 +125,7 @@ where
 {
     pub fn new() -> DiffableSequence<T> {
         DiffableSequence {
-            underlying: Box::new(im_rc::Vector::new()),
+            underlying: im_rc::Vector::new(),
         }
     }
 
@@ -136,11 +134,10 @@ where
         I: IntoIterator<Item = (amp::OpId, T)>,
     {
         DiffableSequence {
-            underlying: Box::new(
-                i.into_iter()
-                    .map(|(oid, v)| Box::new((oid, Some(v))))
-                    .collect(),
-            ),
+            underlying: i
+                .into_iter()
+                .map(|(oid, v)| Box::new((oid, Some(v))))
+                .collect(),
         }
     }
 
@@ -264,10 +261,9 @@ where
 
     pub(super) fn update(&self, index: usize, value: T) -> Self {
         DiffableSequence {
-            underlying: Box::new(
-                self.underlying
-                    .update(index, Box::new((value.default_opid(), Some(value)))),
-            ),
+            underlying: self
+                .underlying
+                .update(index, Box::new((value.default_opid(), Some(value)))),
         }
     }
 

--- a/automerge-frontend/tests/test_backend_concurrency.rs
+++ b/automerge-frontend/tests/test_backend_concurrency.rs
@@ -620,7 +620,7 @@ fn test_deps_are_filled_in_if_frontend_does_not_have_latest_patch() {
 
     let mut doc2 = Frontend::new();
     let mut backend2 = Backend::init();
-    let patch1 = backend2.apply_changes(vec![(*binchange1).clone()]).unwrap();
+    let patch1 = backend2.apply_changes(vec![binchange1.clone()]).unwrap();
     doc2.apply_patch(patch1.clone()).unwrap();
 
     let change2 = doc2

--- a/automerge/benches/crdt_benchmarks.rs
+++ b/automerge/benches/crdt_benchmarks.rs
@@ -59,7 +59,7 @@ pub fn b1_1(c: &mut Criterion) {
                         doc1.apply_patch(patch).unwrap();
 
                         let patch2 = backend2
-                            .apply_changes(vec![(*change_to_send).clone()])
+                            .apply_changes(vec![(change_to_send).clone()])
                             .unwrap();
                         doc2.apply_patch(patch2).unwrap()
                     }
@@ -119,9 +119,7 @@ pub fn b1_2(c: &mut Criterion) {
                         backend1.apply_local_change(doc1_insert_change).unwrap();
                     doc1.apply_patch(patch).unwrap();
 
-                    let patch2 = backend2
-                        .apply_changes(vec![(*change_to_send).clone()])
-                        .unwrap();
+                    let patch2 = backend2.apply_changes(vec![change_to_send]).unwrap();
                     doc2.apply_patch(patch2).unwrap();
                     (doc1, backend1, doc2, backend2)
                 })
@@ -158,9 +156,7 @@ pub fn b3_1(c: &mut Criterion) {
                     .enumerate()
                     .map(|(index, mut doc)| {
                         let mut backend = Backend::init();
-                        let patch = backend
-                            .apply_changes(vec![(*init_binchange).clone()])
-                            .unwrap();
+                        let patch = backend.apply_changes(vec![init_binchange.clone()]).unwrap();
                         doc.apply_patch(patch).unwrap();
                         let change = doc
                             .change(None, |d| {
@@ -171,7 +167,7 @@ pub fn b3_1(c: &mut Criterion) {
                             })
                             .unwrap()
                             .unwrap();
-                        (*backend.apply_local_change(change).unwrap().1).clone()
+                        backend.apply_local_change(change).unwrap().1
                     })
                     .collect();
                 (local_doc, local_backend, updates)

--- a/automerge/src/lib.rs
+++ b/automerge/src/lib.rs
@@ -1,3 +1,5 @@
 pub use automerge_backend::{Backend, Change};
-pub use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value};
+pub use automerge_frontend::{
+    Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value,
+};
 pub use automerge_protocol::{MapType, ObjType, ScalarValue, SequenceType};


### PR DESCRIPTION
This mechanically removes `Rc` from the backend code. There weren't any major issues so it seems as though it wasn't needed.

If someone has more knowledge on why it was needed I'd be happy to hear.

Fixes #75 