### PR TITLE
Make encoding and decoding mods public for errors

### DIFF
--- a/automerge-backend/src/decoding.rs
+++ b/automerge-backend/src/decoding.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, convert::TryFrom, io, io::Read, str};
 
 use automerge_protocol as amp;
 
+/// The error type for decoding operations.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(

--- a/automerge-backend/src/encoding.rs
+++ b/automerge-backend/src/encoding.rs
@@ -12,6 +12,7 @@ use crate::columnar::COLUMN_TYPE_DEFLATE;
 
 pub(crate) const DEFLATE_MIN_SIZE: usize = 256;
 
+/// The error type for encoding operations.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -41,6 +41,8 @@ mod sync;
 
 pub use backend::Backend;
 pub use change::Change;
+pub use decoding::Error as DecodingError;
+pub use encoding::Error as EncodingError;
 pub use error::AutomergeError;
 pub use event_handlers::{ChangeEventHandler, EventHandler, EventHandlerId};
 pub use sync::{BloomFilter, SyncHave, SyncMessage, SyncState};


### PR DESCRIPTION
Fixes https://github.com/automerge/automerge-rs/issues/143

This makes the errors public and usable by consumers of the API.

Up to discussing whether we want to keep a flat API or nested?