### PR TITLE
Use elem id from insertion in frontend

### DIFF
--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -844,7 +844,7 @@ impl StateTreeText {
     ) -> Result<(&amp::OpId, String), error::MissingIndexError> {
         self.graphemes
             .get(index)
-            .map(|mc| (mc.default_opid(), mc.default_grapheme()))
+            .map(|mc| (&mc.0, mc.1.default_grapheme()))
             .ok_or_else(|| error::MissingIndexError {
                 missing_index: index,
                 size_of_collection: self.graphemes.len(),
@@ -907,7 +907,7 @@ impl StateTreeText {
     pub fn pred_for_index(&self, index: u32) -> Vec<amp::OpId> {
         self.graphemes
             .get(index.try_into().unwrap())
-            .map(|v| vec![v.default_opid().clone()])
+            .map(|v| vec![v.1.default_opid().clone()])
             .unwrap_or_else(Vec::new)
     }
 
@@ -1013,17 +1013,17 @@ impl StateTreeList {
     pub fn pred_for_index(&self, index: u32) -> Vec<amp::OpId> {
         self.elements
             .get(index.try_into().unwrap())
-            .map(|v| vec![v.default_opid()])
+            .map(|v| vec![v.1.default_opid()])
             .unwrap_or_else(Vec::new)
     }
 
     pub(crate) fn elem_at(
         &self,
         index: usize,
-    ) -> Result<(amp::OpId, &MultiValue), error::MissingIndexError> {
+    ) -> Result<&(amp::OpId, MultiValue), error::MissingIndexError> {
+        dbg!(index);
         self.elements
             .get(index)
-            .map(|mv| (mv.default_opid(), mv))
             .ok_or_else(|| error::MissingIndexError {
                 missing_index: index,
                 size_of_collection: self.elements.len(),

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -606,7 +606,12 @@ impl ResolvedList {
     ) -> Result<LocalOperationResult, error::MissingIndexError> {
         let current_elemid = match index {
             0 => amp::ElementId::Head,
-            i => self.value.elem_at((i - 1).try_into().unwrap())?.0.into(),
+            i => self
+                .value
+                .elem_at((i - 1).try_into().unwrap())?
+                .0
+                .clone()
+                .into(),
         };
         let newvalue = MultiValue::new_from_value_2(NewValueRequest {
             actor: payload.actor,
@@ -646,7 +651,12 @@ impl ResolvedList {
     {
         let mut last_elemid = match index {
             0 => amp::ElementId::Head,
-            i => self.value.elem_at((i - 1).try_into().unwrap())?.0.into(),
+            i => self
+                .value
+                .elem_at((i - 1).try_into().unwrap())?
+                .0
+                .clone()
+                .into(),
         };
         let mut newvalues = DiffApplicationResult::pure(Vec::with_capacity(payload.value.len()));
         let mut op_num = payload.start_op;
@@ -720,7 +730,7 @@ impl ResolvedList {
         Ok(Cursor::new(
             index,
             self.value.object_id.clone(),
-            current_elemid,
+            current_elemid.clone(),
         ))
     }
 }

--- a/automerge/tests/frontend_backend_roundtrip.rs
+++ b/automerge/tests/frontend_backend_roundtrip.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+use automerge::{Path, Primitive, Value};
+use test_env_log::test;
+
+#[test]
+fn test_frontend_uses_correct_elem_ids() {
+    let mut hm = HashMap::new();
+    hm.insert(
+        "a".to_owned(),
+        automerge::Value::Sequence(vec![automerge::Value::Primitive(Primitive::Null)]),
+    );
+    let mut backend = automerge::Backend::new();
+
+    let (mut frontend, change) =
+        automerge::Frontend::new_with_initial_state(Value::Map(hm, automerge::MapType::Map))
+            .unwrap();
+
+    println!("change1 {:?}", change);
+
+    let (patch, _) = backend.apply_local_change(change).unwrap();
+    frontend.apply_patch(patch).unwrap();
+
+    let ((), c) = frontend
+        .change::<_, _, automerge::InvalidChangeRequest>(None, |d| {
+            d.add_change(automerge::LocalChange::set(
+                automerge::Path::root().key("a").index(0),
+                automerge::Value::Primitive(automerge::Primitive::Int(0)),
+            ))
+            .unwrap();
+            d.add_change(automerge::LocalChange::insert(
+                automerge::Path::root().key("a").index(1),
+                automerge::Value::Primitive(automerge::Primitive::Boolean(false)),
+            ))
+            .unwrap();
+            Ok(())
+        })
+        .unwrap();
+
+    let mut ehm = HashMap::new();
+    ehm.insert(
+        "a".to_owned(),
+        automerge::Value::Sequence(vec![
+            automerge::Value::Primitive(automerge::Primitive::Int(0)),
+            automerge::Value::Primitive(automerge::Primitive::Boolean(false)),
+        ]),
+    );
+    let expected = automerge::Value::Map(ehm.clone(), automerge::MapType::Map);
+
+    assert_eq!(expected, frontend.get_value(&Path::root()).unwrap());
+
+    if let Some(c) = c {
+        println!("change2 {:?}", c);
+        let (p, _) = backend.apply_local_change(c).unwrap();
+        frontend.apply_patch(p).unwrap();
+    }
+    let v = frontend.get_value(&Path::root()).unwrap();
+
+    let expected = automerge::Value::Map(ehm, automerge::MapType::Map);
+    assert_eq!(expected, v);
+}


### PR DESCRIPTION
Element ids in sequences are tied to the operation that created the element. Performing a set shouldn't update the element id as it was previously doing. This was from a test case found by quickcheck in automergeable.