### PR TITLE
Add formatting config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -2,16 +2,17 @@
 
 mod types;
 
-use automerge_backend::{AutomergeError, Backend, Change};
-use automerge_backend::{SyncMessage, SyncState};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+    fmt::Display,
+};
+
+use automerge_backend::{AutomergeError, Backend, Change, SyncMessage, SyncState};
 use automerge_protocol::{ChangeHash, UncompressedChange};
 use js_sys::Array;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::{collections::HashMap, convert::TryFrom};
-use std::{collections::HashSet, fmt::Display};
-use types::RawSyncMessage;
-use types::{BinaryChange, BinaryDocument, BinarySyncMessage, BinarySyncState};
+use serde::{de::DeserializeOwned, Serialize};
+use types::{BinaryChange, BinaryDocument, BinarySyncMessage, BinarySyncState, RawSyncMessage};
 use wasm_bindgen::prelude::*;
 
 extern crate web_sys;

--- a/automerge-backend-wasm/src/types.rs
+++ b/automerge-backend-wasm/src/types.rs
@@ -1,9 +1,8 @@
-use automerge_backend::{AutomergeError, Change};
-use automerge_backend::{BloomFilter, SyncHave, SyncMessage};
-use automerge_protocol::ChangeHash;
-use serde::Deserialize;
-use serde::Serialize;
 use std::convert::TryFrom;
+
+use automerge_backend::{AutomergeError, BloomFilter, Change, SyncHave, SyncMessage};
+use automerge_protocol::ChangeHash;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct BinaryChange(#[serde(with = "serde_bytes")] pub Vec<u8>);

--- a/automerge-backend/src/actor_map.rs
+++ b/automerge-backend/src/actor_map.rs
@@ -1,6 +1,8 @@
-use crate::internal::{ActorId, ElementId, InternalOp, InternalOpType, Key, ObjectId, OpId};
-use automerge_protocol as amp;
 use std::cmp::Ordering;
+
+use automerge_protocol as amp;
+
+use crate::internal::{ActorId, ElementId, InternalOp, InternalOpType, Key, ObjectId, OpId};
 
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) struct ActorMap(Vec<amp::ActorId>);

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -1,15 +1,13 @@
-use crate::actor_map::ActorMap;
-use crate::change::encode_document;
-use crate::error::AutomergeError;
-use crate::internal::ObjectId;
-use crate::op_handle::OpHandle;
-use crate::op_set::OpSet;
-use crate::pending_diff::PendingDiff;
-use crate::Change;
-use amp::ChangeHash;
-use automerge_protocol as amp;
 use core::cmp::max;
 use std::collections::{HashMap, HashSet, VecDeque};
