### PR TITLE
Improve Frontend::apply_patch performance

### DIFF
--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -239,7 +239,7 @@ impl FrontendState {
                     *self = FrontendState::WaitingForInFlightRequests {
                         in_flight_requests,
                         optimistically_updated_root_state: new_root_state,
-                        reconciled_root_state: std::mem::replace(root_state, StateTree::new()),
+                        reconciled_root_state: std::mem::take(root_state),
                         max_op,
                     }
                 };

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -109,14 +109,6 @@ impl MutationTracker {
         }
     }
 
-    pub fn ops(&self) -> Option<Vec<amp::Op>> {
-        if !self.ops.is_empty() {
-            Some(self.ops.clone())
-        } else {
-            None
-        }
-    }
-
     /// If the `value` is a map, individually assign each k,v in it to a key in
     /// the root object
     fn wrap_root_assignment(&mut self, value: &Value) -> Result<(), InvalidChangeRequest> {
@@ -206,6 +198,15 @@ impl MutationTracker {
         } else {
             Err(InvalidChangeRequest::NoSuchPathError { path: path.clone() })
         }
+    }
+
+    pub(crate) fn finalise(self) -> (StateTree, Option<Vec<amp::Op>>) {
+        let ops = if !self.ops.is_empty() {
+            Some(self.ops)
+        } else {
+            None
+        };
+        (self.state, ops)
     }
 }
 
@@ -393,7 +394,6 @@ impl MutableDocument for MutationTracker {
                     })
                 }
             }
-            //<<<<<<< HEAD
             //LocalOperation::Insert(value) => {
             //if let Some(name) = change.path.name() {
             //let index = match name {

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -200,13 +200,8 @@ impl MutationTracker {
         }
     }
 
-    pub(crate) fn finalise(self) -> (StateTree, Option<Vec<amp::Op>>) {
-        let ops = if !self.ops.is_empty() {
-            Some(self.ops)
-        } else {
-            None
-        };
-        (self.state, ops)
+    pub(crate) fn finalise(self) -> (StateTree, Vec<amp::Op>) {
+        (self.state, self.ops)
     }
 }
 

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -350,7 +350,7 @@ impl MutableDocument for MutationTracker {
                                     path: change.path,
                                 })
                             }
