### PR TITLE
Add getAllChanges function to wasm backend

### DIFF
--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 //#![feature(set_stdio)]
 
 use automerge_backend::{AutomergeError, Backend, Change};
-use automerge_protocol::{ActorId, ChangeHash, UncompressedChange};
+use automerge_protocol::{ChangeHash, UncompressedChange};
 use js_sys::{Array, Uint8Array};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -161,18 +161,6 @@ pub fn get_changes(input: Object, have_deps: JsValue) -> Result<JsValue, JsValue
     let deps: Vec<ChangeHash> = js_to_rust(&have_deps)?;
     get_input(input, |state| {
         Ok(export_changes(state.0.get_changes(&deps)).into())
-    })
-}
-
-#[wasm_bindgen(js_name = getChangesForActor)]
-pub fn get_changes_for_actor(input: Object, actorid: JsValue) -> Result<JsValue, JsValue> {
-    let actorid: ActorId = js_to_rust(&actorid)?;
-    get_input(input, |state| {
-        state
-            .0
-            .get_changes_for_actor_id(&actorid)
-            .map(|changes| export_changes(changes).into())
-            .map_err(to_js_err)
     })
 }
 

--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -164,6 +164,14 @@ pub fn get_changes(input: Object, have_deps: JsValue) -> Result<JsValue, JsValue
     })
 }
 
+#[wasm_bindgen(js_name = getAllChanges)]
+pub fn get_all_changes(input: Object) -> Result<JsValue, JsValue> {
+    let deps: Vec<ChangeHash> = vec![];
+    get_input(input, |state| {
+        Ok(export_changes(state.0.get_changes(&deps)).into())
+    })
+}
+
 #[wasm_bindgen(js_name = getMissingDeps)]
 pub fn get_missing_deps(input: Object) -> Result<JsValue, JsValue> {
     get_input(input, |state| rust_to_js(state.0.get_missing_deps()))


### PR DESCRIPTION
Fixes #81. The JS backend now exposes a function `Backend.getAllChanges(backend)`, which is currently just a shortcut for `Backend.getChanges(backend, [])` but which may have a more optimised implementation in the future.

Also removed `Backend.getChangesForActor`, which no longer exists in the JS backend. I think the corresponding `get_changes_for_actor` could also be removed from `automerge-c/src/lib.rs` and `automerge-backend/src/backend.rs`, but the function is currently still used by `automerge-c/automerge.c` so I left it there for now.