+
+use amp::ChangeHash;
+use automerge_protocol as amp;
+
+use crate::{
+    actor_map::ActorMap, change::encode_document, error::AutomergeError, internal::ObjectId,
+    op_handle::OpHandle, op_set::OpSet, pending_diff::PendingDiff, Change,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Backend {

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -1,26 +1,29 @@
 //use crate::columnar;
-use crate::columnar::{
-    ChangeEncoder, ChangeIterator, ColumnEncoder, DocChange, DocOp, DocOpEncoder, DocOpIterator,
-    OperationIterator, COLUMN_TYPE_DEFLATE,
-};
-use crate::encoding::DEFLATE_MIN_SIZE;
-use crate::encoding::{Decodable, Encodable};
-use crate::error::{AutomergeError, InvalidChangeError};
-use automerge_protocol as amp;
 use core::fmt::Debug;
+use std::{
+    collections::{HashMap, HashSet},
+    convert::{TryFrom, TryInto},
+    io::{Read, Write},
+    ops::Range,
+    str,
+};
+
+use automerge_protocol as amp;
 use flate2::{
     bufread::{DeflateDecoder, DeflateEncoder},
     Compression,
 };
 use itertools::Itertools;
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
-use std::convert::TryInto;
-use std::io::Read;
-use std::io::Write;
-use std::ops::Range;
-use std::str;
+
+use crate::{
+    columnar::{
+        ChangeEncoder, ChangeIterator, ColumnEncoder, DocChange, DocOp, DocOpEncoder,
+        DocOpIterator, OperationIterator, COLUMN_TYPE_DEFLATE,
+    },
+    encoding::{Decodable, Encodable, DEFLATE_MIN_SIZE},
+    error::{AutomergeError, InvalidChangeError},
+};
 
 const HASH_BYTES: usize = 32;
 const BLOCK_TYPE_DOC: u8 = 0;
@@ -907,9 +910,11 @@ pub(crate) const HEADER_BYTES: usize = PREAMBLE_BYTES + 1;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use amp::{ActorId, UncompressedChange};
     use std::str::FromStr;
+
+    use amp::{ActorId, UncompressedChange};
+
+    use super::*;
 
     #[test]
     fn test_empty_change() {

--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -1,15 +1,21 @@
-use crate::encoding::{BooleanDecoder, Decodable, Decoder, DeltaDecoder, RleDecoder};
-use crate::encoding::{BooleanEncoder, ColData, DeltaEncoder, Encodable, RleEncoder};
-use automerge_protocol as amp;
 use core::fmt::Debug;
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    collections::HashMap,
+    io,
+    io::{Read, Write},
+    ops::Range,
+    str,
+};
+
+use automerge_protocol as amp;
 use flate2::bufread::DeflateDecoder;
-use std::borrow::Cow;
-use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::io;
-use std::io::{Read, Write};
-use std::ops::Range;
-use std::str;
+
+use crate::encoding::{
+    BooleanDecoder, BooleanEncoder, ColData, Decodable, Decoder, DeltaDecoder, DeltaEncoder,
+    Encodable, RleDecoder, RleEncoder,
+};
 
 impl Encodable for Action {
     fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize> {

--- a/automerge-backend/src/concurrent_operations.rs
+++ b/automerge-backend/src/concurrent_operations.rs
@@ -1,7 +1,6 @@
-use crate::error::AutomergeError;
-use crate::internal::InternalOpType;
-use crate::op_handle::OpHandle;
 use std::ops::Deref;
+
+use crate::{error::AutomergeError, internal::InternalOpType, op_handle::OpHandle};
 
 /// Represents a set of operations which are relevant to either an element ID
 /// or object ID and which occurred without knowledge of each other

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -1,13 +1,16 @@
-use crate::{columnar::COLUMN_TYPE_DEFLATE, error::AutomergeError};
-use automerge_protocol as amp;
 use core::fmt::Debug;
+use std::{
+    borrow::Cow,
+    convert::TryFrom,
+    io,
+    io::{Read, Write},
+    mem, str,
+};
+
+use automerge_protocol as amp;
 use flate2::{bufread::DeflateEncoder, Compression};
-use std::borrow::Cow;
-use std::convert::TryFrom;
-use std::io;
-use std::io::{Read, Write};
-use std::mem;
-use std::str;
+
+use crate::{columnar::COLUMN_TYPE_DEFLATE, error::AutomergeError};
 
 pub(crate) const DEFLATE_MIN_SIZE: usize = 256;
 

--- a/automerge-backend/src/error.rs
+++ b/automerge-backend/src/error.rs
@@ -1,6 +1,7 @@
-use automerge_protocol as amp;
 //use std::error::Error;
 use std::fmt::Debug;
+
+use automerge_protocol as amp;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]

--- a/automerge-backend/src/object_store.rs
+++ b/automerge-backend/src/object_store.rs
@@ -1,11 +1,15 @@
-use crate::actor_map::ActorMap;
-use crate::concurrent_operations::ConcurrentOperations;
-use crate::internal::{ElementId, Key, OpId};
-use crate::op_handle::OpHandle;
-use crate::ordered_set::{OrderedSet, SkipList};
+use std::collections::{HashMap, HashSet};
+
 use automerge_protocol as amp;
 use fxhash::FxBuildHasher;
-use std::collections::{HashMap, HashSet};
+
+use crate::{
+    actor_map::ActorMap,
+    concurrent_operations::ConcurrentOperations,
+    internal::{ElementId, Key, OpId},
+    op_handle::OpHandle,
+    ordered_set::{OrderedSet, SkipList},
+};
 
 /// ObjectHistory is what the OpSet uses to store operations for a particular
 /// key, they represent the two possible container types in automerge, a map or

--- a/automerge-backend/src/op_handle.rs
+++ b/automerge-backend/src/op_handle.rs
@@ -1,11 +1,16 @@
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 
-use crate::actor_map::ActorMap;
-use crate::internal::{InternalOp, InternalOpType, Key, ObjectId, OpId};
-use crate::Change;
 use automerge_protocol as amp;
+
+use crate::{
+    actor_map::ActorMap,
+    internal::{InternalOp, InternalOpType, Key, ObjectId, OpId},
+    Change,
+};
 
 #[derive(Clone)]
 pub(crate) struct OpHandle {

--- a/automerge-backend/src/op_set.rs
+++ b/automerge-backend/src/op_set.rs
@@ -6,20 +6,23 @@
 //! document::state) the implementation fetches the root object ID's history
 //! and then recursively walks through the tree of histories constructing the
 //! state. Obviously this is not very efficient.
-use crate::actor_map::ActorMap;
-use crate::error::AutomergeError;
-use crate::internal::{InternalOpType, ObjectId};
-use crate::object_store::ObjState;
-use crate::op_handle::OpHandle;
-use crate::ordered_set::OrderedSet;
-use crate::pending_diff::PendingDiff;
-use crate::Change;
-use automerge_protocol as amp;
 use core::cmp::max;
+use std::collections::{HashMap, HashSet};
+
+use automerge_protocol as amp;
 use fxhash::FxBuildHasher;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use tracing::instrument;
+
+use crate::{
+    actor_map::ActorMap,
+    error::AutomergeError,
+    internal::{InternalOpType, ObjectId},
+    object_store::ObjState,
+    op_handle::OpHandle,
+    ordered_set::OrderedSet,
+    pending_diff::PendingDiff,
+    Change,
+};
 
 /// The OpSet manages an ObjectStore, and a queue of incoming changes in order
 /// to ensure that operations are delivered to the object store in causal order

--- a/automerge-backend/src/ordered_set.rs
+++ b/automerge-backend/src/ordered_set.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code)]
 
+use std::{
+    cmp::{max, min},
+    collections::HashMap,
+    fmt::Debug,
+    hash::Hash,
+    iter::Iterator,
+    mem,
+    ops::AddAssign,
+};
+
 use fxhash::FxBuildHasher;
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
-use std::cmp::{max, min};
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::iter::Iterator;
-use std::mem;
-use std::ops::AddAssign;
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 struct Link<K>

--- a/automerge-backend/src/pending_diff.rs
+++ b/automerge-backend/src/pending_diff.rs
@@ -1,7 +1,10 @@
-use crate::actor_map::ActorMap;
-use crate::internal::{Key, OpId};
-use crate::op_handle::OpHandle;
 use automerge_protocol as amp;
+
+use crate::{
+    actor_map::ActorMap,
+    internal::{Key, OpId},
+    op_handle::OpHandle,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PendingDiff {

--- a/automerge-backend/tests/apply_change.rs
+++ b/automerge-backend/tests/apply_change.rs
@@ -1,4 +1,6 @@
 extern crate automerge_backend;
+use std::{convert::TryInto, str::FromStr};
+
 use automerge_backend::{AutomergeError, Backend, Change};
 use automerge_protocol as amp;
 use automerge_protocol::{
@@ -6,8 +8,6 @@ use automerge_protocol::{
     Op, Patch, ScalarValue, SeqDiff, SequenceType, UncompressedChange,
 };
 use maplit::hashmap;
-use std::convert::TryInto;
-use std::str::FromStr;
 
 #[test]
 fn test_incremental_diffs_in_a_map() {

--- a/automerge-backend/tests/apply_local_change.rs
+++ b/automerge-backend/tests/apply_local_change.rs
@@ -1,14 +1,13 @@
 extern crate automerge_backend;
-use automerge_backend::Backend;
-use automerge_backend::Change;
+use std::{collections::HashSet, convert::TryInto};
+
+use automerge_backend::{Backend, Change};
 use automerge_protocol as protocol;
 use automerge_protocol::{
     ActorId, ChangeHash, Diff, DiffEdit, ElementId, MapDiff, MapType, ObjType, ObjectId, Op,
     OpType, Patch, SeqDiff, SequenceType, UncompressedChange,
 };
 use maplit::hashmap;
-use std::collections::HashSet;
-use std::convert::TryInto;
 
 #[test]
 fn test_apply_local_change() {

--- a/automerge-backend/tests/get_patch.rs
+++ b/automerge-backend/tests/get_patch.rs
@@ -1,4 +1,6 @@
 extern crate automerge_backend;
+use std::convert::TryInto;
+
 use automerge_backend::{Backend, Change};
 use automerge_protocol as amp;
 use automerge_protocol::{
@@ -6,7 +8,6 @@ use automerge_protocol::{
     SeqDiff, SequenceType, UncompressedChange,
 };
 use maplit::hashmap;
-use std::convert::TryInto;
 
 #[test]
 fn test_include_most_recent_value_for_key() {

--- a/automerge-c/build.rs
+++ b/automerge-c/build.rs
@@ -1,7 +1,6 @@
 extern crate cbindgen;
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 fn main() {
     let crate_dir = PathBuf::from(

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -3,16 +3,19 @@ extern crate errno;
 extern crate libc;
 extern crate serde;
 
+use core::fmt::Debug;
+use std::{
+    convert::TryInto,
+    ffi::{CStr, CString},
+    ops::{Deref, DerefMut},
+    os::raw::c_char,
+    ptr,
+};
+
 use automerge_backend::{AutomergeError, Change};
 use automerge_protocol::{ChangeHash, UncompressedChange};
-use core::fmt::Debug;
 use errno::{set_errno, Errno};
 use serde::ser::Serialize;
-use std::convert::TryInto;
-use std::ffi::{CStr, CString};
-use std::ops::{Deref, DerefMut};
-use std::os::raw::c_char;
-use std::ptr;
 
 #[derive(Clone)]
 pub struct Backend {

--- a/automerge-cli/src/change.rs
+++ b/automerge-cli/src/change.rs
@@ -1,8 +1,8 @@
+use std::iter::FromIterator;
+
 use automerge_backend as amb;
 use automerge_frontend as amf;
-use combine::parser::char as charparser;
-use combine::{EasyParser, ParseError, Parser};
-use std::iter::FromIterator;
+use combine::{parser::char as charparser, EasyParser, ParseError, Parser};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -209,8 +209,9 @@ pub fn change(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use maplit::hashmap;
+
+    use super::*;
 
     #[test]
     fn test_parse_change_script() {

--- a/automerge-cli/src/main.rs
+++ b/automerge-cli/src/main.rs
@@ -1,8 +1,7 @@
+use std::{fs::File, path::PathBuf, str::FromStr};
+
 use anyhow::{anyhow, Result};
 use clap::Clap;
-use std::fs::File;
-use std::path::PathBuf;
-use std::str::FromStr;
 
 mod change;
 mod examine;

--- a/automerge-cli/tests/integration.rs
+++ b/automerge-cli/tests/integration.rs
@@ -1,5 +1,6 @@
-use duct::cmd;
 use std::env;
+
+use duct::cmd;
 
 #[test]
 fn import_stdin() {

--- a/automerge-frontend/benches/statetree_apply_diff.rs
+++ b/automerge-frontend/benches/statetree_apply_diff.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
+
 use automerge_frontend::Frontend;
 use automerge_protocol as amp;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use maplit::hashmap;
-use std::collections::HashMap;
 
 pub fn sequential_inserts_in_multiple_patches(c: &mut Criterion) {
     let actor_id = amp::ActorId::random();

--- a/automerge-frontend/src/error.rs
+++ b/automerge-frontend/src/error.rs
@@ -1,10 +1,10 @@
-use crate::value::Value;
-use crate::Path;
+use std::{error::Error, fmt};
+
 use automerge_protocol as amp;
 use automerge_protocol::ObjectId;
-use std::error::Error;
-use std::fmt;
 use thiserror::Error;
+
+use crate::{value::Value, Path};
 
 #[derive(Debug, PartialEq)]
 pub enum AutomergeFrontendError {

--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -8,6 +8,8 @@ mod path;
 mod state_tree;
 mod value;
 
+use std::{collections::HashMap, convert::TryFrom, error::Error, fmt::Debug};
+
 pub use error::{
     AutomergeFrontendError, InvalidChangeRequest, InvalidInitialStateError, InvalidPatch,
 };
@@ -15,9 +17,6 @@ pub use mutation::{LocalChange, MutableDocument};
 pub use path::Path;
 use path::PathElement;
 use state_tree::ResolvedPath;
-use std::convert::TryFrom;
-use std::error::Error;
-use std::{collections::HashMap, fmt::Debug};
 pub use value::{Conflicts, Cursor, Primitive, Value};
 
 /// Tracks the possible states of the frontend

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -1,9 +1,12 @@
-use crate::error::InvalidChangeRequest;
-use crate::state_tree::{LocalOperationResult, SetOrInsertPayload, StateTree, Target};
-use crate::value::{Cursor, Primitive, Value};
-use crate::{Path, PathElement};
 use automerge_protocol as amp;
 use unicode_segmentation::UnicodeSegmentation;
+
+use crate::{
+    error::InvalidChangeRequest,
+    state_tree::{LocalOperationResult, SetOrInsertPayload, StateTree, Target},
+    value::{Cursor, Primitive, Value},
+    Path, PathElement,
+};
 
 pub trait MutableDocument {
     fn value_at_path(&self, path: &Path) -> Option<Value>;

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
+use automerge_protocol as amp;
+
 use super::{DiffApplicationResult, DiffToApply, MultiGrapheme, MultiValue, StateTreeChange};
 use crate::error::InvalidPatch;
-use automerge_protocol as amp;
-use std::collections::HashMap;
 
 pub(super) trait DiffableValue: Sized {
     fn construct<K>(

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -1,9 +1,8 @@
-use crate::error;
-use crate::{Cursor, Primitive, Value};
-use crate::{Path, PathElement};
+use std::{collections::HashMap, convert::TryInto};
+
 use automerge_protocol as amp;
-use std::collections::HashMap;
-use std::convert::TryInto;
+
+use crate::{error, Cursor, Path, PathElement, Primitive, Value};
 
 mod diff_application_result;
 mod diffable_sequence;

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -1,3 +1,5 @@
+use std::iter::Iterator;
+
 use automerge_protocol as amp;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -5,9 +7,10 @@ use super::{
     CursorState, Cursors, DiffApplicationResult, DiffToApply, DiffableSequence, StateTreeChange,
     StateTreeComposite, StateTreeList, StateTreeMap, StateTreeTable, StateTreeText, StateTreeValue,
 };
-use crate::error;
-use crate::value::{Primitive, Value};
-use std::iter::Iterator;
+use crate::{
+    error,
+    value::{Primitive, Value},
+};
 
 pub(crate) struct NewValueRequest<'a, 'b, 'c, 'd> {
     pub(crate) actor: &'a amp::ActorId,

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -1,13 +1,13 @@
-use super::focus::Focus;
-use super::{
-    random_op_id, DiffApplicationResult, LocalOperationResult, MultiGrapheme, MultiValue,
-    NewValueRequest, StateTree, StateTreeChange, StateTreeComposite, StateTreeList, StateTreeMap,
-    StateTreeTable, StateTreeText, StateTreeValue,
-};
-use crate::error;
-use crate::{Cursor, Primitive, Value};
-use automerge_protocol as amp;
 use std::convert::TryInto;
+
+use automerge_protocol as amp;
+
+use super::{
+    focus::Focus, random_op_id, DiffApplicationResult, LocalOperationResult, MultiGrapheme,
+    MultiValue, NewValueRequest, StateTree, StateTreeChange, StateTreeComposite, StateTreeList,
+    StateTreeMap, StateTreeTable, StateTreeText, StateTreeValue,
+};
+use crate::{error, Cursor, Primitive, Value};
 
 #[derive(Debug)]
 pub struct ResolvedPath<'a> {

--- a/automerge-frontend/src/state_tree/state_tree_change.rs
+++ b/automerge-frontend/src/state_tree/state_tree_change.rs
@@ -1,6 +1,8 @@
-use super::{Cursors, StateTreeComposite};
-use automerge_protocol as amp;
 use std::ops::{Add, AddAssign};
+
+use automerge_protocol as amp;
+
+use super::{Cursors, StateTreeComposite};
 
 #[derive(Clone)]
 pub struct StateTreeChange {

--- a/automerge-frontend/src/value.rs
+++ b/automerge-frontend/src/value.rs
@@ -1,6 +1,7 @@
+use std::{borrow::Borrow, collections::HashMap};
+
 use automerge_protocol as amp;
 use serde::Serialize;
-use std::{borrow::Borrow, collections::HashMap};
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct Conflicts(HashMap<amp::OpId, Value>);

--- a/automerge-frontend/tests/test_apply_patch.rs
+++ b/automerge-frontend/tests/test_apply_patch.rs
@@ -1,7 +1,8 @@
+use std::convert::TryInto;
+
 use automerge_frontend::{Frontend, Path, Primitive, Value};
 use automerge_protocol as amp;
 use maplit::hashmap;
-use std::convert::TryInto;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[test]

--- a/automerge-frontend/tests/test_cursor.rs
+++ b/automerge-frontend/tests/test_cursor.rs
@@ -1,8 +1,9 @@
+use std::convert::TryInto;
+
 use automerge_backend::Backend;
 use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value};
 use automerge_protocol as amp;
 use maplit::hashmap;
-use std::convert::TryInto;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[test]

--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -1,7 +1,8 @@
+use std::convert::TryInto;
+
 use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value};
 use automerge_protocol as amp;
 use maplit::hashmap;
-use std::convert::TryInto;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[test]

--- a/automerge-protocol/src/error.rs
+++ b/automerge-protocol/src/error.rs
@@ -1,5 +1,6 @@
-use crate::{DataType, ScalarValue};
 use thiserror::Error;
+
+use crate::{DataType, ScalarValue};
 
 #[derive(Error, Debug)]
 #[error("Invalid OpID: {0}")]

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -1,11 +1,9 @@
 pub mod error;
 mod serde_impls;
 mod utility_impls;
-use std::convert::TryFrom;
-use std::fmt;
+use std::{collections::HashMap, convert::TryFrom, fmt};
 
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
-use std::collections::HashMap;
 
 #[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
 pub struct ActorId(Vec<u8>);

--- a/automerge-protocol/src/serde_impls/actor_id.rs
+++ b/automerge-protocol/src/serde_impls/actor_id.rs
@@ -1,7 +1,8 @@
-use crate::ActorId;
-use serde::de;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::ActorId;
 
 impl<'de> Deserialize<'de> for ActorId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/automerge-protocol/src/serde_impls/change_hash.rs
+++ b/automerge-protocol/src/serde_impls/change_hash.rs
@@ -1,7 +1,8 @@
-use crate::ChangeHash;
-use serde::de;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryInto;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::ChangeHash;
 
 impl Serialize for ChangeHash {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/automerge-protocol/src/serde_impls/cursor_diff.rs
+++ b/automerge-protocol/src/serde_impls/cursor_diff.rs
@@ -1,5 +1,6 @@
-use crate::CursorDiff;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
+
+use crate::CursorDiff;
 
 impl Serialize for CursorDiff {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/automerge-protocol/src/serde_impls/diff.rs
+++ b/automerge-protocol/src/serde_impls/diff.rs
@@ -1,16 +1,17 @@
-use super::read_field;
-use crate::{
-    CursorDiff, DataType, Diff, DiffEdit, MapDiff, ObjDiff, ObjType, ObjectId, OpId, ScalarValue,
-    SeqDiff,
-};
+use std::{collections::HashMap, fmt};
+
 use serde::{
     de,
     de::{Error, MapAccess, Unexpected},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::collections::HashMap;
-use std::fmt;
+
+use super::read_field;
+use crate::{
+    CursorDiff, DataType, Diff, DiffEdit, MapDiff, ObjDiff, ObjType, ObjectId, OpId, ScalarValue,
+    SeqDiff,
+};
 
 impl Serialize for Diff {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -180,10 +181,11 @@ fn maybe_add_datatype_to_value(value: ScalarValue, datatype: DataType) -> Scalar
 
 #[cfg(test)]
 mod tests {
-    use crate::{CursorDiff, Diff, MapDiff, MapType, ObjectId, OpId, SeqDiff, SequenceType};
+    use std::{convert::TryInto, str::FromStr};
+
     use maplit::hashmap;
-    use std::convert::TryInto;
-    use std::str::FromStr;
+
+    use crate::{CursorDiff, Diff, MapDiff, MapType, ObjectId, OpId, SeqDiff, SequenceType};
 
     #[test]
     fn map_diff_serialization_round_trip() {

--- a/automerge-protocol/src/serde_impls/element_id.rs
+++ b/automerge-protocol/src/serde_impls/element_id.rs
@@ -1,6 +1,8 @@
-use crate::ElementId;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::ElementId;
 
 impl Serialize for ElementId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/automerge-protocol/src/serde_impls/key.rs
+++ b/automerge-protocol/src/serde_impls/key.rs
@@ -1,6 +1,8 @@
-use crate::{ElementId, Key};
-use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer};
+
+use crate::{ElementId, Key};
 
 impl<'de> Deserialize<'de> for Key {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/automerge-protocol/src/serde_impls/object_id.rs
+++ b/automerge-protocol/src/serde_impls/object_id.rs
@@ -1,6 +1,8 @@
-use crate::{ObjectId, OpId};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{ObjectId, OpId};
 
 impl Serialize for ObjectId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/automerge-protocol/src/serde_impls/op.rs
+++ b/automerge-protocol/src/serde_impls/op.rs
@@ -1,11 +1,12 @@
+use serde::{
+    de::{Error, MapAccess, Unexpected, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
 use super::read_field;
 use crate::{
     DataType, Key, MapType, ObjType, ObjectId, Op, OpId, OpType, ScalarValue, SequenceType,
-};
-use serde::ser::SerializeStruct;
-use serde::{
-    de::{Error, MapAccess, Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
 };
 
 impl Serialize for Op {
@@ -185,8 +186,9 @@ impl<'de> Deserialize<'de> for Op {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     #[test]
     fn test_deserialize_action() {

--- a/automerge-protocol/src/serde_impls/op_type.rs
+++ b/automerge-protocol/src/serde_impls/op_type.rs
@@ -1,5 +1,6 @@
-use crate::{MapType, ObjType, OpType, SequenceType};
 use serde::{Serialize, Serializer};
+
+use crate::{MapType, ObjType, OpType, SequenceType};
 
 impl Serialize for OpType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/automerge-protocol/src/serde_impls/opid.rs
+++ b/automerge-protocol/src/serde_impls/opid.rs
@@ -1,7 +1,8 @@
-use crate::OpId;
-use serde::de;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::OpId;
 
 impl<'de> Deserialize<'de> for OpId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/automerge-protocol/src/serde_impls/scalar_value.rs
+++ b/automerge-protocol/src/serde_impls/scalar_value.rs
@@ -1,5 +1,6 @@
-use crate::ScalarValue;
 use serde::{de, Deserialize, Deserializer};
+
+use crate::ScalarValue;
 
 impl<'de> Deserialize<'de> for ScalarValue {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/automerge-protocol/src/utility_impls/actor_id.rs
+++ b/automerge-protocol/src/utility_impls/actor_id.rs
@@ -1,7 +1,6 @@
-use crate::error::InvalidActorId;
-use crate::ActorId;
-use std::convert::TryFrom;
-use std::{fmt, str::FromStr};
+use std::{convert::TryFrom, fmt, str::FromStr};
+
+use crate::{error::InvalidActorId, ActorId};
 
 impl TryFrom<&str> for ActorId {
     type Error = InvalidActorId;

--- a/automerge-protocol/src/utility_impls/change_hash.rs
+++ b/automerge-protocol/src/utility_impls/change_hash.rs
@@ -1,6 +1,6 @@
-use crate::error::InvalidChangeHashSlice;
-use crate::ChangeHash;
 use std::convert::TryFrom;
+
+use crate::{error::InvalidChangeHashSlice, ChangeHash};
 
 impl TryFrom<&[u8]> for ChangeHash {
     type Error = InvalidChangeHashSlice;

--- a/automerge-protocol/src/utility_impls/element_id.rs
+++ b/automerge-protocol/src/utility_impls/element_id.rs
@@ -1,7 +1,10 @@
-use crate::error::InvalidElementId;
-use crate::{ElementId, OpId};
-use std::cmp::{Ordering, PartialOrd};
-use std::{convert::TryFrom, str::FromStr};
+use std::{
+    cmp::{Ordering, PartialOrd},
+    convert::TryFrom,
+    str::FromStr,
+};
+
+use crate::{error::InvalidElementId, ElementId, OpId};
 
 impl PartialOrd for ElementId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/automerge-protocol/src/utility_impls/key.rs
+++ b/automerge-protocol/src/utility_impls/key.rs
@@ -1,5 +1,6 @@
-use crate::{ElementId, Key, OpId};
 use std::cmp::{Ordering, PartialOrd};
+
+use crate::{ElementId, Key, OpId};
 
 impl PartialOrd for Key {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/automerge-protocol/src/utility_impls/object_id.rs
+++ b/automerge-protocol/src/utility_impls/object_id.rs
@@ -1,8 +1,11 @@
-use crate::error::InvalidObjectId;
-use crate::{ObjectId, OpId};
-use std::cmp::{Ordering, PartialOrd};
-use std::fmt;
-use std::{convert::TryFrom, str::FromStr};
+use std::{
+    cmp::{Ordering, PartialOrd},
+    convert::TryFrom,
+    fmt,
+    str::FromStr,
+};
+
+use crate::{error::InvalidObjectId, ObjectId, OpId};
 
 impl PartialOrd for ObjectId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/automerge-protocol/src/utility_impls/opid.rs
+++ b/automerge-protocol/src/utility_impls/opid.rs
@@ -1,11 +1,11 @@
-use crate::error::InvalidOpId;
-use crate::{ActorId, OpId};
 use core::fmt;
 use std::{
     cmp::{Ordering, PartialOrd},
     convert::TryFrom,
     str::FromStr,
 };
+
+use crate::{error::InvalidOpId, ActorId, OpId};
 
 impl Ord for OpId {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/automerge-protocol/src/utility_impls/scalar_value.rs
+++ b/automerge-protocol/src/utility_impls/scalar_value.rs
@@ -1,5 +1,6 @@
-use crate::ScalarValue;
 use std::fmt;
+
+use crate::ScalarValue;
 
 impl From<&str> for ScalarValue {
     fn from(s: &str) -> Self {

--- a/automerge/benches/crdt_benchmarks.rs
+++ b/automerge/benches/crdt_benchmarks.rs
@@ -1,9 +1,8 @@
+use std::{collections::HashMap, convert::TryInto, default::Default};
+
 use automerge::{Backend, Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::default::Default;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub fn b1_1(c: &mut Criterion) {

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -1,10 +1,6 @@
-use automerge::Backend;
-use automerge::Frontend;
-use automerge::LocalChange;
-use automerge::MapType;
-use automerge::Path;
-use automerge::Value;
-use automerge::{InvalidChangeRequest, Primitive};
+use automerge::{
+    Backend, Frontend, InvalidChangeRequest, LocalChange, MapType, Path, Primitive, Value,
+};
 use automerge_protocol::{
     ActorId, ElementId, Key, ObjType, ObjectId, Op, OpId, OpType, ScalarValue, SequenceType,
     UncompressedChange,


### PR DESCRIPTION
This should help keep `use` statements more consistent.