### PR TITLE
Add mismatched sequence number failing test

### DIFF
--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -129,11 +129,12 @@ impl DiffableValue for MultiValue {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct DiffableSequence<T>
 where
     T: DiffableValue,
     T: Clone,
+    T: PartialEq,
 {
     // stores the opid that created the element and the diffable value
     underlying: Box<im_rc::Vector<(OpId, T)>>,
@@ -143,6 +144,7 @@ impl<T> DiffableSequence<T>
 where
     T: Clone,
     T: DiffableValue,
+    T: PartialEq,
 {
     pub fn new() -> DiffableSequence<T> {
         DiffableSequence {

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -35,7 +35,7 @@ impl LocalOperationResult {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct StateTree {
     objects: im_rc::HashMap<amp::ObjectId, StateTreeComposite>,
     cursors: Cursors,
@@ -317,13 +317,13 @@ impl StateTree {
 
 /// A node in the state tree is either a leaf node containing a scalarvalue,
 /// or an internal composite type (e.g a Map or a List)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 enum StateTreeValue {
     Leaf(Primitive),
     Link(amp::ObjectId),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 enum StateTreeComposite {
     Map(StateTreeMap),
     Table(StateTreeTable),
@@ -572,7 +572,7 @@ impl StateTreeValue {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct StateTreeMap {
     object_id: amp::ObjectId,
     props: im_rc::HashMap<String, MultiValue>,
@@ -694,7 +694,7 @@ impl StateTreeMap {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct StateTreeTable {
     object_id: amp::ObjectId,
     props: im_rc::HashMap<String, MultiValue>,
@@ -797,7 +797,7 @@ impl StateTreeTable {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct StateTreeText {
     object_id: amp::ObjectId,
     graphemes: DiffableSequence<MultiGrapheme>,
@@ -916,7 +916,7 @@ impl StateTreeText {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct StateTreeList {
     object_id: amp::ObjectId,
     elements: DiffableSequence<MultiValue>,

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -23,7 +23,7 @@ pub(crate) struct NewValueRequest<'a, 'b, 'c, 'd> {
 }
 
 /// A set of conflicting values for the same key, indexed by OpID
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(super) struct MultiValue {
     winning_value: (amp::OpId, StateTreeValue),
     conflicts: im_rc::HashMap<amp::OpId, StateTreeValue>,
@@ -275,7 +275,7 @@ impl NewValue {
 
 /// This struct exists to constrain the values of a text type to just containing
 /// sequences of grapheme clusters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(super) struct MultiGrapheme {
     winning_value: (amp::OpId, String),
     conflicts: Option<im_rc::HashMap<amp::OpId, String>>,


### PR DESCRIPTION
Was failing with `MismatchedSequenceNumber { expected: 1, actual: 2 }`

Now fixed!