### PR TITLE
Set console_error_panic_hook when initing a backend

### DIFF
--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -105,6 +105,7 @@ impl JsSyncState {
 
 #[wasm_bindgen]
 pub fn init() -> Result<Object, JsValue> {
+    console_error_panic_hook::set_once();
     Ok(wrapper(State(Backend::new()), false, Vec::new()))
 }
 


### PR DESCRIPTION
This means we can get nicer panic messages in the JS side when using the wasm backend.

This was already in the `Cargo.toml` so I expect it was there at some point in history in the code too but I don't know what happened to it.

Ideally we wouldn't ever panic but especially as this is still under development with things breaking it will at least make debugging wasm tests a bit easier.

We could also add it in more places, e.g. where we create sync states but I think the backend is the main place.