### PR TITLE
encodable: Require encode function implementation

### DIFF
--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -44,6 +44,11 @@ impl Encodable for amp::ActorId {
     ) -> io::Result<usize> {
         map_actor(self, actors).encode(buf)
     }
+
+    fn encode<R: Write>(&self, _buf: &mut R) -> io::Result<usize> {
+        // we instead encode actors as their position on a sequence
+        Ok(0)
+    }
 }
 
 impl Encodable for Vec<u8> {

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -543,9 +543,7 @@ pub(crate) trait Encodable {
         self.encode(buf)
     }
 
-    fn encode<R: Write>(&self, _buf: &mut R) -> io::Result<usize> {
-        Ok(0)
-    }
+    fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize>;
 }
 
 impl Encodable for String {


### PR DESCRIPTION
For `encode` being the basic operation of the `Encodable` trait it seems strange to have it be default implementable. I think this could ultimately lead to more annoyances than writing the default explanation where we don't want it to actually encode, e.g. with `ActorId`s. It also encourages to document why the encoding is different for those special cases.