### PR TITLE
Backend tidy

### DIFF
--- a/automerge-backend/src/actor_map.rs
+++ b/automerge-backend/src/actor_map.rs
@@ -15,7 +15,7 @@ impl ActorMap {
     pub fn import_key(&mut self, key: &amp::Key) -> Key {
         match key {
             amp::Key::Map(string) => Key::Map(string.to_string()),
-            amp::Key::Seq(eid) => Key::Seq(self.import_element_id(&eid)),
+            amp::Key::Seq(eid) => Key::Seq(self.import_element_id(eid)),
         }
     }
 
@@ -48,7 +48,7 @@ impl ActorMap {
 
     pub fn import_op(&mut self, op: amp::Op) -> InternalOp {
         InternalOp {
-            action: self.import_optype(&op.action),
+            action: Self::import_optype(&op.action),
             obj: self.import_obj(&op.obj),
             key: self.import_key(&op.key),
             pred: op
@@ -60,7 +60,7 @@ impl ActorMap {
         }
     }
 
-    pub fn import_optype(&mut self, optype: &amp::OpType) -> InternalOpType {
+    pub fn import_optype(optype: &amp::OpType) -> InternalOpType {
         match optype {
             amp::OpType::Make(val) => InternalOpType::Make(*val),
             amp::OpType::Del => InternalOpType::Del,
@@ -126,13 +126,13 @@ impl ActorMap {
     }
 
     fn cmp_opid(&self, op1: &OpId, op2: &OpId) -> Ordering {
-        if op1.0 != op2.0 {
-            op1.0.cmp(&op2.0)
-        } else {
+        if op1.0 == op2.0 {
             let actor1 = &self.0[(op1.1).0];
             let actor2 = &self.0[(op2.1).0];
-            actor1.cmp(&actor2)
+            actor1.cmp(actor2)
             //op1.1.cmp(&op2.1)
+        } else {
+            op1.0.cmp(&op2.0)
         }
     }
 }

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -42,8 +42,8 @@ impl Backend {
             self.op_set
                 .deps
                 .iter()
+                .filter(|&dep| dep != &last_hash)
                 .cloned()
-                .filter(|dep| dep != &last_hash)
                 .collect()
         } else {
             self.op_set.deps.iter().cloned().collect()
@@ -322,21 +322,22 @@ impl Backend {
         let in_queue: HashSet<_> = self.queue.iter().map(|change| change.hash).collect();
         let mut missing = HashSet::new();
 
-        for head in self.queue.iter().flat_map(|change| change.deps.clone()) {
-            if !self.history_index.contains_key(&head) {
+        for head in self.queue.iter().flat_map(|change| &change.deps) {
+            if !self.history_index.contains_key(head) {
                 missing.insert(head);
             }
         }
 
         for head in heads {
             if !self.history_index.contains_key(&head) {
-                missing.insert(*head);
+                missing.insert(head);
             }
         }
 
         let mut missing = missing
             .into_iter()
             .filter(|hash| !in_queue.contains(hash))
+            .cloned()
             .collect::<Vec<_>>();
         missing.sort();
         missing

--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -424,7 +424,7 @@ impl<'a> Iterator for ValueIterator<'a> {
             v if v % 16 == VALUE_TYPE_UTF8 => {
                 let len = v >> 4;
                 let data = self.val_raw.read_bytes(len).ok()?;
-                let s = str::from_utf8(&data).ok()?;
+                let s = str::from_utf8(data).ok()?;
                 Some(amp::ScalarValue::Str(s.to_string()))
             }
             v if v % 16 == VALUE_TYPE_BYTES => {
@@ -490,7 +490,7 @@ impl<'a> Iterator for ObjIterator<'a> {
     fn next(&mut self) -> Option<amp::ObjectId> {
         if let (Some(actor), Some(ctr)) = (self.actor.next()?, self.ctr.next()?) {
             let actor_id = self.actors.get(actor)?;
-            Some(amp::ObjectId::Id(amp::OpId::new(ctr, &actor_id)))
+            Some(amp::ObjectId::Id(amp::OpId::new(ctr, actor_id)))
         } else {
             Some(amp::ObjectId::Root)
         }
@@ -562,12 +562,9 @@ impl ValEncoder {
         // It may seem weird to have two consecutive matches on the same value. The reason is so
         // that we don't have to repeat the `append_null` calls on ref_actor and ref_counter in
         // every arm of the next match
-        match val {
-            amp::ScalarValue::Cursor(_) => {}
-            _ => {
-                self.ref_actor.append_null();
-                self.ref_counter.append_null();
-            }
+        if !matches!(val, amp::ScalarValue::Cursor(_)) {
+            self.ref_actor.append_null();
+            self.ref_counter.append_null();
         }
         match val {
             amp::ScalarValue::Null => self.len.append_value(VALUE_TYPE_NULL),
@@ -657,7 +654,7 @@ impl KeyEncoder {
                 self.str.append_null();
             }
             amp::Key::Seq(amp::ElementId::Id(amp::OpId(ctr, actor))) => {
-                self.actor.append_value(map_actor(&actor, actors));
+                self.actor.append_value(map_actor(actor, actors));
                 self.ctr.append_value(*ctr);
                 self.str.append_null();
             }
@@ -757,7 +754,7 @@ impl ObjEncoder {
                 self.ctr.append_null();
             }
             amp::ObjectId::Id(amp::OpId(ctr, actor)) => {
-                self.actor.append_value(map_actor(&actor, actors));
+                self.actor.append_value(map_actor(actor, actors));
                 self.ctr.append_value(*ctr);
             }
         }
@@ -824,7 +821,7 @@ impl ChangeEncoder {
             self.time.append_value(change.time as u64);
             self.message.append_value(change.message.clone());
             self.deps_num.append_value(change.deps.len());
-            for dep in change.deps.iter() {
+            for dep in &change.deps {
                 if let Some(dep_index) = index_by_hash.get(dep) {
                     self.deps_index.append_value(*dep_index as u64)
                 } else {
@@ -863,11 +860,11 @@ impl ChangeEncoder {
             .count()
             .encode(&mut info)
             .ok();
-        for d in coldata.iter_mut() {
+        for d in &mut coldata {
             d.deflate();
             d.encode_col_len(&mut info).ok();
         }
-        for d in coldata.iter() {
+        for d in &coldata {
             data.write_all(d.data.as_slice()).ok();
         }
         (data, info)
@@ -973,11 +970,11 @@ impl DocOpEncoder {
             .count()
             .encode(&mut info)
             .ok();
-        for d in coldata.iter_mut() {
+        for d in &mut coldata {
             d.deflate();
             d.encode_col_len(&mut info).ok();
         }
-        for d in coldata.iter() {
+        for d in &coldata {
             data.write_all(d.data.as_slice()).ok();
         }
         (data, info)
@@ -1078,10 +1075,10 @@ impl ColumnEncoder {
             .count()
             .encode(&mut data)
             .ok();
-        for d in coldata.iter_mut() {
+        for d in &mut coldata {
             d.encode_col_len(&mut data).ok();
         }
-        for d in coldata.iter() {
+        for d in &coldata {
             let begin = data.len();
             data.write_all(d.data.as_slice()).ok();
             if !d.data.is_empty() {

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -226,7 +226,7 @@ where
                 }
             }
             RleState::LoneVal(value) => self.flush_lit_run(vec![value]),
-            RleState::Run(value, len) => self.flush_run(value, len),
+            RleState::Run(value, len) => self.flush_run(&value, len),
             RleState::LiteralRun(last, mut run) => {
                 run.push(last);
                 self.flush_lit_run(run);
@@ -236,20 +236,20 @@ where
         ColData::new(col, self.buf)
     }
 
-    fn flush_run(&mut self, val: T, len: usize) {
-        self.encode(len as i64);
+    fn flush_run(&mut self, val: &T, len: usize) {
+        self.encode(&(len as i64));
         self.encode(val);
     }
 
     fn flush_null_run(&mut self, len: usize) {
-        self.encode::<i64>(0);
-        self.encode(len);
+        self.encode::<i64>(&0);
+        self.encode(&len);
     }
 
     fn flush_lit_run(&mut self, run: Vec<T>) {
-        self.encode(-(run.len() as i64));
+        self.encode(&-(run.len() as i64));
         for val in run {
-            self.encode(val);
+            self.encode(&val);
         }
     }
 
@@ -268,7 +268,7 @@ where
                 RleState::NullRun(1)
             }
             RleState::Run(other, len) => {
-                self.flush_run(other, len);
+                self.flush_run(&other, len);
                 RleState::NullRun(1)
             }
             RleState::LiteralRun(last, mut run) => {
@@ -293,7 +293,7 @@ where
                 if other == value {
                     RleState::Run(other, len + 1)
                 } else {
-                    self.flush_run(other, len);
+                    self.flush_run(&other, len);
                     RleState::LoneVal(value)
                 }
             }
@@ -313,7 +313,7 @@ where
         }
     }
 
-    fn encode<V>(&mut self, val: V)
+    fn encode<V>(&mut self, val: &V)
     where
         V: Encodable,
     {
@@ -639,13 +639,13 @@ impl Encodable for usize {
 
 impl Encodable for u32 {
     fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize> {
-        (*self as u64).encode(buf)
+        u64::from(*self).encode(buf)
     }
 }
 
 impl Encodable for i32 {
     fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize> {
-        (*self as i64).encode(buf)
+        i64::from(*self).encode(buf)
     }
 }
 

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -1,3 +1,20 @@
+#![warn(clippy::pedantic)]
+#![warn(clippy::nursery)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::option_if_let_else)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::shadow_unrelated)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::redundant_pub_crate)]
+#![allow(clippy::missing_const_for_fn)]
+#![allow(clippy::use_self)]
+#![allow(clippy::too_many_lines)]
+
 extern crate fxhash;
 extern crate hex;
 extern crate itertools;

--- a/automerge-backend/src/object_store.rs
+++ b/automerge-backend/src/object_store.rs
@@ -46,7 +46,7 @@ impl ObjState {
     }
 
     fn get_parent(&self, id: &ElementId) -> Option<ElementId> {
-        self.insertions.get(&id).and_then(|i| i.key.as_element_id())
+        self.insertions.get(id).and_then(|i| i.key.as_element_id())
     }
 
     fn insertions_after(&self, parent: &ElementId) -> Vec<ElementId> {

--- a/automerge-backend/src/op_handle.rs
+++ b/automerge-backend/src/op_handle.rs
@@ -20,7 +20,7 @@ pub(crate) struct OpHandle {
 }
 
 impl OpHandle {
-    pub fn extract(change: Change, actors: &mut ActorMap) -> Vec<OpHandle> {
+    pub fn extract(change: &Change, actors: &mut ActorMap) -> Vec<OpHandle> {
         change
             .iter_ops()
             .enumerate()

--- a/automerge-backend/src/ordered_set.rs
+++ b/automerge-backend/src/ordered_set.rs
@@ -235,8 +235,7 @@ where
         } else {
             self.key_of(index - 1)
                 .cloned()
-                .map(|suc| self.insert_after(&suc, key))
-                .unwrap_or(false)
+                .map_or(false, |suc| self.insert_after(&suc, key))
         }
     }
 }
@@ -383,7 +382,7 @@ where
         let mut pre_level = 0;
         let mut suc_level = 0;
 
-        for level in 1..(max_level + 1) {
+        for level in 1..=max_level {
             let update_level = min(level, removed.level);
             if level == max_level
                 || pre.get(level).map(|l| &l.key) != pre.get(pre_level).map(|l| &l.key)
@@ -404,7 +403,7 @@ where
     }
 
     fn get_node(&self, key: Option<&K>) -> &Node<K> {
-        if let Some(ref k) = key {
+        if let Some(k) = key {
             self.nodes
                 .get(k)
                 .unwrap_or_else(|| panic!("get_node - missing key {:?}", key))
@@ -414,7 +413,7 @@ where
     }
 
     fn get_node_mut(&mut self, key: Option<&K>) -> &mut Node<K> {
-        if let Some(ref k) = key {
+        if let Some(k) = key {
             self.nodes
                 .get_mut(k)
                 .unwrap_or_else(|| panic!("get_node - missing key {:?}", key))
@@ -499,7 +498,7 @@ where
 
         let mut pre_level = 0;
         let mut suc_level = 0;
-        for level in 1..(max_level + 1) {
+        for level in 1..=max_level {
             let update_level = min(level, new_level);
             if level == max_level
                 || pre.get(level).map(|l| &l.key) != pre.get(pre_level).map(|l| &l.key)
@@ -575,7 +574,7 @@ where
     fn next(&mut self) -> Option<&'a K> {
         let mut successor = match self.id {
             None => None,
-            Some(ref key) => self.nodes.get(key).and_then(|n| n.successor()),
+            Some(key) => self.nodes.get(key).and_then(Node::successor),
         };
         mem::swap(&mut successor, &mut self.id);
         successor
@@ -835,7 +834,7 @@ mod tests {
             .collect();
 
         let mut s = SkipList::<&str>::new();
-        for elem in elems.iter() {
+        for elem in &elems {
             s.insert_head(elem);
         }
 

--- a/automerge-backend/src/pending_diff.rs
+++ b/automerge-backend/src/pending_diff.rs
@@ -17,9 +17,9 @@ pub(crate) enum PendingDiff {
 impl PendingDiff {
     pub fn operation_key(&self) -> Key {
         match self {
-            Self::SeqInsert(op, _, _) => op.operation_key(),
-            Self::SeqRemove(op, _) => op.operation_key(),
-            Self::Set(op) => op.operation_key(),
+            Self::SeqInsert(op, _, _) | Self::SeqRemove(op, _) | Self::Set(op) => {
+                op.operation_key()
+            }
             Self::CursorChange(k) => k.clone(),
         }
     }

--- a/automerge-backend/src/sync.rs
+++ b/automerge-backend/src/sync.rs
@@ -19,6 +19,7 @@ mod state;
 pub use bloom::BloomFilter;
 pub use state::{SyncHave, SyncState};
 
+const HASH_SIZE: usize = 32; // 256 bits = 32 bytes
 const MESSAGE_TYPE_SYNC: u8 = 0x42; // first byte of a sync message, for identification
 
 impl Backend {
@@ -222,8 +223,8 @@ impl Backend {
             let mut changes_to_send = Vec::new();
             for hash in need {
                 hashes_to_send.insert(*hash);
-                if !change_hashes.contains(&hash) {
-                    let change = self.get_change_by_hash(&hash);
+                if !change_hashes.contains(hash) {
+                    let change = self.get_change_by_hash(hash);
                     if let Some(change) = change {
                         changes_to_send.push(change)
                     }
@@ -328,7 +329,6 @@ fn decode_hashes(decoder: &mut Decoder) -> Result<Vec<ChangeHash>, AutomergeErro
     let length = decoder.read::<u32>()?;
     let mut hashes = Vec::with_capacity(length as usize);
 
-    const HASH_SIZE: usize = 32; // 256 bits = 32 bytes
     for _ in 0..length {
         let hash_bytes = decoder.read_bytes(HASH_SIZE)?;
         let hash = ChangeHash::try_from(hash_bytes)

--- a/automerge-backend/src/sync/bloom.rs
+++ b/automerge-backend/src/sync/bloom.rs
@@ -92,7 +92,7 @@ impl BloomFilter {
 }
 
 fn bits_capacity(num_entries: u32, num_bits_per_entry: u32) -> usize {
-    let f = ((num_entries as f64 * num_bits_per_entry as f64) / 8f64).ceil();
+    let f = ((f64::from(num_entries) * f64::from(num_bits_per_entry)) / 8_f64).ceil();
     f as usize
 }
 


### PR DESCRIPTION
Move to storing changes only in the history to reduce duplication and some other style cleanups. Also introduced some more clippy linting and I've disabled some annoying lints but find that it does improve the code further and we can always re-enable them later.

Happy to discuss things / update clippy rules. May be best to look commit-by-commit.