### PR TITLE
Change init to new and add defaults

### DIFF
--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -105,7 +105,7 @@ impl JsSyncState {
 
 #[wasm_bindgen]
 pub fn init() -> Result<Object, JsValue> {
-    Ok(wrapper(State(Backend::init()), false, Vec::new()))
+    Ok(wrapper(State(Backend::new()), false, Vec::new()))
 }
 
 #[wasm_bindgen(js_name = getHeads)]

--- a/automerge-backend/src/actor_map.rs
+++ b/automerge-backend/src/actor_map.rs
@@ -4,14 +4,10 @@ use automerge_protocol as amp;
 
 use crate::internal::{ActorId, ElementId, InternalOp, InternalOpType, Key, ObjectId, OpId};
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Default)]
 pub(crate) struct ActorMap(Vec<amp::ActorId>);
 
 impl ActorMap {
-    pub fn new() -> ActorMap {
-        ActorMap(Vec::new())
-    }
-
     pub fn import_key(&mut self, key: &amp::Key) -> Key {
         match key {
             amp::Key::Map(string) => Key::Map(string.to_string()),

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -19,7 +19,7 @@ use crate::{
     Change, EventHandler,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Backend {
     queue: Vec<Change>,
     op_set: OpSet,
@@ -31,17 +31,8 @@ pub struct Backend {
 }
 
 impl Backend {
-    pub fn init() -> Backend {
-        let op_set = OpSet::init();
-        Backend {
-            op_set,
-            queue: Vec::new(),
-            actors: ActorMap::new(),
-            states: HashMap::new(),
-            history: Vec::new(),
-            history_index: HashMap::new(),
-            event_handlers: EventHandlers::default(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     fn make_patch(
@@ -330,7 +321,7 @@ impl Backend {
     #[allow(clippy::needless_pass_by_value)]
     pub fn load(data: Vec<u8>) -> Result<Self, AutomergeError> {
         let changes = Change::load_document(&data)?;
-        let mut backend = Self::init();
+        let mut backend = Self::new();
         backend.load_changes(changes)?;
         Ok(backend)
     }
@@ -529,7 +520,7 @@ mod tests {
         }
         .try_into()
         .unwrap();
-        let mut backend = Backend::init();
+        let mut backend = Backend::new();
 
         backend
             .apply_changes(vec![change_a1.clone(), change_a2.clone()])

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -1059,7 +1059,7 @@ mod tests {
     #[test]
     fn test_encode_decode_document() {
         let actor = amp::ActorId::random();
-        let mut backend = crate::Backend::init();
+        let mut backend = crate::Backend::new();
         let change1 = amp::UncompressedChange {
             start_op: 1,
             seq: 1,
@@ -1143,7 +1143,7 @@ mod tests {
     #[test_env_log::test]
     fn test_encode_decode_document_large_enough_for_compression() {
         let actor = amp::ActorId::random();
-        let mut backend = crate::Backend::init();
+        let mut backend = crate::Backend::new();
         let mut change1 = amp::UncompressedChange {
             start_op: 1,
             seq: 1,

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn sync_and_send_backend() {
-        let b = crate::Backend::init();
+        let b = crate::Backend::new();
         let mb = Arc::new(Mutex::new(b));
         thread::spawn(move || {
             let b = mb.lock().unwrap();

--- a/automerge-backend/src/op_set.rs
+++ b/automerge-backend/src/op_set.rs
@@ -47,8 +47,14 @@ pub(crate) struct OpSet {
     cursors: HashMap<ObjectId, Vec<CursorState>>,
 }
 
+impl Default for OpSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OpSet {
-    pub fn init() -> OpSet {
+    pub fn new() -> OpSet {
         let mut objs = HashMap::default();
         objs.insert(ObjectId::Root, ObjState::new(amp::ObjType::map()));
 

--- a/automerge-backend/tests/apply_change.rs
+++ b/automerge-backend/tests/apply_change.rs
@@ -32,7 +32,7 @@ fn test_incremental_diffs_in_a_map() {
     .try_into()
     .unwrap();
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_changes(vec![change.clone()]).unwrap();
     let expected_patch = Patch {
         actor: None,
@@ -115,7 +115,7 @@ fn test_increment_key_in_map() {
             .into(),
         ),
     };
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     let patch = backend.apply_changes(vec![change2]).unwrap();
     assert_eq!(patch, expected_patch);
@@ -187,7 +187,7 @@ fn test_conflict_on_assignment_to_same_map_key() {
             .into(),
         ),
     };
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let _patch1 = backend.apply_changes(vec![change1]).unwrap();
     let patch2 = backend.apply_changes(vec![change2]).unwrap();
     //let patch = backend.get_patch().unwrap();
@@ -253,7 +253,7 @@ fn delete_key_from_map() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     let patch = backend.apply_changes(vec![change2]).unwrap();
     assert_eq!(patch, expected_patch)
@@ -317,7 +317,7 @@ fn create_nested_maps() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_changes(vec![change]).unwrap();
     assert_eq!(patch, expected_patch)
 }
@@ -402,7 +402,7 @@ fn test_assign_to_nested_keys_in_map() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     let patch = backend.apply_changes(vec![change2]).unwrap();
     assert_eq!(patch, expected_patch)
@@ -469,7 +469,7 @@ fn test_create_lists() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_changes(vec![change]).unwrap();
     assert_eq!(patch, expected_patch)
 }
@@ -555,7 +555,7 @@ fn test_apply_updates_inside_lists() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     let patch = backend.apply_changes(vec![change2]).unwrap();
     assert_eq!(patch, expected_patch)
@@ -638,7 +638,7 @@ fn test_delete_list_elements() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     let patch = backend.apply_changes(vec![change2]).unwrap();
     assert_eq!(patch, expected_patch)
@@ -724,7 +724,7 @@ fn test_handle_list_element_insertion_and_deletion_in_same_change() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     let patch = backend.apply_changes(vec![change2]).unwrap();
     assert_eq!(patch, expected_patch)
@@ -827,7 +827,7 @@ fn test_handle_changes_within_conflicted_objects() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change1]).unwrap();
     backend.apply_changes(vec![change2]).unwrap();
     let patch = backend.apply_changes(vec![change3]).unwrap();
@@ -877,7 +877,7 @@ fn test_support_date_objects_at_root() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_changes(vec![change]).unwrap();
     assert_eq!(patch, expected_patch)
 }
@@ -943,7 +943,7 @@ fn test_support_date_objects_in_a_list() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_changes(vec![change]).unwrap();
     assert_eq!(patch, expected_patch)
 }
@@ -985,7 +985,7 @@ fn test_cursor_objects() {
         extra_bytes: Vec::new(),
     };
     let binchange: Change = (&change).try_into().unwrap();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_changes(vec![Change::from(change)]).unwrap();
     let expected_patch = amp::Patch {
         clock: hashmap! {
@@ -1045,16 +1045,21 @@ fn test_throws_on_attempt_to_create_missing_cursor() {
         }],
         extra_bytes: Vec::new(),
     };
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let err = backend
         .apply_changes(vec![Change::from(change)])
         .expect_err("Should be an error");
-    assert_eq!(
-        err,
-        AutomergeError::InvalidCursor {
-            opid: actor.op_id_at(2)
+    if let AutomergeError::InvalidCursor { opid } = err {
+        if opid != actor.op_id_at(2) {
+            panic!(
+                "Expected InvalidCursor error with opid {:?} but found one with {:?}",
+                actor.op_id_at(2),
+                opid
+            )
         }
-    );
+    } else {
+        panic!("Expected InvalidCursor error but found {:?}", err)
+    }
 }
 
 #[test]
@@ -1112,7 +1117,7 @@ fn test_updating_sequences_updates_referring_cursors() {
         extra_bytes: Vec::new(),
     };
     let binchange2: Change = change2.try_into().unwrap();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![binchange1]).unwrap();
     let patch = backend.apply_changes(vec![binchange2.clone()]).unwrap();
     let expected_patch = amp::Patch {
@@ -1215,7 +1220,7 @@ fn test_updating_sequences_updates_referring_cursors_with_deleted_items() {
         extra_bytes: Vec::new(),
     };
     let binchange2: Change = change2.try_into().unwrap();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![binchange1]).unwrap();
     let patch = backend.apply_changes(vec![binchange2.clone()]).unwrap();
     let expected_patch = amp::Patch {

--- a/automerge-backend/tests/apply_local_change.rs
+++ b/automerge-backend/tests/apply_local_change.rs
@@ -30,7 +30,7 @@ fn test_apply_local_change() {
         extra_bytes: Vec::new(),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let patch = backend.apply_local_change(change_request).unwrap().0;
 
     let changes = backend.get_changes(&[]);
@@ -115,7 +115,7 @@ fn test_error_on_duplicate_requests() {
         }],
         extra_bytes: Vec::new(),
     };
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_local_change(change_request1.clone()).unwrap();
     backend.apply_local_change(change_request2.clone()).unwrap();
     assert!(backend.apply_local_change(change_request1).is_err());
@@ -234,7 +234,7 @@ fn test_handle_concurrent_frontend_and_backend_changes() {
         }],
         extra_bytes: Vec::new(),
     };
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_local_change(local1).unwrap();
     let backend_after_first = backend.clone();
     let changes1 = backend_after_first.get_changes(&[]);
@@ -427,7 +427,7 @@ fn test_transform_list_indexes_into_element_ids() {
         extra_bytes: Vec::new(),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![remote1.clone()]).unwrap();
     backend.apply_local_change(local1).unwrap();
     let backend_after_first = backend.clone();
@@ -532,7 +532,7 @@ fn test_handle_list_insertion_and_deletion_in_same_change() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_local_change(local1).unwrap();
     let patch = backend.apply_local_change(local2).unwrap().0;
     expected_patch.deps = patch.deps.clone();

--- a/automerge-backend/tests/get_changes.rs
+++ b/automerge-backend/tests/get_changes.rs
@@ -25,7 +25,7 @@ fn test_deflate_correctly() {
         49, 70, 74, 86, 10, 18, 99, 18, 229, 36, 183, 50, 20, 113, 229, 103, 206, 190, 0,
     ];
     let change: Change = Change::from_bytes(init_change.clone()).unwrap();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_changes(vec![change]).unwrap();
 
     let change_back = backend.get_changes(&[]);

--- a/automerge-backend/tests/get_patch.rs
+++ b/automerge-backend/tests/get_patch.rs
@@ -72,7 +72,7 @@ fn test_include_most_recent_value_for_key() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1, change2]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -144,7 +144,7 @@ fn test_includes_conflicting_values_for_key() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1, change2]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -213,7 +213,7 @@ fn test_handles_counter_increment_at_keys_in_a_map() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1, change2]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -308,7 +308,7 @@ fn test_creates_nested_maps() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1, change2]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -378,7 +378,7 @@ fn test_create_lists() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -470,7 +470,7 @@ fn test_includes_latests_state_of_list() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -519,7 +519,7 @@ fn test_includes_date_objects_at_root() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)
@@ -586,7 +586,7 @@ fn test_includes_date_objects_in_a_list() {
         })),
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.load_changes(vec![change1]).unwrap();
     let patch = backend.get_patch().unwrap();
     assert_eq!(patch, expected_patch)

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -168,7 +168,7 @@ impl From<Vec<ChangeHash>> for BinaryResults {
 
 #[no_mangle]
 pub extern "C" fn automerge_init() -> *mut Backend {
-    Backend::init(automerge_backend::Backend::init()).into()
+    Backend::init(automerge_backend::Backend::new()).into()
 }
 
 /// # Safety

--- a/automerge-cli/src/change.rs
+++ b/automerge-cli/src/change.rs
@@ -175,7 +175,7 @@ pub fn change(
     mut writer: impl std::io::Write,
     script: &str,
 ) -> Result<(), ChangeError> {
-    let mut backend = amb::Backend::init();
+    let mut backend = amb::Backend::new();
     let mut buf: Vec<u8> = Vec::new();
     reader
         .read_to_end(&mut buf)

--- a/automerge-cli/src/export.rs
+++ b/automerge-cli/src/export.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 fn get_state_json(input_data: Vec<u8>) -> Result<serde_json::Value> {
-    let mut backend = automerge_backend::Backend::init();
+    let mut backend = automerge_backend::Backend::new();
     let changes = automerge_backend::Change::load_document(&input_data)?;
     let patch = backend.apply_changes(changes)?;
 
@@ -50,7 +50,7 @@ mod tests {
 
         let (_, initial_change) =
             automerge_frontend::Frontend::new_with_initial_state(value).unwrap();
-        let mut backend = automerge_backend::Backend::init();
+        let mut backend = automerge_backend::Backend::new();
         backend.apply_local_change(initial_change).unwrap();
 
         let change_bytes = backend.save().unwrap();
@@ -76,7 +76,7 @@ mod tests {
 
         let (_, initial_change) =
             automerge_frontend::Frontend::new_with_initial_state(value).unwrap();
-        let mut backend = automerge_backend::Backend::init();
+        let mut backend = automerge_backend::Backend::new();
         backend.apply_local_change(initial_change).unwrap();
 
         let change_bytes = backend.save().unwrap();

--- a/automerge-cli/src/import.rs
+++ b/automerge-cli/src/import.rs
@@ -6,7 +6,7 @@ fn initialize_from_json(json_value: &serde_json::Value) -> Result<Vec<u8>> {
     let value: Value = Value::from_json(&json_value);
 
     let (_, initial_change) = Frontend::new_with_initial_state(value)?;
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_local_change(initial_change)?;
 
     Ok(backend.save()?)

--- a/automerge-frontend/tests/test_backend_concurrency.rs
+++ b/automerge-frontend/tests/test_backend_concurrency.rs
@@ -553,7 +553,7 @@ fn allow_interleaving_of_patches_and_changes() {
         }
     );
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let (patch1, _) = backend.apply_local_change(req1).unwrap();
     doc.apply_patch(patch1).unwrap();
 
@@ -634,11 +634,11 @@ fn test_deps_are_filled_in_if_frontend_does_not_have_latest_patch() {
     let (doc, change1) =
         Frontend::new_with_initial_state(hashmap! {"number" => Primitive::Int(1)}.into()).unwrap();
 
-    let mut backend1 = Backend::init();
+    let mut backend1 = Backend::new();
     let (_, binchange1) = backend1.apply_local_change(change1).unwrap();
 
     let mut doc2 = Frontend::new();
-    let mut backend2 = Backend::init();
+    let mut backend2 = Backend::new();
     let patch1 = backend2.apply_changes(vec![binchange1.clone()]).unwrap();
     doc2.apply_patch(patch1.clone()).unwrap();
 

--- a/automerge-frontend/tests/test_cursor.rs
+++ b/automerge-frontend/tests/test_cursor.rs
@@ -22,12 +22,12 @@ fn test_allow_cursor_on_list_element() {
         .unwrap()
         .1
         .unwrap();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend
         .apply_changes(vec![change.try_into().unwrap()])
         .unwrap();
 
-    let mut backend2 = Backend::init();
+    let mut backend2 = Backend::new();
     backend2
         .apply_changes(backend.get_changes(&[]).into_iter().cloned().collect())
         .unwrap();
@@ -63,12 +63,12 @@ fn test_allow_cursor_on_text_element() {
         .unwrap()
         .1
         .unwrap();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend
         .apply_changes(vec![change.try_into().unwrap()])
         .unwrap();
 
-    let mut backend2 = Backend::init();
+    let mut backend2 = Backend::new();
     backend2
         .apply_changes(backend.get_changes(&[]).into_iter().cloned().collect())
         .unwrap();

--- a/automerge/benches/crdt_benchmarks.rs
+++ b/automerge/benches/crdt_benchmarks.rs
@@ -21,13 +21,13 @@ pub fn b1_1(c: &mut Criterion) {
                     .unwrap()
                     .1
                     .unwrap();
-                let mut backend1 = Backend::init();
+                let mut backend1 = Backend::new();
                 let (patch1, _) = backend1.apply_local_change(changedoc1).unwrap();
                 doc1.apply_patch(patch1).unwrap();
 
                 let mut doc2 = Frontend::new();
                 let changedoc2 = backend1.get_changes(&[]);
-                let mut backend2 = Backend::init();
+                let mut backend2 = Backend::new();
                 let patch2 = backend2
                     .apply_changes(changedoc2.into_iter().cloned().collect())
                     .unwrap();
@@ -88,13 +88,13 @@ pub fn b1_2(c: &mut Criterion) {
                     .unwrap()
                     .1
                     .unwrap();
-                let mut backend1 = Backend::init();
+                let mut backend1 = Backend::new();
                 let (patch1, _) = backend1.apply_local_change(changedoc1).unwrap();
                 doc1.apply_patch(patch1).unwrap();
 
                 let mut doc2 = Frontend::new();
                 let changedoc2 = backend1.get_changes(&[]);
-                let mut backend2 = Backend::init();
+                let mut backend2 = Backend::new();
                 let patch2 = backend2
                     .apply_changes(changedoc2.into_iter().cloned().collect())
                     .unwrap();
@@ -143,7 +143,7 @@ pub fn b3_1(c: &mut Criterion) {
                 let n: f64 = 6000.0;
                 let root_n: i64 = n.sqrt().floor() as i64;
                 let mut local_doc = Frontend::new();
-                let mut local_backend = Backend::init();
+                let mut local_backend = Backend::new();
                 let init_change = local_doc
                     .change::<_, _, InvalidChangeRequest>(None, |d| {
                         d.add_change(LocalChange::set(
@@ -163,7 +163,7 @@ pub fn b3_1(c: &mut Criterion) {
                     .into_iter()
                     .enumerate()
                     .map(|(index, mut doc)| {
-                        let mut backend = Backend::init();
+                        let mut backend = Backend::new();
                         let patch = backend.apply_changes(vec![init_binchange.clone()]).unwrap();
                         doc.apply_patch(patch).unwrap();
                         let change = doc

--- a/automerge/benches/save_load.rs
+++ b/automerge/benches/save_load.rs
@@ -5,7 +5,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn small_change_backend() -> Backend {
     let mut frontend = Frontend::new();
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let (_, change) = frontend
         .change::<_, _, InvalidChangeRequest>(None, |doc| {
             doc.add_change(LocalChange::set(
@@ -136,7 +136,7 @@ fn medium_change_backend() -> Backend {
         LocalChange::delete(Path::root().key("\u{1}")),
     ];
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
     let patch = backend.get_patch().unwrap();
     frontend.apply_patch(patch).unwrap();
@@ -176,7 +176,7 @@ fn medium_change_backend() -> Backend {
 fn save_empty(c: &mut Criterion) {
     c.bench_function("save an empty backend", |b| {
         b.iter_batched(
-            Backend::init,
+            Backend::new,
             |b| black_box(b.save().unwrap()),
             criterion::BatchSize::SmallInput,
         )
@@ -206,7 +206,7 @@ fn save_medium(c: &mut Criterion) {
 fn load_empty(c: &mut Criterion) {
     c.bench_function("load an empty backend", |b| {
         b.iter_batched(
-            || Backend::init().save().unwrap(),
+            || Backend::new().save().unwrap(),
             |v| black_box(Backend::load(v).unwrap()),
             criterion::BatchSize::SmallInput,
         )

--- a/automerge/benches/sync.rs
+++ b/automerge/benches/sync.rs
@@ -42,8 +42,8 @@ fn sync(
 }
 
 fn sync_per_change(count: u32, sync_interval: u32) {
-    let mut n1 = Backend::init();
-    let mut n2 = Backend::init();
+    let mut n1 = Backend::new();
+    let mut n2 = Backend::new();
     let mut s1 = SyncState::default();
     let mut s2 = SyncState::default();
 

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -125,7 +125,7 @@ fn missing_object_error_flaky_null_rle_decoding() {
         LocalChange::delete(Path::root().key("\u{1}")),
     ];
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     let mut frontend = Frontend::new_with_timestamper_and_actor_id(Box::new(|| None), actor_id);
     let patch = backend.get_patch().unwrap();
     frontend.apply_patch(patch).unwrap();
@@ -687,7 +687,7 @@ fn missing_object_error_null_rle_decoding() {
         extra_bytes: vec![],
     };
 
-    let mut backend = Backend::init();
+    let mut backend = Backend::new();
     backend.apply_local_change(raw_change).unwrap();
 
     let backend_bytes = backend.save().unwrap();

--- a/automerge/tests/text_grapheme_clusters.rs
+++ b/automerge/tests/text_grapheme_clusters.rs
@@ -12,7 +12,7 @@ fn create_frontend_with_grapheme_clusters() {
         automerge::MapType::Map,
     ))
     .unwrap();
-    let mut b = automerge::Backend::init();
+    let mut b = automerge::Backend::new();
     let (p, _) = b.apply_local_change(c).unwrap();
     f.apply_patch(p).unwrap();
 }


### PR DESCRIPTION
Structs should use `new` for the constructor name and implement
`Default` where they can.

This keeps the `init` function exposed to wasm and C for the backend.