### PR TITLE
diffable seq: Avoid rebuilding the updating list each time

### DIFF
--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -845,7 +845,7 @@ impl StateTreeText {
     ) -> Result<(&amp::OpId, String), error::MissingIndexError> {
         self.graphemes
             .get(index)
-            .map(|mc| (&mc.0, mc.1.default_grapheme()))
+            .map(|mc| (mc.0, mc.1.default_grapheme()))
             .ok_or_else(|| error::MissingIndexError {
                 missing_index: index,
                 size_of_collection: self.graphemes.len(),
@@ -1021,7 +1021,7 @@ impl StateTreeList {
     pub(crate) fn elem_at(
         &self,
         index: usize,
-    ) -> Result<&(amp::OpId, MultiValue), error::MissingIndexError> {
+    ) -> Result<(&amp::OpId, &MultiValue), error::MissingIndexError> {
         self.elements
             .get(index)
             .ok_or_else(|| error::MissingIndexError {


### PR DESCRIPTION
This means we can keep things in the original state but while applying
the diff we don't have to keep building a new vec each time.

This makes B1.1 run in ~11 seconds for me.