### PR TITLE
Remove automerge bench harness

### DIFF
--- a/automerge-backend-wasm/Cargo.toml
+++ b/automerge-backend-wasm/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 
 [lib]
 crate-type = ["cdylib","rlib"]
+bench = false
 
 [features]
 # default = ["console_error_panic_hook", "wee_alloc"]

--- a/automerge-backend/Cargo.toml
+++ b/automerge-backend/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Alex Good <alex@memoryandthought.me>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+bench = false
 
 [dependencies]
 serde = { version = "^1.0", features=["derive"] }

--- a/automerge-c/Cargo.toml
+++ b/automerge-c/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [lib]
 name = "automerge"
 crate-type = ["cdylib", "staticlib"]
+bench = false
 
 [dependencies]
 automerge-backend = { path = "../automerge-backend" }

--- a/automerge-cli/Cargo.toml
+++ b/automerge-cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [[bin]]
 name = "automerge"
 path = "src/main.rs"
+bench = false
 
 [dependencies]
 clap = "3.0.0-beta.2"

--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Alex Good <alex@memoryandthought.me>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+bench = false
 
 [dependencies]
 automerge-protocol = { path = "../automerge-protocol" }

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Alex Good <alex@memoryandthought.me>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+bench = false
 
 [dependencies]
 hex = "^0.4.2"


### PR DESCRIPTION
This removes the default wrapper which throws errors with some cli
arguments, e.g. --save-baseline which is nice for being able to compare
versions!