### PR TITLE
Remove value_at_path

### DIFF
--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -465,16 +465,9 @@ impl Frontend {
             .map(|o| o.values())
     }
 
+    /// Returns the value given by path, if it exists
     pub fn get_value(&self, path: &Path) -> Option<Value> {
         self.state.as_ref().and_then(|s| s.get_value(path))
-    }
-
-    /// Returns the value given by path, if it exists
-    pub fn value_at_path(&self, path: &Path) -> Option<Value> {
-        self.state
-            .as_ref()
-            .and_then(|s| s.resolve_path(&path))
-            .map(|o| o.default_value())
     }
 }
 

--- a/automerge-frontend/tests/test_cursor.rs
+++ b/automerge-frontend/tests/test_cursor.rs
@@ -36,9 +36,7 @@ fn test_allow_cursor_on_list_element() {
     frontend2
         .apply_patch(backend2.get_patch().unwrap())
         .unwrap();
-    let index_value = frontend2
-        .value_at_path(&Path::root().key("cursor"))
-        .unwrap();
+    let index_value = frontend2.get_value(&Path::root().key("cursor")).unwrap();
     if let Value::Primitive(Primitive::Cursor(c)) = index_value {
         assert_eq!(c.index, 1)
     } else {
@@ -77,9 +75,7 @@ fn test_allow_cursor_on_text_element() {
     frontend2
         .apply_patch(backend2.get_patch().unwrap())
         .unwrap();
-    let index_value = frontend2
-        .value_at_path(&Path::root().key("cursor"))
-        .unwrap();
+    let index_value = frontend2.get_value(&Path::root().key("cursor")).unwrap();
     if let Value::Primitive(Primitive::Cursor(c)) = index_value {
         assert_eq!(c.index, 1)
     } else {


### PR DESCRIPTION
This has the same functionality as get_value and we only need one.

We can always rename `get_value` another time but we don't need both of these.