### PR TITLE
Refactor travis to have more jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: linux
 dist: xenial
 language: rust
 
-if: branch = main OR type = pull_request
+if: branch = main
 
 install:
 - rustup self update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,71 @@
 os: linux
 dist: xenial
 language: rust
-rust:
-- stable
-- beta
-- nightly
+
 if: branch = main
+
 install:
 - rustup self update
 - rustup component add clippy
 - rustup component add rustfmt
 - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 - nvm install 10
-before_script:
-- export -f travis_fold
-script:
-- travis_fold start "format"
-- cargo fmt --all -- --check
-- travis_fold end "format"
-- travis_fold start "clippy"
-- cargo clippy --all-targets --all-features -- -D warnings
-- travis_fold end "clippy"
-- travis_fold start "build"
-- cargo build --verbose --all-targets --workspace
-- travis_fold end "build"
-- travis_fold start "test"
-- cargo test --verbose --workspace
-- travis_fold end "test"
-- travis_fold start "wasm-build"
-- cd automerge-backend-wasm && yarn release
-- travis_fold end "wasm-build"
-- cd $TRAVIS_BUILD_DIR
-- travis_fold start "wasm-test"
-- wasm-pack test automerge-frontend --node
-- travis_fold end "wasm-test"
-- travis_fold start "js-interop-test"
-- cd automerge-backend-wasm && yarn test:js
-- cd $TRAVIS_BUILD_DIR
-- travis_fold end "js-interop-test"
+
 jobs:
   allow_failures:
   - rust: nightly
   fast_finish: true
+  include:
+    - name: Stable - Format and Clippy
+      rust: stable
+      script:
+      - cargo fmt --all -- --check
+      - cargo clippy --all-targets --all-features -- -D warnings
+    - name: Stable - Build and Test
+      rust: stable
+      script:
+      - cargo build --all-targets --workspace
+      - cargo test --workspace
+    - name: Stable - Wasm and Interop
+      rust: stable
+      script:
+      - wasm-pack test automerge-frontend --node
+      - cd automerge-backend-wasm
+      - yarn release
+      - yarn test:js
+
+    - name: Beta - Format and Clippy
+      rust: beta
+      script:
+      - cargo fmt --all -- --check
+      - cargo clippy --all-targets --all-features -- -D warnings
+    - name: Beta - Build and Test
+      rust: beta
+      script:
+      - cargo build --all-targets --workspace
+      - cargo test --workspace
+    - name: Beta - Wasm and Interop
+      rust: beta
+      script:
+      - wasm-pack test automerge-frontend --node
+      - cd automerge-backend-wasm
+      - yarn release
+      - yarn test:js
+
+    - name: Nightly - Format and Clippy
+      rust: nightly
+      script:
+      - cargo fmt --all -- --check
+      - cargo clippy --all-targets --all-features -- -D warnings
+    - name: Nightly - Build and Test
+      rust: nightly
+      script:
+      - cargo build --all-targets --workspace
+      - cargo test --workspace
+    - name: Nightly - Wasm and Interop
+      rust: nightly
+      script:
+      - wasm-pack test automerge-frontend --node
+      - cd automerge-backend-wasm
+      - yarn release
+      - yarn test:js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: linux
 dist: xenial
 language: rust
 
-if: branch = main
+if: branch = main OR type = pull_request
 
 install:
 - rustup self update


### PR DESCRIPTION
This splits the `script` up into separate jobs. I find it very hard to find a failure on travis when all of the output is in one file. This helps to break it down to some related jobs. Keeping some bits together avoids recompilation, e.g. build then test. This can also help with overall feedback time as jobs can fail before others (e.g. clippy fails before build completes).

Happy to discuss if there are any other ideas :)

Since this makes things (at least seem) a bit quicker we could get away without the complexity of managing a cache.