### PR TITLE
Use 32 bits on binary encoding

### DIFF
--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -59,10 +59,16 @@ impl<'a> Decoder<'a> {
     }
 }
 
+/// Encodes booleans by storing the count of the same value.
+///
+/// The sequence of numbers describes the count of false values on even indices (0-indexed) and the
+/// count of true values on odd indices (0-indexed).
+///
+/// Counts are encoded as u32s.
 pub(crate) struct BooleanEncoder {
     buf: Vec<u8>,
     last: bool,
-    count: usize,
+    count: u32,
 }
 
 impl BooleanEncoder {
@@ -95,10 +101,11 @@ impl BooleanEncoder {
     }
 }
 
+/// See discussion on [`BooleanEncoder`] for the format data is stored in.
 pub(crate) struct BooleanDecoder<'a> {
     decoder: Decoder<'a>,
     last_value: bool,
-    count: usize,
+    count: u32,
 }
 
 impl<'a> From<&'a [u8]> for Decoder<'a> {

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -141,6 +141,11 @@ impl<'a> Iterator for BooleanDecoder<'a> {
     }
 }
 
+/// Encodes integers as the change since the previous value.
+///
+/// The initial value is 0 encoded as u64. Deltas are encoded as i64.
+///
+/// Run length encoding is then applied to the resulting sequence.
 pub(crate) struct DeltaEncoder {
     rle: RleEncoder<i64>,
     absolute_value: u64,
@@ -384,6 +389,7 @@ where
     }
 }
 
+/// See discussion on [`DeltaDecoder`] for the format data is stored in.
 pub(crate) struct DeltaDecoder<'a> {
     rle: RleDecoder<'a, i64>,
     absolute_val: u64,

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -164,10 +164,10 @@ impl DeltaEncoder {
 
 enum RleState<T> {
     Empty,
-    NullRun(usize),
+    NullRun(u32),
     LiteralRun(T, Vec<T>),
     LoneVal(T),
-    Run(T, usize),
+    Run(T, i32),
 }
 
 /// Encodes data in run lengh encoding format. This is very efficient for long repeats of data
@@ -205,7 +205,7 @@ where
 
     pub fn finish(mut self, col: u32) -> ColData {
         match self.take_state() {
-            // this coveres `only_nulls`
+            // this covers `only_nulls`
             RleState::NullRun(size) => {
                 if !self.buf.is_empty() {
                     self.flush_null_run(size)
@@ -225,14 +225,14 @@ where
         }
     }
 
-    fn flush_run(&mut self, val: T, len: usize) {
+    fn flush_run(&mut self, val: T, len: i32) {
         self.encode(len as i32);
         self.encode(val);
     }
 
-    fn flush_null_run(&mut self, len: usize) {
+    fn flush_null_run(&mut self, len: u32) {
         self.encode::<i32>(0);
-        self.encode(len as u32);
+        self.encode(len);
     }
 
     fn flush_lit_run(&mut self, run: Vec<T>) {


### PR DESCRIPTION
This changes the binary encoding to not use `*size` types but `*32` types. `*size` shouldn't be used since it is different sizes on different platforms so could lead to different issues. Also on 32 bit platforms we can't represent things like `Vec` to the same length as on 64 bit platforms so I think we should prefer to limit things where possible to 32 bits in length.

Relates to #70 

What are your thoughts?