### PR TITLE
Implement encode/decode for SyncState

### DIFF
--- a/automerge-c/automerge.c
+++ b/automerge-c/automerge.c
@@ -29,33 +29,55 @@ void test_sync_basic() {
 }
 
 void test_sync_encode_decode() {
-  // TODO: Commented out b/c this fails.
-  //printf("begin sync test - encode/decode\n");
-  //int len;
+  printf("begin sync test - encode/decode\n");
+  int len;
 
-  //char buff[BUFSIZE];
-  //char sync_state_buff[BUFSIZE];
+  char buff[BUFSIZE];
+  char sync_state_buff[BUFSIZE];
 
-  //Backend * dbA = automerge_init();
-  //Backend * dbB = automerge_init();
+  Backend * dbA = automerge_init();
+  Backend * dbB = automerge_init();
 
-  //SyncState * ssA = automerge_sync_state_init();
-  //SyncState * ssB = automerge_sync_state_init();
+  const char * requestA1 = "{\"actor\":\"111111\",\"seq\":1,\"time\":0,\"deps\":[],\"startOp\":1,\"ops\":[{\"action\":\"set\",\"obj\":\"_root\",\"key\":\"bird\",\"value\":\"magpie\",\"pred\":[]}]}";
+  const char * requestB1 = "{\"actor\":\"222222\",\"seq\":1,\"time\":0,\"deps\":[],\"startOp\":1,\"ops\":[{\"action\":\"set\",\"obj\":\"_root\",\"key\":\"bird\",\"value\":\"crow\",\"pred\":[]}]}";
+  automerge_apply_local_change(dbA, requestA1);
+  automerge_apply_local_change(dbB, requestB1);
 
-  //len = automerge_generate_sync_message(dbA, ssA);
-  //automerge_read_binary(dbA, buff);
-  //automerge_receive_sync_message(dbB, ssB, buff, len);
+  SyncState * ssA = automerge_sync_state_init();
+  SyncState * ssB = automerge_sync_state_init();
 
-  //// Save the sync state to `sync_state_buff`
-  //int encoded_len = automerge_encode_sync_state(dbB, ssB);
-  //automerge_read_binary(dbB, sync_state_buff);
+  len = automerge_generate_sync_message(dbA, ssA);
+  automerge_read_binary(dbA, buff);
+  automerge_receive_sync_message(dbB, ssB, buff, len);
 
-  //// Read it back
-  //ssB = automerge_decode_sync_state(sync_state_buff, encoded_len);
+  len = automerge_generate_sync_message(dbB, ssB);
+  automerge_read_binary(dbB, buff);
+  automerge_receive_sync_message(dbA, ssA, buff, len);
 
-  //len = automerge_generate_sync_message(dbB, ssB);
-  // TODO: This assertion fails (len == 7 not 0)
-  //assert(len == 0);
+  len = automerge_generate_sync_message(dbA, ssA);
+  automerge_read_binary(dbA, buff);
+  automerge_receive_sync_message(dbB, ssB, buff, len);
+
+
+  len = automerge_generate_sync_message(dbB, ssB);
+  automerge_read_binary(dbB, buff);
+  automerge_receive_sync_message(dbA, ssA, buff, len);
+
+  len = automerge_generate_sync_message(dbA, ssA);
+
+  // Save the sync state
+  int encoded_len = automerge_encode_sync_state(dbB, ssB);
+  automerge_read_binary(dbB, sync_state_buff);
+  // Read it back
+  ssB = automerge_decode_sync_state(sync_state_buff, encoded_len);
+
+  len = automerge_generate_sync_message(dbB, ssB);
+  automerge_read_binary(dbB, buff);
+  automerge_receive_sync_message(dbA, ssA, buff, len);
+
+
+  len = automerge_generate_sync_message(dbA, ssA);
+  assert(len == 0);
 }
 
 void test_sync() {

--- a/automerge-c/automerge.c
+++ b/automerge-c/automerge.c
@@ -29,6 +29,7 @@ void test_sync_basic() {
 }
 
 void test_sync_encode_decode() {
+  // TODO: Commented out b/c this fails.
   //printf("begin sync test - encode/decode\n");
   //int len;
 
@@ -42,11 +43,8 @@ void test_sync_encode_decode() {
   //SyncState * ssB = automerge_sync_state_init();
 
   //len = automerge_generate_sync_message(dbA, ssA);
-  //int len2 = automerge_read_binary(dbA, buff);
+  //automerge_read_binary(dbA, buff);
   //automerge_receive_sync_message(dbB, ssB, buff, len);
-
-  //len = automerge_generate_sync_message(dbB, ssB);
-  //printf("LEN2: %i\n", len);
 
   //// Save the sync state to `sync_state_buff`
   //int encoded_len = automerge_encode_sync_state(dbB, ssB);
@@ -56,7 +54,7 @@ void test_sync_encode_decode() {
   //ssB = automerge_decode_sync_state(sync_state_buff, encoded_len);
 
   //len = automerge_generate_sync_message(dbB, ssB);
-  //printf("LEN: %i\n", len);
+  // TODO: This assertion fails (len == 7 not 0)
   //assert(len == 0);
 }
 

--- a/automerge-c/automerge.c
+++ b/automerge-c/automerge.c
@@ -6,8 +6,8 @@
 
 #define BUFSIZE 4096
 
-void test_sync() {
-  printf("begin sync test\n");
+void test_sync_basic() {
+  printf("begin sync test - basic\n");
   int len;
 
   // In a real application you would need to check to make sure your buffer is large enough for any given read
@@ -26,6 +26,44 @@ void test_sync() {
   len = automerge_generate_sync_message(dbB, ssB);
   // No more sync messages were generated
   assert(len == 0);
+}
+
+void test_sync_encode_decode() {
+  //printf("begin sync test - encode/decode\n");
+  //int len;
+
+  //char buff[BUFSIZE];
+  //char sync_state_buff[BUFSIZE];
+
+  //Backend * dbA = automerge_init();
+  //Backend * dbB = automerge_init();
+
+  //SyncState * ssA = automerge_sync_state_init();
+  //SyncState * ssB = automerge_sync_state_init();
+
+  //len = automerge_generate_sync_message(dbA, ssA);
+  //int len2 = automerge_read_binary(dbA, buff);
+  //automerge_receive_sync_message(dbB, ssB, buff, len);
+
+  //len = automerge_generate_sync_message(dbB, ssB);
+  //printf("LEN2: %i\n", len);
+
+  //// Save the sync state to `sync_state_buff`
+  //int encoded_len = automerge_encode_sync_state(dbB, ssB);
+  //automerge_read_binary(dbB, sync_state_buff);
+
+  //// Read it back
+  //ssB = automerge_decode_sync_state(sync_state_buff, encoded_len);
+
+  //len = automerge_generate_sync_message(dbB, ssB);
+  //printf("LEN: %i\n", len);
+  //assert(len == 0);
+}
+
+void test_sync() {
+    printf("begin sync test");
+    test_sync_basic();
+    test_sync_encode_decode();
 }
 
 int main() {

--- a/automerge-c/automerge.h
+++ b/automerge-c/automerge.h
@@ -37,9 +37,25 @@ intptr_t automerge_decode_change(Backend *backend, uintptr_t len, const uint8_t 
 
 /**
  * # Safety
+ * `encoded_state_[ptr|len]` must be the address & length of a byte array
+ * Returns an opaque pointer to a SyncState
+ * panics (segfault?) if the buffer was invalid
+ */
+SyncState *automerge_decode_sync_state(const uint8_t *encoded_state_ptr, uintptr_t encoded_state_len);
+
+/**
+ * # Safety
  * This must me called with a valid pointer a json string of a change
  */
 intptr_t automerge_encode_change(Backend *backend, const char *change);
+
+/**
+ * Must be called with a valid backend pointer
+ * sync_state must be a valid pointer to a SyncState
+ * Returns an `isize` indicating the length of the binary message
+ * (-1 if there was an error)
+ */
+intptr_t automerge_encode_sync_state(Backend *backend, SyncState *sync_state);
 
 /**
  * # Safety

--- a/automerge-c/automerge.h
+++ b/automerge-c/automerge.h
@@ -50,6 +50,7 @@ SyncState *automerge_decode_sync_state(const uint8_t *encoded_state_ptr, uintptr
 intptr_t automerge_encode_change(Backend *backend, const char *change);
 
 /**
+ * # Safety
  * Must be called with a valid backend pointer
  * sync_state must be a valid pointer to a SyncState
  * Returns an `isize` indicating the length of the binary message

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -517,6 +517,7 @@ pub extern "C" fn automerge_sync_state_init() -> *mut SyncState {
     state.into()
 }
 
+/// # Safety
 /// Must be called with a valid backend pointer
 /// sync_state must be a valid pointer to a SyncState
 /// Returns an `isize` indicating the length of the binary message

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -526,7 +526,6 @@ pub unsafe extern "C" fn automerge_encode_sync_state(
     backend: *mut Backend,
     sync_state: &mut SyncState,
 ) -> isize {
-    let enc = sync_state.handle.encode();
     (*backend).handle_binary(
         sync_state
             .handle


### PR DESCRIPTION
Follow-up to the PR implementing C-bindings for sync state.

There seems to be 1 issue (can't tell if it's an issue really), where the assert at the end of the new test fails (`len == 7` not `len == 0`). I'm not sure if this is b/c the test is incorrect or the bindings are incorrect.

My guess is the test is incorrect.

Also the sync state serializes to 2 byes in the test which seems really small?