### PR TITLE
Dont document the C lib and CLI

### DIFF
--- a/automerge-c/Cargo.toml
+++ b/automerge-c/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 name = "automerge"
 crate-type = ["cdylib", "staticlib"]
 bench = false
+doc = false
 
 [dependencies]
 automerge-backend = { path = "../automerge-backend" }

--- a/automerge-cli/Cargo.toml
+++ b/automerge-cli/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 name = "automerge"
 path = "src/main.rs"
 bench = false
+doc = false
 
 [dependencies]
 clap = "3.0.0-beta.2"


### PR DESCRIPTION
This gives an error due to the duplicate name.

Avoids
```
error: The library `automerge` is specified by packages `automerge v0.0.2 (/home/$USER/projects/automerge-rs/automerge)` and `automerge-c v0.1.0 (/home/$USER/projects/automerge-rs/automerge-c)` but can only be documented once. Consider renaming or marking one of the targets as `doc = false`.
```

The CLI similarly has a name conflict with the automerge library and generates a warning.