### PR TITLE
Fix backend panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "automerge-frontend",
     "automerge-cli",
     "automerge-protocol",
+    "fuzz",
 ]
 
 [profile.release]

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -192,7 +192,10 @@ impl Backend {
 
         let ops = OpHandle::extract(change, &mut self.actors);
 
-        op_set.max_op = max(op_set.max_op, start_op + (ops.len() as u64) - 1);
+        op_set.max_op = max(
+            op_set.max_op,
+            (start_op + (ops.len() as u64)).saturating_sub(1),
+        );
 
         op_set.apply_ops(ops, diffs, &mut self.actors)?;
 

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -670,42 +670,42 @@ fn doc_changes_to_uncompressed_changes(
 
 fn load_blocks(bytes: &[u8]) -> Result<Vec<Change>, AutomergeError> {
     let mut changes = Vec::new();
-    for slice in split_blocks(bytes) {
+    for slice in split_blocks(bytes)? {
         decode_block(slice, &mut changes)?;
     }
     Ok(changes)
 }
 
-fn split_blocks(bytes: &[u8]) -> Vec<&[u8]> {
+fn split_blocks(bytes: &[u8]) -> Result<Vec<&[u8]>, decoding::Error> {
     // split off all valid blocks - ignore the rest if its corrupted or truncated
     let mut blocks = Vec::new();
     let mut cursor = bytes;
-    while let Some(block) = pop_block(cursor) {
+    while let Some(block) = pop_block(cursor)? {
         blocks.push(&cursor[block.clone()]);
         if cursor.len() <= block.end {
             break;
         }
         cursor = &cursor[block.end..];
     }
-    blocks
+    Ok(blocks)
 }
 
-fn pop_block(bytes: &[u8]) -> Option<Range<usize>> {
+fn pop_block(bytes: &[u8]) -> Result<Option<Range<usize>>, decoding::Error> {
     if bytes.len() < 4 || bytes[0..4] != MAGIC_BYTES {
         // not reporting error here - file got corrupted?
-        return None;
+        return Ok(None);
     }
     if bytes.len() < HEADER_BYTES {
         // TODO: actually return an error here
-        return None;
+        return Ok(None);
     }
-    let (val, len) = read_leb128(&mut &bytes[HEADER_BYTES..]).unwrap();
+    let (val, len) = read_leb128(&mut &bytes[HEADER_BYTES..])?;
     let end = HEADER_BYTES + len + val;
     if end > bytes.len() {
         // not reporting error here - file got truncated?
-        return None;
+        return Ok(None);
     }
-    Some(0..end)
+    Ok(Some(0..end))
 }
 
 fn decode_document(bytes: &[u8]) -> Result<Vec<Change>, decoding::Error> {

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -421,7 +421,11 @@ fn decode_actors(
         actors.push(actor)
     }
     for _ in 0..num_actors {
-        actors.push(amp::ActorId::from(&bytes[slice_bytes(bytes, cursor)?]));
+        actors.push(amp::ActorId::from(
+            bytes
+                .get(slice_bytes(bytes, cursor)?)
+                .ok_or(decoding::Error::NotEnoughBytes)?,
+        ));
     }
     Ok(actors)
 }

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -695,6 +695,10 @@ fn pop_block(bytes: &[u8]) -> Option<Range<usize>> {
         // not reporting error here - file got corrupted?
         return None;
     }
+    if bytes.len() < HEADER_BYTES {
+        // TODO: actually return an error here
+        return None;
+    }
     let (val, len) = read_leb128(&mut &bytes[HEADER_BYTES..]).unwrap();
     let end = HEADER_BYTES + len + val;
     if end > bytes.len() {

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -706,7 +706,10 @@ fn pop_block(bytes: &[u8]) -> Result<Option<Range<usize>>, decoding::Error> {
             .get(HEADER_BYTES..)
             .ok_or(decoding::Error::NotEnoughBytes)?,
     )?;
-    let end = HEADER_BYTES + len + val;
+    // val is arbitrary so it could overflow
+    let end = (HEADER_BYTES + len)
+        .checked_add(val)
+        .ok_or(decoding::Error::Overflow)?;
     if end > bytes.len() {
         // not reporting error here - file got truncated?
         return Ok(None);

--- a/automerge-backend/src/change.rs
+++ b/automerge-backend/src/change.rs
@@ -399,6 +399,9 @@ fn decode_hashes(
     for _ in 0..num_hashes {
         let hash = cursor.start..(cursor.start + HASH_BYTES);
         *cursor = hash.end..cursor.end;
+        if bytes.len() < hash.end {
+            return Err(decoding::Error::NotEnoughBytes);
+        }
         hashes.push(bytes[hash].try_into().map_err(InvalidChangeError::from)?);
     }
     Ok(hashes)

--- a/automerge-backend/src/decoding.rs
+++ b/automerge-backend/src/decoding.rs
@@ -37,6 +37,8 @@ pub enum Error {
     ChangeDecompressFailed(String),
     #[error("No doc changes found")]
     NoDocChanges,
+    #[error("An overflow would have occurred, the data may be corrupt")]
+    Overflow,
     #[error("Failed to read leb128 number {0}")]
     Leb128(#[from] leb128::read::Error),
     #[error(transparent)]

--- a/automerge-backend/tests/load.rs
+++ b/automerge-backend/tests/load.rs
@@ -33,3 +33,13 @@ fn test_load_overflowing_add() {
     ];
     let _ = Backend::load(bytes);
 }
+
+#[test]
+fn test_load_overflowing_sub() {
+    // these are just random bytes
+    let bytes = vec![
+        133, 111, 74, 131, 68, 193, 221, 243, 2, 16, 35, 80, 80, 10, 131, 0, 255, 28, 10, 0, 0, 65,
+        8, 0, 133, 0,
+    ];
+    let _ = Backend::load(bytes);
+}

--- a/automerge-backend/tests/load.rs
+++ b/automerge-backend/tests/load.rs
@@ -8,6 +8,16 @@ fn test_load_index_out_of_bounds() {
 }
 
 #[test]
+fn test_load_index_out_of_bounds_2() {
+    // these are just random bytes
+    let bytes = vec![
+        133, 111, 74, 131, 171, 99, 102, 54, 2, 16, 42, 0, 18, 255, 255, 61, 57, 57, 57, 29, 48,
+        48, 48, 116, 0, 0, 0, 46, 46,
+    ];
+    let _ = Backend::load(bytes);
+}
+
+#[test]
 fn test_load_leb_failed_to_read_whole_buffer() {
     // these are just random bytes
     let bytes = vec![133, 111, 74, 131, 46, 46, 46, 46, 46];

--- a/automerge-backend/tests/load.rs
+++ b/automerge-backend/tests/load.rs
@@ -6,3 +6,10 @@ fn test_load_index_out_of_bounds() {
     let bytes = vec![133, 111, 74, 131, 0, 46, 128, 0];
     let _ = Backend::load(bytes);
 }
+
+#[test]
+fn test_load_leb_failed_to_read_whole_buffer() {
+    // these are just random bytes
+    let bytes = vec![133, 111, 74, 131, 46, 46, 46, 46, 46];
+    let _ = Backend::load(bytes);
+}

--- a/automerge-backend/tests/load.rs
+++ b/automerge-backend/tests/load.rs
@@ -1,0 +1,8 @@
+use automerge_backend::Backend;
+
+#[test]
+fn test_load_index_out_of_bounds() {
+    // these are just random bytes
+    let bytes = vec![133, 111, 74, 131, 0, 46, 128, 0];
+    let _ = Backend::load(bytes);
+}

--- a/automerge-backend/tests/load.rs
+++ b/automerge-backend/tests/load.rs
@@ -18,6 +18,13 @@ fn test_load_index_out_of_bounds_2() {
 }
 
 #[test]
+fn test_load_index_out_of_bounds_3() {
+    // these are just random bytes
+    let bytes = vec![133, 111, 74, 131, 29, 246, 20, 11, 0, 2, 8, 61, 44];
+    let _ = Backend::load(bytes);
+}
+
+#[test]
 fn test_load_leb_failed_to_read_whole_buffer() {
     // these are just random bytes
     let bytes = vec![133, 111, 74, 131, 46, 46, 46, 46, 46];

--- a/automerge-backend/tests/load.rs
+++ b/automerge-backend/tests/load.rs
@@ -23,3 +23,13 @@ fn test_load_leb_failed_to_read_whole_buffer() {
     let bytes = vec![133, 111, 74, 131, 46, 46, 46, 46, 46];
     let _ = Backend::load(bytes);
 }
+
+#[test]
+fn test_load_overflowing_add() {
+    // these are just random bytes
+    let bytes = vec![
+        133, 111, 74, 131, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1,
+        16,
+    ];
+    let _ = Backend::load(bytes);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
                 cargo-edit
                 cargo-watch
                 cargo-criterion
+                cargo-fuzz
                 crate2nix
                 wasm-pack
                 pkgconfig

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,20 @@
+
+[package]
+name = "automerge-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+automerge-backend = { path = "../automerge-backend" }
+
+[[bin]]
+name = "backend_load"
+path = "src/backend_load.rs"
+test = false
+doc = false

--- a/fuzz/src/backend_load.rs
+++ b/fuzz/src/backend_load.rs
@@ -1,0 +1,6 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: Vec<u8>| {
+    let _ = automerge_backend::Backend::load(data);
+});


### PR DESCRIPTION
This adds some fuzzing to check loading arbitrary bytes. While these shouldn't always generate actual values it shouldn't panic.

The fuzzing found some issues that I've encapsulated in tests and fixed.