### PR TITLE
SyncState: encode can take a ref

### DIFF
--- a/automerge-backend/src/sync/state.rs
+++ b/automerge-backend/src/sync/state.rs
@@ -24,7 +24,7 @@ pub struct SyncHave {
 }
 
 impl SyncState {
-    pub fn encode(self) -> Result<Vec<u8>, AutomergeError> {
+    pub fn encode(&self) -> Result<Vec<u8>, AutomergeError> {
         let mut buf = vec![SYNC_STATE_TYPE];
         encode_hashes(&mut buf, &self.shared_heads)?;
         Ok(buf)


### PR DESCRIPTION
This unnecessarily moves it, we don't event use the owned data in the encode operation.