-                            Target::Root(r) => match name {
+                            Target::Root(mut r) => match name {
                                 PathElement::Key(k) => r.delete_key(k),
                                 _ => {
                                     return Err(InvalidChangeRequest::NoSuchPathError {

--- a/automerge-frontend/src/state_tree/diff_application_result.rs
+++ b/automerge-frontend/src/state_tree/diff_application_result.rs
@@ -28,17 +28,6 @@ impl<T> DiffApplicationResult<T> {
         }
     }
 
-    pub(crate) fn try_map<F, U, E>(self, f: F) -> Result<DiffApplicationResult<U>, E>
-    where
-        F: FnOnce(T) -> Result<U, E>,
-    {
-        let value = f(self.value)?;
-        Ok(DiffApplicationResult {
-            value,
-            change: self.change,
-        })
-    }
-
     pub(crate) fn and_then<F, U>(self, f: F) -> DiffApplicationResult<U>
     where
         F: FnOnce(T) -> DiffApplicationResult<U>,

--- a/automerge-frontend/src/state_tree/diff_application_result.rs
+++ b/automerge-frontend/src/state_tree/diff_application_result.rs
@@ -43,10 +43,10 @@ impl<T> DiffApplicationResult<T> {
     where
         F: FnOnce(T) -> DiffApplicationResult<U>,
     {
-        let result = f(self.value);
+        let mut result = f(self.value);
         DiffApplicationResult {
             value: result.value,
-            change: result.change.union(self.change),
+            change: result.change.union(self.change).clone(),
         }
     }
 
@@ -54,10 +54,10 @@ impl<T> DiffApplicationResult<T> {
     where
         F: FnOnce(T) -> Result<DiffApplicationResult<U>, E>,
     {
-        let result = f(self.value)?;
+        let mut result = f(self.value)?;
         Ok(DiffApplicationResult {
             value: result.value,
-            change: result.change.union(self.change),
+            change: result.change.union(self.change).clone(),
         })
     }
 }

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -176,7 +176,7 @@ where
     }
 
     pub fn apply_diff(
-        &self,
+        &mut self,
         object_id: &amp::ObjectId,
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
@@ -318,15 +318,13 @@ where
         self.underlying.len()
     }
 
-    pub(super) fn update(&self, index: usize, value: T) -> Self {
+    pub(super) fn update(&mut self, index: usize, value: T) {
         let elem_id = if let Some(existing) = self.underlying.get(index) {
             existing.0.clone()
         } else {
             value.default_opid()
         };
-        DiffableSequence {
-            underlying: Box::new(self.underlying.update(index, (elem_id, value))),
-        }
+        self.underlying.set(index, (elem_id, value));
     }
 
     pub(super) fn get(&self, index: usize) -> Option<&(OpId, T)> {

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -183,9 +183,6 @@ where
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<DiffableSequence<T>, InvalidPatch> {
-        let mut opids_in_this_diff: std::collections::HashSet<amp::OpId> =
-            std::collections::HashSet::new();
-
         for edit in edits {
             match edit {
                 amp::DiffEdit::Remove { index, count } => {
@@ -213,7 +210,6 @@ where
                     op_id,
                     value,
                 } => {
-                    opids_in_this_diff.insert(op_id.clone());
                     let value = T::construct(
                         &op_id,
                         DiffToApply {

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -18,7 +18,7 @@ pub(super) trait DiffableValue: Sized {
     where
         K: Into<amp::Key>;
     fn apply_diff<K>(
-        &self,
+        &mut self,
         opid: &amp::OpId,
         diff: DiffToApply<K, amp::Diff>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
@@ -54,7 +54,7 @@ impl DiffableValue for MultiGrapheme {
     }
 
     fn apply_diff<K>(
-        &self,
+        &mut self,
         opid: &amp::OpId,
         diff: DiffToApply<K, amp::Diff>,
         _current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
@@ -104,7 +104,7 @@ impl DiffableValue for MultiValue {
     }
 
     fn apply_diff<K>(
-        &self,
+        &mut self,
         opid: &amp::OpId,
         diff: DiffToApply<K, amp::Diff>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
@@ -404,7 +404,7 @@ where
     {
         match self {
             UpdatingSequenceElement::Original(v) => {
-                let updated = if let Some(existing) = v.only_for_opid(opid) {
+                let updated = if let Some(mut existing) = v.only_for_opid(opid) {
                     existing.apply_diff(opid, diff, current_objects)?
                 } else {
                     T::construct(opid, diff, current_objects)?
@@ -417,7 +417,7 @@ where
                 Ok(updated.change)
             }
             UpdatingSequenceElement::New(v) => {
-                let updated = if let Some(existing) = v.only_for_opid(opid) {
+                let updated = if let Some(mut existing) = v.only_for_opid(opid) {
                     existing.apply_diff(opid, diff, current_objects)?
                 } else {
                     T::construct(opid, diff, current_objects)?
@@ -435,13 +435,13 @@ where
                 remaining_updates,
             } => {
                 println!("UPdating already updated value");
-                let updated = if let Some(update) =
+                let updated = if let Some(mut update) =
                     remaining_updates.iter().find_map(|v| v.only_for_opid(opid))
                 {
                     update.apply_diff(opid, diff, current_objects)?
-                } else if let Some(initial) = initial_update.only_for_opid(opid) {
+                } else if let Some(mut initial) = initial_update.only_for_opid(opid) {
                     initial.apply_diff(opid, diff, current_objects)?
-                } else if let Some(original) = original.only_for_opid(opid) {
+                } else if let Some(mut original) = original.only_for_opid(opid) {
                     original.apply_diff(opid, diff, current_objects)?
                 } else {
                     T::construct(opid, diff, current_objects)?

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -241,6 +241,7 @@ where
                             object_id: object_id.clone(),
                         });
                     }
+                    let mut to_insert = im_rc::Vector::new();
                     for (i, value) in values.iter().enumerate() {
                         let opid = elem_id.as_opid().unwrap().increment_by(i as u64);
                         let value = T::construct(
@@ -252,11 +253,13 @@ where
                             },
                             current_objects,
                         )?;
-                        self.underlying.insert(
-                            index + i,
-                            (value.default_opid(), UpdatingSequenceElement::New(value)),
-                        );
+                        to_insert
+                            .push_back((value.default_opid(), UpdatingSequenceElement::New(value)));
                     }
+                    let (mut left, right) = self.underlying.clone().split_at(index);
+                    left.append(to_insert);
+                    left.append(right);
+                    self.underlying = Box::new(left);
                 }
                 amp::DiffEdit::Update {
                     index,

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -182,7 +182,7 @@ where
         object_id: &amp::ObjectId,
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
-    ) -> Result<DiffableSequence<T>, InvalidPatch> {
+    ) -> Result<(), InvalidPatch> {
         for edit in edits {
             match edit {
                 amp::DiffEdit::Remove { index, count } => {
@@ -283,7 +283,7 @@ where
             };
         }
 
-        Ok(self.clone())
+        Ok(())
     }
 
     pub(super) fn remove(&mut self, index: usize) -> T {

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -187,7 +187,6 @@ where
     ) -> Result<DiffApplicationResult<DiffableSequence<T>>, InvalidPatch> {
         let mut opids_in_this_diff: std::collections::HashSet<amp::OpId> =
             std::collections::HashSet::new();
-        let mut old_conflicts: Vec<Option<T>> = vec![None; self.underlying.len()];
         let mut changes = StateTreeChange::empty();
 
         for edit in edits {
@@ -228,11 +227,9 @@ where
                         current_objects,
                     )?;
                     if (index as usize) == self.underlying.len() {
-                        old_conflicts.push(None);
                         self.underlying
                             .push_back((value.default_opid(), UpdatingSequenceElement::New(value)));
                     } else {
-                        old_conflicts.insert(index as usize, None);
                         self.underlying.insert(
                             index as usize,
                             (value.default_opid(), UpdatingSequenceElement::New(value)),

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -23,7 +23,7 @@ pub(super) trait DiffableValue: Sized {
     where
         K: Into<amp::Key>;
     fn apply_diff_iter<'a, 'b, 'c, I, K: 'c>(
-        &'a self,
+        &'a mut self,
         diff: &mut I,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<Self, InvalidPatch>
@@ -63,7 +63,7 @@ impl DiffableValue for MultiGrapheme {
     }
 
     fn apply_diff_iter<'a, 'b, 'c, 'd, I, K: 'c>(
-        &'a self,
+        &'a mut self,
         diff: &mut I,
         _current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<Self, InvalidPatch>
@@ -113,7 +113,7 @@ impl DiffableValue for MultiValue {
     }
 
     fn apply_diff_iter<'a, 'b, 'c, I, K: 'c>(
-        &'a self,
+        &'a mut self,
         diff: &mut I,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<Self, InvalidPatch>
@@ -121,7 +121,8 @@ impl DiffableValue for MultiValue {
         K: Into<amp::Key>,
         I: Iterator<Item = (&'b amp::OpId, DiffToApply<'c, K, amp::Diff>)>,
     {
-        self.apply_diff_iter(
+        Self::apply_diff_iter(
+            self,
             &mut diff.map(|(o, d)| (Cow::Borrowed(o), d)),
             current_objects,
         )

--- a/automerge-frontend/src/state_tree/focus.rs
+++ b/automerge-frontend/src/state_tree/focus.rs
@@ -150,10 +150,8 @@ struct ListFocus {
 impl ListFocus {
     fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
         let new_diffapp = diffapp.and_then(|v| {
-            let updated = StateTreeComposite::List(StateTreeList {
-                object_id: self.list.object_id.clone(),
-                elements: self.list.elements.update(self.index, v),
-            });
+            self.list.elements.update(self.index, v);
+            let updated = StateTreeComposite::List(self.list.clone());
             DiffApplicationResult::pure(
                 self.multivalue
                     .update_default(StateTreeValue::Link(updated.object_id())),

--- a/automerge-frontend/src/state_tree/focus.rs
+++ b/automerge-frontend/src/state_tree/focus.rs
@@ -7,9 +7,9 @@ use super::{
 pub(crate) struct Focus(FocusInner);
 
 impl Focus {
-    pub(super) fn update(&self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
-        match &self.0 {
-            FocusInner::Root(root) => root.update(diffapp),
+    pub(super) fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
+        match &mut self.0 {
+            FocusInner::Root(root) => root.update(diffapp).clone(),
             FocusInner::Map(mapfocus) => mapfocus.update(diffapp),
             FocusInner::Table(tablefocus) => tablefocus.update(diffapp),
             FocusInner::List(listfocus) => listfocus.update(diffapp),
@@ -81,7 +81,7 @@ struct RootFocus {
 }
 
 impl RootFocus {
-    fn update(&self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
+    fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> &mut StateTree {
         self.root.update(self.key.clone(), diffapp)
     }
 }
@@ -95,7 +95,7 @@ struct MapFocus {
 }
 
 impl MapFocus {
-    fn update(&self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
+    fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
         let new_diffapp = diffapp.and_then(|v| {
             let updated = StateTreeComposite::Map(StateTreeMap {
                 object_id: self.map.object_id.clone(),
@@ -120,7 +120,7 @@ struct TableFocus {
 }
 
 impl TableFocus {
-    fn update(&self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
+    fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
         let new_diffapp = diffapp.and_then(|v| {
             let updated = StateTreeComposite::Table(StateTreeTable {
                 object_id: self.table.object_id.clone(),
@@ -148,7 +148,7 @@ struct ListFocus {
 }
 
 impl ListFocus {
-    fn update(&self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
+    fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
         let new_diffapp = diffapp.and_then(|v| {
             let updated = StateTreeComposite::List(StateTreeList {
                 object_id: self.list.object_id.clone(),

--- a/automerge-frontend/src/state_tree/focus.rs
+++ b/automerge-frontend/src/state_tree/focus.rs
@@ -9,7 +9,10 @@ pub(crate) struct Focus(FocusInner);
 impl Focus {
     pub(super) fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> StateTree {
         match &mut self.0 {
-            FocusInner::Root(root) => root.update(diffapp).clone(),
+            FocusInner::Root(root) => {
+                root.update(diffapp);
+                root.root.clone()
+            }
             FocusInner::Map(mapfocus) => mapfocus.update(diffapp),
             FocusInner::Table(tablefocus) => tablefocus.update(diffapp),
             FocusInner::List(listfocus) => listfocus.update(diffapp),
@@ -81,7 +84,7 @@ struct RootFocus {
 }
 
 impl RootFocus {
-    fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) -> &mut StateTree {
+    fn update(&mut self, diffapp: DiffApplicationResult<MultiValue>) {
         self.root.update(self.key.clone(), diffapp)
     }
 }
@@ -107,7 +110,8 @@ impl MapFocus {
             )
             .with_changes(StateTreeChange::single(self.map.object_id.clone(), updated))
         });
-        self.state_tree.apply(new_diffapp.change)
+        self.state_tree.apply(new_diffapp.change);
+        self.state_tree.clone()
     }
 }
 
@@ -135,7 +139,8 @@ impl TableFocus {
                 updated,
             ))
         });
-        self.state_tree.apply(new_diffapp.change)
+        self.state_tree.apply(new_diffapp.change);
+        self.state_tree.clone()
     }
 }
 
@@ -161,6 +166,7 @@ impl ListFocus {
                 updated,
             ))
         });
-        self.state_tree.apply(new_diffapp.change)
+        self.state_tree.apply(new_diffapp.change);
+        self.state_tree.clone()
     }
 }

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -41,6 +41,15 @@ pub(crate) struct StateTree {
     cursors: Cursors,
 }
 
+impl Default for StateTree {
+    fn default() -> Self {
+        Self {
+            objects: im_rc::HashMap::new(),
+            cursors: Cursors::new(),
+        }
+    }
+}
+
 impl StateTree {
     pub fn new() -> StateTree {
         StateTree {

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -619,7 +619,7 @@ impl StateTreeMap {
                     self.props.remove(&prop);
                 }
                 Some((opid, diff)) => {
-                    let node = match self.props.get(&prop) {
+                    let node = match self.props.get_mut(&prop) {
                         Some(n) => {
                             let diff_result = n.apply_diff(
                                 &opid,
@@ -742,7 +742,7 @@ impl StateTreeTable {
             match diff_iter.next() {
                 None => new_props = new_props.without(&prop),
                 Some((opid, diff)) => {
-                    let mut node_diffapp = match new_props.get(&prop) {
+                    let mut node_diffapp = match new_props.get_mut(&prop) {
                         Some(n) => n.apply_diff(
                             &opid,
                             DiffToApply {

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -109,7 +109,7 @@ impl StateTree {
         }
     }
 
-    fn update(&mut self, k: String, diffapp: DiffApplicationResult<MultiValue>) -> &mut StateTree {
+    fn update(&mut self, k: String, diffapp: DiffApplicationResult<MultiValue>) {
         for (k, v) in diffapp.change.objects() {
             self.objects.insert(k, v);
         }
@@ -121,7 +121,6 @@ impl StateTree {
             _ => panic!("Root map did not exist or was wrong type"),
         };
         self.update_cursors();
-        self
     }
 
     fn update_cursors(&mut self) {
@@ -166,13 +165,14 @@ impl StateTree {
         }
     }
 
-    fn apply(&mut self, change: StateTreeChange) -> StateTree {
+    fn apply(&mut self, change: StateTreeChange) {
         let mut cursors = change.new_cursors();
         cursors.union(self.cursors.clone());
-        let objects = change.objects().union(self.objects.clone());
-        let mut new_tree = StateTree { objects, cursors };
-        new_tree.update_cursors();
-        new_tree
+        self.cursors = cursors;
+        for (k, v) in change.objects() {
+            self.objects.insert(k, v);
+        }
+        self.update_cursors();
     }
 
     pub(crate) fn resolve_path(&self, path: &Path) -> Option<resolved_path::ResolvedPath> {

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -889,16 +889,13 @@ impl StateTreeText {
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<(), error::InvalidPatch> {
-        let new_graphemes = self
-            .graphemes
+        self.graphemes
             .apply_diff(&self.object_id, edits, current_objects)?;
 
-        let new_list = StateTreeText {
-            object_id: self.object_id.clone(),
-            graphemes: new_graphemes,
-        };
-
-        current_objects.insert(self.object_id.clone(), StateTreeComposite::Text(new_list));
+        current_objects.insert(
+            self.object_id.clone(),
+            StateTreeComposite::Text(self.clone()),
+        );
 
         Ok(())
     }
@@ -991,16 +988,13 @@ impl StateTreeList {
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<(), error::InvalidPatch> {
-        let new_elements = self
-            .elements
+        self.elements
             .apply_diff(&self.object_id, edits, current_objects)?;
 
-        let new_list = StateTreeList {
-            object_id: self.object_id.clone(),
-            elements: new_elements,
-        };
-
-        current_objects.insert(self.object_id.clone(), StateTreeComposite::List(new_list));
+        current_objects.insert(
+            self.object_id.clone(),
+            StateTreeComposite::List(self.clone()),
+        );
 
         Ok(())
     }

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -847,7 +847,7 @@ impl StateTreeText {
     ) -> Result<(&amp::OpId, String), error::MissingIndexError> {
         self.graphemes
             .get(index)
-            .map(|mc| (&mc.0, mc.1.default_grapheme()))
+            .map(|mc| (mc.0, mc.1.default_grapheme()))
             .ok_or_else(|| error::MissingIndexError {
                 missing_index: index,
                 size_of_collection: self.graphemes.len(),
@@ -1026,7 +1026,7 @@ impl StateTreeList {
     pub(crate) fn elem_at(
         &self,
         index: usize,
-    ) -> Result<&(amp::OpId, MultiValue), error::MissingIndexError> {
+    ) -> Result<(&amp::OpId, MultiValue), error::MissingIndexError> {
         self.elements
             .get(index)
             .ok_or_else(|| error::MissingIndexError {

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -150,9 +150,6 @@ impl StateTree {
         match self.objects.get_mut(&amp::ObjectId::Root) {
             Some(StateTreeComposite::Map(root_map)) => {
                 root_map.remove(k);
-                let root = root_map.clone();
-                self.objects
-                    .insert(amp::ObjectId::Root, StateTreeComposite::Map(root));
             }
             _ => panic!("Root map did not exist or was wrong type"),
         }

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -542,7 +542,7 @@ impl StateTreeValue {
                 ..
             }) => {
                 let object_id = object_id.clone();
-                match obj_type {
+                let mut value = match obj_type {
                     amp::MapType::Map => StateTreeComposite::Map(StateTreeMap {
                         object_id: object_id.clone(),
                         props: im_rc::HashMap::new(),
@@ -551,8 +551,9 @@ impl StateTreeValue {
                         object_id: object_id.clone(),
                         props: im_rc::HashMap::new(),
                     }),
-                }
-                .apply_diff(diff, current_objects)?;
+                };
+                value.apply_diff(diff, current_objects)?;
+                current_objects.insert(object_id.clone(), value);
                 StateTreeValue::Link(object_id)
             }
             amp::Diff::Seq(amp::SeqDiff {
@@ -561,7 +562,7 @@ impl StateTreeValue {
                 ..
             }) => {
                 let object_id = object_id.clone();
-                match obj_type {
+                let mut value = match obj_type {
                     amp::SequenceType::Text => StateTreeComposite::Text(StateTreeText {
                         object_id: object_id.clone(),
                         graphemes: DiffableSequence::new(),
@@ -570,9 +571,9 @@ impl StateTreeValue {
                         object_id: object_id.clone(),
                         elements: DiffableSequence::new(),
                     }),
-                }
-                .apply_diff(diff, current_objects)?;
-
+                };
+                value.apply_diff(diff, current_objects)?;
+                current_objects.insert(object_id.clone(), value);
                 StateTreeValue::Link(object_id)
             }
             amp::Diff::Cursor(ref c) => StateTreeValue::Leaf(c.into()),

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -837,15 +837,14 @@ impl StateTreeText {
     }
 
     fn set(
-        &self,
+        &mut self,
         index: usize,
         value: MultiGrapheme,
     ) -> Result<StateTreeText, error::MissingIndexError> {
         if self.graphemes.len() > index {
-            Ok(StateTreeText {
-                object_id: self.object_id.clone(),
-                graphemes: self.graphemes.update(index, value),
-            })
+            self.graphemes.update(index, value);
+
+            Ok(self.clone())
         } else {
             Err(error::MissingIndexError {
                 missing_index: index,
@@ -901,7 +900,7 @@ impl StateTreeText {
     }
 
     fn apply_diff(
-        &self,
+        &mut self,
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<DiffApplicationResult<StateTreeText>, error::InvalidPatch> {
@@ -956,15 +955,13 @@ impl StateTreeList {
     }
 
     fn set(
-        &self,
+        &mut self,
         index: usize,
         value: MultiValue,
     ) -> Result<StateTreeList, error::MissingIndexError> {
         if self.elements.len() > index {
-            Ok(StateTreeList {
-                object_id: self.object_id.clone(),
-                elements: self.elements.update(index, value),
-            })
+            self.elements.update(index, value);
+            Ok(self.clone())
         } else {
             Err(error::MissingIndexError {
                 missing_index: index,
@@ -974,7 +971,7 @@ impl StateTreeList {
     }
 
     fn insert(
-        &self,
+        &mut self,
         index: usize,
         value: MultiValue,
     ) -> Result<StateTreeList, error::MissingIndexError> {
@@ -982,14 +979,13 @@ impl StateTreeList {
     }
 
     fn insert_many<I>(
-        &self,
+        &mut self,
         index: usize,
         values: I,
     ) -> Result<StateTreeList, error::MissingIndexError>
     where
         I: IntoIterator<Item = MultiValue>,
     {
-        let mut new_elems = self.elements.clone();
         if index > self.elements.len() {
             Err(error::MissingIndexError {
                 missing_index: index,
@@ -997,17 +993,17 @@ impl StateTreeList {
             })
         } else {
             for (i, value) in values.into_iter().enumerate() {
-                new_elems.insert(index + i, value);
+                self.elements.insert(index + i, value);
             }
             Ok(StateTreeList {
                 object_id: self.object_id.clone(),
-                elements: new_elems,
+                elements: self.elements.clone(),
             })
         }
     }
 
     fn apply_diff(
-        &self,
+        &mut self,
         edits: Vec<amp::DiffEdit>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     ) -> Result<DiffApplicationResult<StateTreeList>, error::InvalidPatch> {

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -616,7 +616,7 @@ impl StateTreeMap {
                     self.props.remove(&prop);
                 }
                 Some((opid, diff)) => {
-                    let node = match self.props.get_mut(&prop) {
+                    match self.props.get_mut(&prop) {
                         Some(n) => {
                             let diff_result = n.apply_diff(
                                 &opid,
@@ -632,8 +632,7 @@ impl StateTreeMap {
                                 current_objects.insert(id, composite);
                             }
 
-                            self.props.insert(prop.clone(), diff_result.value.clone());
-                            diff_result.value
+                            self.props.insert(prop.clone(), diff_result.value);
                         }
                         None => {
                             let diff_result = MultiValue::new_from_diff(
@@ -650,11 +649,10 @@ impl StateTreeMap {
                                 current_objects.insert(id, composite);
                             }
 
-                            self.props.insert(prop.clone(), diff_result.value.clone());
-                            diff_result.value
+                            self.props.insert(prop.clone(), diff_result.value);
                         }
                     };
-                    let other_changes = node.apply_diff_iter(
+                    let other_changes = self.props.get(&prop).unwrap().apply_diff_iter(
                         &mut diff_iter.map(|(oid, diff)| {
                             (
                                 Cow::Owned(oid),

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -329,7 +329,7 @@ impl MultiGrapheme {
     }
 
     pub(super) fn apply_diff<K>(
-        &self,
+        &mut self,
         opid: &amp::OpId,
         diff: DiffToApply<K, amp::Diff>,
     ) -> Result<MultiGrapheme, error::InvalidPatch>
@@ -340,7 +340,7 @@ impl MultiGrapheme {
     }
 
     pub(super) fn apply_diff_iter<'a, 'b, 'c, 'd, I, K: 'c>(
-        &'a self,
+        &'a mut self,
         diff: &mut I,
     ) -> Result<MultiGrapheme, error::InvalidPatch>
     where

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -86,7 +86,7 @@ impl MultiValue {
     }
 
     pub(super) fn apply_diff<K>(
-        &self,
+        &mut self,
         opid: &amp::OpId,
         subdiff: DiffToApply<K, amp::Diff>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::Ordering, iter::Iterator};
+use std::{borrow::Cow, cmp::Ordering, collections::HashMap, iter::Iterator};
 
 use automerge_protocol as amp;
 use unicode_segmentation::UnicodeSegmentation;
@@ -26,7 +26,7 @@ pub(crate) struct NewValueRequest<'a, 'b, 'c, 'd> {
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct MultiValue {
     winning_value: (amp::OpId, StateTreeValue),
-    conflicts: im_rc::HashMap<amp::OpId, StateTreeValue>,
+    conflicts: HashMap<amp::OpId, StateTreeValue>,
 }
 
 impl MultiValue {
@@ -41,7 +41,7 @@ impl MultiValue {
         Ok(
             StateTreeValue::new_from_diff(diff, current_objects)?.map(move |value| MultiValue {
                 winning_value: (opid, value),
-                conflicts: im_rc::HashMap::new(),
+                conflicts: HashMap::new(),
             }),
         )
     }
@@ -49,7 +49,7 @@ impl MultiValue {
     pub fn from_statetree_value(statetree_val: StateTreeValue, opid: amp::OpId) -> MultiValue {
         MultiValue {
             winning_value: (opid, statetree_val),
-            conflicts: im_rc::HashMap::new(),
+            conflicts: HashMap::new(),
         }
     }
 
@@ -187,12 +187,12 @@ impl MultiValue {
         if *opid == self.winning_value.0 {
             Some(MultiValue {
                 winning_value: self.winning_value.clone(),
-                conflicts: im_rc::HashMap::new(),
+                conflicts: HashMap::new(),
             })
         } else {
             self.conflicts.get(opid).map(|value| MultiValue {
                 winning_value: (opid.clone(), value.clone()),
-                conflicts: im_rc::HashMap::new(),
+                conflicts: HashMap::new(),
             })
         }
     }

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -89,7 +89,7 @@ impl MultiValue {
         opid: &amp::OpId,
         subdiff: DiffToApply<K, amp::Diff>,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
-    ) -> Result<DiffApplicationResult<MultiValue>, error::InvalidPatch>
+    ) -> Result<MultiValue, error::InvalidPatch>
     where
         K: Into<amp::Key>,
     {
@@ -103,7 +103,7 @@ impl MultiValue {
         &'a self,
         diff: &mut I,
         current_objects: &mut im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
-    ) -> Result<DiffApplicationResult<MultiValue>, error::InvalidPatch>
+    ) -> Result<MultiValue, error::InvalidPatch>
     where
         K: Into<amp::Key>,
         I: Iterator<Item = (Cow<'b, amp::OpId>, DiffToApply<'c, K, amp::Diff>)>,
@@ -129,7 +129,7 @@ impl MultiValue {
             }?;
             updated = updated.update(&opid, &value)
         }
-        Ok(DiffApplicationResult::pure(updated.result()))
+        Ok(updated.result())
     }
 
     pub(super) fn default_statetree_value(&self) -> StateTreeValue {
@@ -337,13 +337,12 @@ impl MultiGrapheme {
         K: Into<amp::Key>,
     {
         self.apply_diff_iter(&mut std::iter::once((opid, diff)))
-            .map(|d| d.value)
     }
 
     pub(super) fn apply_diff_iter<'a, 'b, 'c, 'd, I, K: 'c>(
         &'a self,
         diff: &mut I,
-    ) -> Result<DiffApplicationResult<MultiGrapheme>, error::InvalidPatch>
+    ) -> Result<MultiGrapheme, error::InvalidPatch>
     where
         K: Into<amp::Key>,
         I: Iterator<Item = (&'b amp::OpId, DiffToApply<'c, K, amp::Diff>)>,
@@ -369,7 +368,7 @@ impl MultiGrapheme {
                 }
             }
         }
-        Ok(DiffApplicationResult::pure(updated.result()))
+        Ok(updated.result())
     }
 
     pub(super) fn default_grapheme(&self) -> String {

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -38,12 +38,12 @@ impl MultiValue {
     where
         K: Into<amp::Key>,
     {
-        StateTreeValue::new_from_diff(diff, current_objects)?.try_map(move |value| {
-            Ok(MultiValue {
+        Ok(
+            StateTreeValue::new_from_diff(diff, current_objects)?.map(move |value| MultiValue {
                 winning_value: (opid, value),
                 conflicts: im_rc::HashMap::new(),
-            })
-        })
+            }),
+        )
     }
 
     pub fn from_statetree_value(statetree_val: StateTreeValue, opid: amp::OpId) -> MultiValue {

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -117,12 +117,16 @@ impl MultiValue {
                     StateTreeValue::Leaf(_) => {
                         StateTreeValue::new_from_diff(subdiff, current_objects)
                     }
-                    StateTreeValue::Link(obj_id) => current_objects
-                        .get(obj_id)
-                        .cloned()
-                        .expect("link to nonexistent object")
-                        .apply_diff(subdiff, current_objects)
-                        .map(|c| c.map(|c| StateTreeValue::Link(c.object_id()))),
+                    StateTreeValue::Link(obj_id) => {
+                        current_objects
+                            .get(obj_id)
+                            .cloned()
+                            .expect("link to nonexistent object")
+                            .apply_diff(subdiff, current_objects)?;
+                        Ok(DiffApplicationResult::pure(StateTreeValue::Link(
+                            obj_id.clone(),
+                        )))
+                    }
                 }
             } else {
                 StateTreeValue::new_from_diff(subdiff, current_objects)

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -547,9 +547,10 @@ where
                 pred: Vec::new(),
                 insert: false,
             };
-            let next_value = context.create(value);
+            let mut next_value = context.create(value);
             current_max_op = next_value.max_op;
-            cursors = next_value.new_cursors.clone().union(cursors);
+            next_value.new_cursors.union(cursors);
+            cursors = next_value.new_cursors;
             for (k, v) in next_value.new_objects {
                 objects.insert(k, v);
             }
@@ -607,11 +608,12 @@ where
                 parent_obj: make_list_opid.clone(),
             };
             last_elemid = elem_opid.clone().into();
-            let next_value = context.create(value);
+            let mut next_value = context.create(value);
             current_max_op = next_value.max_op;
             result_elems.push(next_value.multivalue());
             objects = next_value.new_objects.union(objects.clone());
-            cursors = next_value.new_cursors.union(cursors);
+            next_value.new_cursors.union(cursors);
+            cursors = next_value.new_cursors;
             ops.extend(next_value.ops);
         }
         let list = StateTreeComposite::List(StateTreeList {

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -116,11 +116,11 @@ impl MultiValue {
                         StateTreeValue::new_from_diff(subdiff, current_objects)
                     }
                     StateTreeValue::Link(obj_id) => {
-                        current_objects
-                            .get(obj_id)
-                            .expect("link to nonexistent object")
-                            .clone()
-                            .apply_diff(subdiff, current_objects)?;
+                        let mut value = current_objects
+                            .remove(obj_id)
+                            .expect("link to nonexistent object");
+                        value.apply_diff(subdiff, current_objects)?;
+                        current_objects.insert(obj_id.clone(), value);
                         Ok(StateTreeValue::Link(obj_id.clone()))
                     }
                 }

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, cmp::Ordering, collections::HashMap, iter::Iterator};
 
+use amp::Key;
 use automerge_protocol as amp;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -12,11 +13,11 @@ use crate::{
     value::{Primitive, Value},
 };
 
-pub(crate) struct NewValueRequest<'a, 'b, 'c, 'd> {
+pub(crate) struct NewValueRequest<'a, 'b, 'd> {
     pub(crate) actor: &'a amp::ActorId,
     pub(crate) start_op: u64,
     pub(crate) key: &'b amp::Key,
-    pub(crate) value: &'c Value,
+    pub(crate) value: Value,
     pub(crate) parent_obj: &'d amp::ObjectId,
     pub(crate) insert: bool,
     pub(crate) pred: Vec<amp::OpId>,
@@ -69,7 +70,7 @@ impl MultiValue {
         start_op: u64,
         parent_id: amp::ObjectId,
         key: &amp::Key,
-        value: &Value,
+        value: Value,
         insert: bool,
         pred: Vec<amp::OpId>,
     ) -> NewValue {
@@ -487,7 +488,7 @@ where
     O: Into<amp::ObjectId>,
     O: Clone,
 {
-    fn create(self, value: &Value) -> NewValue {
+    fn create(self, value: Value) -> NewValue {
         match value {
             Value::Map(props, map_type) => self.new_map_or_table(props, map_type),
             Value::Sequence(values) => self.new_list(values),
@@ -498,12 +499,12 @@ where
 
     fn new_map_or_table(
         self,
-        props: &std::collections::HashMap<String, Value>,
-        map_type: &amp::MapType,
+        props: std::collections::HashMap<String, Value>,
+        map_type: amp::MapType,
     ) -> NewValue {
         let make_op_id = amp::OpId(self.start_op, self.actor.clone());
         let make_op = amp::Op {
-            action: amp::OpType::Make(amp::ObjType::Map(*map_type)),
+            action: amp::OpType::Make(amp::ObjType::Map(map_type)),
             obj: self.parent_obj.clone().into(),
             key: self.key.clone(),
             insert: self.insert,
@@ -514,12 +515,12 @@ where
         let mut cursors = Cursors::new();
         let mut objects: im_rc::HashMap<amp::ObjectId, StateTreeComposite> = im_rc::HashMap::new();
         let mut result_props: im_rc::HashMap<String, MultiValue> = im_rc::HashMap::new();
-        for (prop, value) in props.iter() {
+        for (prop, value) in props.into_iter() {
             let context = NewValueContext {
                 actor: self.actor,
                 parent_obj: &make_op_id,
                 start_op: current_max_op + 1,
-                key: &prop.into(),
+                key: &Key::Map(prop.clone()),
                 pred: Vec::new(),
                 insert: false,
             };
@@ -558,7 +559,7 @@ where
         }
     }
 
-    fn new_list(self, values: &[Value]) -> NewValue {
+    fn new_list(self, values: Vec<Value>) -> NewValue {
         let make_list_opid = amp::OpId::new(self.start_op, self.actor);
         let make_op = amp::Op {
             action: amp::OpType::Make(amp::ObjType::list()),
@@ -573,7 +574,7 @@ where
         let mut objects = im_rc::HashMap::new();
         let mut result_elems: Vec<MultiValue> = Vec::with_capacity(values.len());
         let mut last_elemid = amp::ElementId::Head;
-        for value in values.iter() {
+        for value in values.into_iter() {
             let elem_opid = self.actor.op_id_at(current_max_op + 1);
             let context = NewValueContext {
                 start_op: current_max_op + 1,
@@ -608,7 +609,7 @@ where
         }
     }
 
-    fn new_text(self, graphemes: &[String]) -> NewValue {
+    fn new_text(self, graphemes: Vec<String>) -> NewValue {
         let make_text_opid = self.actor.op_id_at(self.start_op);
         let mut ops: Vec<amp::Op> = vec![amp::Op {
             action: amp::OpType::Make(amp::ObjType::text()),
@@ -653,9 +654,9 @@ where
         }
     }
 
-    fn new_primitive(self, primitive: &Primitive) -> NewValue {
+    fn new_primitive(self, primitive: Primitive) -> NewValue {
         let new_cursors = match primitive {
-            Primitive::Cursor(c) => Cursors::new_from(CursorState {
+            Primitive::Cursor(ref c) => Cursors::new_from(CursorState {
                 index: c.index as usize,
                 referring_object_id: self.parent_obj.clone().into(),
                 referring_key: self.key.clone(),
@@ -665,20 +666,20 @@ where
             _ => Cursors::new(),
         };
         let value = match primitive {
-            Primitive::Str(s) => amp::ScalarValue::Str(s.clone()),
-            Primitive::Int(i) => amp::ScalarValue::Int(*i),
-            Primitive::Uint(u) => amp::ScalarValue::Uint(*u),
-            Primitive::F64(f) => amp::ScalarValue::F64(*f),
-            Primitive::F32(f) => amp::ScalarValue::F32(*f),
-            Primitive::Counter(i) => amp::ScalarValue::Counter(*i),
-            Primitive::Timestamp(t) => amp::ScalarValue::Timestamp(*t),
-            Primitive::Boolean(b) => amp::ScalarValue::Boolean(*b),
-            Primitive::Cursor(c) => amp::ScalarValue::Cursor(c.elem_opid.clone()),
+            Primitive::Str(ref s) => amp::ScalarValue::Str(s.clone()),
+            Primitive::Int(i) => amp::ScalarValue::Int(i),
+            Primitive::Uint(u) => amp::ScalarValue::Uint(u),
+            Primitive::F64(f) => amp::ScalarValue::F64(f),
+            Primitive::F32(f) => amp::ScalarValue::F32(f),
+            Primitive::Counter(i) => amp::ScalarValue::Counter(i),
+            Primitive::Timestamp(t) => amp::ScalarValue::Timestamp(t),
+            Primitive::Boolean(b) => amp::ScalarValue::Boolean(b),
+            Primitive::Cursor(ref c) => amp::ScalarValue::Cursor(c.elem_opid.clone()),
             Primitive::Null => amp::ScalarValue::Null,
         };
         let opid = self.actor.op_id_at(self.start_op);
         NewValue {
-            value: StateTreeValue::Leaf(primitive.clone()),
+            value: StateTreeValue::Leaf(primitive),
             opid,
             ops: vec![amp::Op {
                 action: amp::OpType::Set(value),

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -118,8 +118,8 @@ impl MultiValue {
                     StateTreeValue::Link(obj_id) => {
                         current_objects
                             .get(obj_id)
-                            .cloned()
                             .expect("link to nonexistent object")
+                            .clone()
                             .apply_diff(subdiff, current_objects)?;
                         Ok(StateTreeValue::Link(obj_id.clone()))
                     }

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -235,7 +235,7 @@ impl ResolvedRoot {
             .update(key.to_string(), newvalue.diff_app_result())
             .clone();
         LocalOperationResult {
-            new_state,
+            new_state: self.root.clone(),
             new_ops: newvalue.ops(),
         }
     }

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -230,10 +230,8 @@ impl ResolvedRoot {
                 .map(|mv| vec![mv.default_opid()])
                 .unwrap_or_else(Vec::new),
         });
-        let new_state = self
-            .root
-            .update(key.to_string(), newvalue.diff_app_result())
-            .clone();
+        self.root
+            .update(key.to_string(), newvalue.diff_app_result());
         LocalOperationResult {
             new_state: self.root.clone(),
             new_ops: newvalue.ops(),

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -499,7 +499,7 @@ impl ResolvedText {
         payload: SetOrInsertPayload<String>,
     ) -> Result<LocalOperationResult, error::MissingIndexError> {
         let index: usize = index.try_into().unwrap();
-        let (current_elemid, _) = self.value.elem_at(index)?;
+        let current_elemid = self.value.elem_at(index)?.0.clone();
         let update_op = amp::OpId::new(payload.start_op, payload.actor);
         let c = MultiGrapheme::new_from_grapheme_cluster(update_op, payload.value.clone());
         let updated = StateTreeComposite::Text(self.value.set(index, c)?);

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -215,7 +215,7 @@ impl ResolvedRoot {
     pub(crate) fn set_key(
         &mut self,
         key: &str,
-        payload: SetOrInsertPayload<&Value>,
+        payload: SetOrInsertPayload<Value>,
     ) -> LocalOperationResult {
         let newvalue = MultiValue::new_from_value_2(NewValueRequest {
             actor: payload.actor,
@@ -294,7 +294,7 @@ impl ResolvedMap {
     pub(crate) fn set_key(
         &mut self,
         key: &str,
-        payload: SetOrInsertPayload<&Value>,
+        payload: SetOrInsertPayload<Value>,
     ) -> LocalOperationResult {
         let newvalue = MultiValue::new_from_value_2(NewValueRequest {
             actor: payload.actor,
@@ -355,7 +355,7 @@ impl ResolvedTable {
     pub(crate) fn set_key(
         &mut self,
         key: &str,
-        payload: SetOrInsertPayload<&Value>,
+        payload: SetOrInsertPayload<Value>,
     ) -> LocalOperationResult {
         let newvalue = MultiValue::new_from_value_2(NewValueRequest {
             actor: payload.actor,
@@ -567,7 +567,7 @@ impl ResolvedList {
     pub(crate) fn set(
         &mut self,
         index: u32,
-        payload: SetOrInsertPayload<&Value>,
+        payload: SetOrInsertPayload<Value>,
     ) -> Result<LocalOperationResult, error::MissingIndexError> {
         let (current_elemid, _) = self.value.elem_at(index.try_into().unwrap())?;
         let newvalue = MultiValue::new_from_value_2(NewValueRequest {
@@ -602,7 +602,7 @@ impl ResolvedList {
     pub(crate) fn insert(
         &mut self,
         index: u32,
-        payload: SetOrInsertPayload<&Value>,
+        payload: SetOrInsertPayload<Value>,
     ) -> Result<LocalOperationResult, error::MissingIndexError> {
         let current_elemid = match index {
             0 => amp::ElementId::Head,
@@ -641,13 +641,13 @@ impl ResolvedList {
         })
     }
 
-    pub(crate) fn insert_many<'a, 'b, I>(
-        &'a mut self,
+    pub(crate) fn insert_many<I>(
+        &mut self,
         index: u32,
         payload: SetOrInsertPayload<I>,
     ) -> Result<LocalOperationResult, error::MissingIndexError>
     where
-        I: ExactSizeIterator<Item = &'b Value>,
+        I: ExactSizeIterator<Item = Value>,
     {
         let mut last_elemid = match index {
             0 => amp::ElementId::Head,
@@ -665,7 +665,7 @@ impl ResolvedList {
             let newvalue = MultiValue::new_from_value_2(NewValueRequest {
                 actor: payload.actor,
                 start_op: op_num,
-                value: &value,
+                value,
                 parent_obj: &self.value.object_id,
                 key: &last_elemid.clone().into(),
                 insert: true,

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -47,7 +47,9 @@ impl StateTreeChange {
 
     /// Include changes from `other` in this change
     pub(super) fn update_with(&mut self, other: StateTreeChange) {
-        self.objects = other.objects.union(self.objects.clone());
+        for (k, v) in other.objects {
+            self.objects.insert(k, v);
+        }
         self.new_cursors = other.new_cursors.union(self.new_cursors.clone());
     }
 

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -59,3 +59,24 @@ impl StateTreeChange {
         }
     }
 }
+
+impl Add for StateTreeChange {
+    type Output = StateTreeChange;
+
+    fn add(mut self, rhs: StateTreeChange) -> Self::Output {
+        for (k, v) in rhs.objects {
+            self.objects.insert(k, v);
+        }
+        self.new_cursors = self.new_cursors.union(rhs.new_cursors);
+        self
+    }
+}
+
+impl AddAssign for StateTreeChange {
+    fn add_assign(&mut self, rhs: StateTreeChange) {
+        for (k, v) in rhs.objects {
+            self.objects.insert(k, v);
+        }
+        self.new_cursors = self.new_cursors.clone().union(rhs.new_cursors);
+    }
+}

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -32,8 +32,9 @@ impl StateTreeChange {
         }
     }
 
-    pub(super) fn with_cursors(mut self, cursors: Cursors) -> StateTreeChange {
-        self.new_cursors = cursors.union(self.new_cursors);
+    pub(super) fn with_cursors(mut self, mut cursors: Cursors) -> StateTreeChange {
+        cursors.union(self.new_cursors);
+        self.new_cursors = cursors;
         self
     }
 
@@ -50,7 +51,9 @@ impl StateTreeChange {
         for (k, v) in other.objects {
             self.objects.insert(k, v);
         }
-        self.new_cursors = self.new_cursors.clone().union(other.new_cursors);
+        let mut cursors = self.new_cursors.clone();
+        cursors.union(other.new_cursors);
+        self.new_cursors = cursors;
         self
     }
 }

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -59,24 +59,3 @@ impl StateTreeChange {
         }
     }
 }
-
-impl Add for StateTreeChange {
-    type Output = StateTreeChange;
-
-    fn add(mut self, rhs: StateTreeChange) -> Self::Output {
-        for (k, v) in rhs.objects {
-            self.objects.insert(k, v);
-        }
-        self.new_cursors = self.new_cursors.union(rhs.new_cursors);
-        self
-    }
-}
-
-impl AddAssign for StateTreeChange {
-    fn add_assign(&mut self, rhs: StateTreeChange) {
-        for (k, v) in rhs.objects {
-            self.objects.insert(k, v);
-        }
-        self.new_cursors = self.new_cursors.clone().union(rhs.new_cursors);
-    }
-}

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -54,10 +54,11 @@ impl StateTreeChange {
     }
 
     /// Combine with `other`, entries in the current change take precedence
-    pub(super) fn union(&self, other: StateTreeChange) -> StateTreeChange {
-        StateTreeChange {
-            objects: self.objects.clone().union(other.objects.clone()),
-            new_cursors: self.new_cursors.clone().union(other.new_cursors),
+    pub(super) fn union(&mut self, other: StateTreeChange) -> &mut StateTreeChange {
+        for (k, v) in other.objects {
+            self.objects.insert(k, v);
         }
+        self.new_cursors = self.new_cursors.clone().union(other.new_cursors);
+        self
     }
 }

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -45,14 +45,6 @@ impl StateTreeChange {
         self.new_cursors.clone()
     }
 
-    /// Include changes from `other` in this change
-    pub(super) fn update_with(&mut self, other: StateTreeChange) {
-        for (k, v) in other.objects {
-            self.objects.insert(k, v);
-        }
-        self.new_cursors = other.new_cursors.union(self.new_cursors.clone());
-    }
-
     /// Combine with `other`, entries in the current change take precedence
     pub(super) fn union(&mut self, other: StateTreeChange) -> &mut StateTreeChange {
         for (k, v) in other.objects {

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -32,7 +32,7 @@ env_logger = "*"
 tracing = "0.1.25"
 tracing-subscriber = {version = "0.2", features = ["chrono", "env-filter", "fmt"]}
 unicode-segmentation = "1.7.1"
-maplit = "^1.0.2"
+maplit = "1.0.2"
 
 [[bench]]
 name = "crdt_benchmarks"
@@ -44,4 +44,8 @@ harness = false
 
 [[bench]]
 name = "save_load"
+harness = false
+
+[[bench]]
+name = "frontend_patch"
 harness = false

--- a/automerge/benches/frontend_patch.rs
+++ b/automerge/benches/frontend_patch.rs
@@ -1,0 +1,157 @@
+use automerge::{Backend, Primitive};
+use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Value};
+use automerge_protocol::MapType;
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use maplit::hashmap;
+use rand::{thread_rng, Rng};
+use unicode_segmentation::UnicodeSegmentation;
+
+fn apply_small_patch(c: &mut Criterion) {
+    c.bench_function("Frontend::apply_patch, small patch", |b| {
+        b.iter_batched(
+            || {
+                let mut doc = Frontend::new();
+                let random_string: String = thread_rng()
+                    .sample_iter(&rand::distributions::Alphanumeric)
+                    .take(1000)
+                    .map(char::from)
+                    .collect();
+                let change = doc
+                    .change::<_, _, InvalidChangeRequest>(None, |d| {
+                        d.add_change(LocalChange::set(
+                            Path::root().key("text"),
+                            Value::Text(
+                                random_string
+                                    .graphemes(true)
+                                    .map(|s| s.to_owned())
+                                    .collect(),
+                            ),
+                        ))
+                    })
+                    .unwrap()
+                    .1
+                    .unwrap();
+                let mut backend = Backend::new();
+                let (patch, _) = backend.apply_local_change(change).unwrap();
+
+                (Frontend::new(), patch)
+            },
+            |(mut doc, patch)| {
+                #[allow(clippy::unit_arg)]
+                black_box(doc.apply_patch(patch).unwrap())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn apply_small_patch_many_changes(c: &mut Criterion) {
+    c.bench_function("Frontend::apply_patch, small patch, many changes", |b| {
+        b.iter_batched(
+            || {
+                let mut doc = Frontend::new();
+                let random_string: String = thread_rng()
+                    .sample_iter(&rand::distributions::Alphanumeric)
+                    .take(1000)
+                    .map(char::from)
+                    .collect();
+                let mut backend = Backend::new();
+                let change = doc
+                    .change(None, |d| {
+                        d.add_change(LocalChange::set(
+                            Path::root().key("text"),
+                            Value::Text(vec![]),
+                        ))
+                    })
+                    .unwrap()
+                    .1
+                    .unwrap();
+                let (patch, _) = backend.apply_local_change(change).unwrap();
+                doc.apply_patch(patch).unwrap();
+
+                for (i, c) in random_string.graphemes(true).enumerate() {
+                    let change = doc
+                        .change::<_, _, InvalidChangeRequest>(None, |d| {
+                            d.add_change(LocalChange::insert(
+                                Path::root().key("text").index(i as u32),
+                                Value::Primitive(Primitive::Str(c.to_owned())),
+                            ))
+                        })
+                        .unwrap()
+                        .1
+                        .unwrap();
+                    let (patch, _) = backend.apply_local_change(change).unwrap();
+                    doc.apply_patch(patch).unwrap();
+                }
+                let patch = backend.get_patch().unwrap();
+
+                (Frontend::new(), patch)
+            },
+            |(mut doc, patch)| {
+                #[allow(clippy::unit_arg)]
+                black_box(doc.apply_patch(patch).unwrap())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn apply_patch_nested_maps(c: &mut Criterion) {
+    c.bench_function("Frontend::apply_patch, nested maps", |b| {
+        b.iter_batched(
+            || {
+                let mut doc = Frontend::new();
+                let mut backend = Backend::new();
+
+                let m = hashmap! {
+                    "a".to_owned() =>
+                    Value::Map(hashmap!{
+                        "b".to_owned()=>
+                        Value::Map(
+                            hashmap! {
+                                "abc".to_owned() => Value::Primitive(Primitive::Str("hello world".to_owned()))
+                            },
+                            MapType::Map,
+                        ),
+                        "d".to_owned() => Value::Primitive(Primitive::Uint(20)),
+                    },MapType::Map)
+                };
+
+                for _ in 0..400 {
+                    let random_string: String = thread_rng()
+                        .sample_iter(&rand::distributions::Alphanumeric)
+                        .take(10)
+                        .map(char::from)
+                        .collect();
+                    let change = doc
+                        .change::<_,_, InvalidChangeRequest>(None, |d| {
+                            d.add_change(LocalChange::set(
+                                Path::root().key(random_string),
+                                Value::Map(m.clone(), MapType::Map),
+                            ))
+                        })
+                        .unwrap().1
+                        .unwrap();
+                    let (patch, _) = backend.apply_local_change(change).unwrap();
+                    doc.apply_patch(patch).unwrap();
+                }
+
+                let patch = backend.get_patch().unwrap();
+
+                (Frontend::new(), patch)
+            },
+            |(mut doc, patch)| {
+                #[allow(clippy::unit_arg)]
+                black_box(doc.apply_patch(patch).unwrap())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = apply_small_patch, apply_small_patch_many_changes, apply_patch_nested_maps
+}
+criterion_main!(benches);


### PR DESCRIPTION
I've been testing this with a patch built from 159 changes. The `apply_patch` operation was taking ~720ms to finish (which was getting rather noticeable) but with this PR it now takes just ~52ms.

I believe my changeset was rather object heavy (rather than just a text value) which may have been more of an issue for the logic. I have added some benchmarks for the `apply_patch` operation to cover some of these cases.

From `perf` I found that lots of time was spent doing `malloc` and `free`. Then DHAT helped give a picture of where lots of the allocations were coming from and it turned out to be lots of cloning. So I've been through and tried to reduce the clones by either passing by value (rather than ref) or re-using existing datastructures (in the case of `current_objects`).

I think there is still room for improvement but wanted to do it bit by bit so it should be easier to check correctness.

Here are the benchmark results compared to main (https://github.com/automerge/automerge-rs/commit/ae56f0d12f1ed599720219b6246c1659d839b486) with the extra benchmarks.

```
B1.1 Append N characters
                        time:   [823.11 ms 825.63 ms 828.38 ms]
                        change: [-4.6630% -4.2938% -3.8849%] (p = 0.00 < 0.05)
                        Performance has improved.

B1.2 Append string of length N
                        time:   [61.911 ms 62.138 ms 62.317 ms]
                        change: [-19.129% -18.232% -17.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low severe

B1.3 20√N clients concurrently set number in Map
                        time:   [436.28 us 440.28 us 444.61 us]
                        change: [-17.639% -16.373% -15.127%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Frontend::apply_patch, small patch
                        time:   [1.5974 ms 1.6159 ms 1.6243 ms]
                        change: [-39.633% -37.435% -35.191%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild

Frontend::apply_patch, small patch, many changes
                        time:   [1.5724 ms 1.5954 ms 1.6098 ms]
                        change: [-39.902% -37.844% -36.178%] (p = 0.00 < 0.05)
                        Performance has improved.

Frontend::apply_patch, nested maps
                        time:   [109.52 ms 110.49 ms 111.75 ms]
                        change: [-83.156% -82.963% -82.744%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

Frontend::change insert long string
                        time:   [2.7435 ms 2.7906 ms 2.8168 ms]
                        change: [-17.015% -15.666% -14.331%] (p = 0.00 < 0.05)
                        Performance has improved.

StateTreeValue::apply_diff sequential text inserts across multiple patches
                        time:   [220.76 ms 221.50 ms 222.19 ms]
                        change: [-7.3750% -6.9084% -6.4340%] (p = 0.00 < 0.05)
                        Performance has improved.

StateTreeValue::apply_diff sequential text inserts in a single patch
                        time:   [9.5635 ms 9.6017 ms 9.6321 ms]
                        change: [-36.976% -35.693% -34.027%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe
```