### PR TITLE
Add derive Arbitrary support behind cargo feature

### DIFF
--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -18,6 +18,7 @@ maplit = "1.0.2"
 thiserror = "1.0.16"
 im-rc = "15.0.0"
 unicode-segmentation = "1.7.1"
+arbitrary = { version = "1", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2.2", features=["js"] }
@@ -41,4 +42,5 @@ harness = false
 
 [features]
 default = ["std"]
+derive-arbitrary = ["arbitrary"]
 std = []

--- a/automerge-frontend/src/value.rs
+++ b/automerge-frontend/src/value.rs
@@ -13,6 +13,7 @@ impl From<HashMap<amp::OpId, Value>> for Conflicts {
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(untagged)]
 pub enum Value {
     Map(HashMap<String, Value>, amp::MapType),
@@ -23,6 +24,7 @@ pub enum Value {
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Primitive {
     Str(String),
     Int(i64),
@@ -37,6 +39,7 @@ pub enum Primitive {
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Cursor {
     pub index: u32,
     pub(crate) object: amp::ObjectId,

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -13,8 +13,12 @@ hex = "^0.4.2"
 uuid = { version = "^0.8.2", features=["v4"] }
 thiserror = "1.0.16"
 serde = { version = "^1.0", features=["derive"] }
+arbitrary = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 maplit = "^1.0.2"
 serde_json = { version = "^1.0.61", features=["float_roundtrip"], default-features=true }
 proptest = "0.10.1"
+
+[features]
+derive-arbitrary = ["arbitrary"]

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, convert::TryFrom, fmt};
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 
 #[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ActorId(Vec<u8>);
 
 impl fmt::Debug for ActorId {
@@ -68,6 +69,7 @@ impl ObjType {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub enum MapType {
     Map,
@@ -82,6 +84,7 @@ pub enum SequenceType {
 }
 
 #[derive(Eq, PartialEq, Hash, Clone)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OpId(pub u64, pub ActorId);
 
 impl OpId {
@@ -95,6 +98,7 @@ impl OpId {
 }
 
 #[derive(Eq, PartialEq, Debug, Hash, Clone)]
+#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ObjectId {
     Id(OpId),
     Root,


### PR DESCRIPTION
This makes it possible to use a fuzzer to generate `Value` types among others. This is useful when we can generate these and feed them into something like `frontend.change(...)`.

Its behind a feature since most people won't need it on so only pull in the dependency and build the code when explicitly asked.