### PR TITLE
Mutation tracker rollback

### DIFF
--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -4,7 +4,8 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::{
     error::InvalidChangeRequest,
     state_tree::{
-        LocalOperationResult, ResolvedPath, ResolvedPathMut, SetOrInsertPayload, StateTree,
+        LocalOperationResult, MultiGrapheme, MultiValue, ResolvedPath, ResolvedPathMut,
+        SetOrInsertPayload, StateTree,
     },
     value::{Cursor, Primitive, Value},
     Path, PathElement,
@@ -82,6 +83,36 @@ impl LocalChange {
     }
 }
 
+// A container for either a multivalue or a multigrapheme
+enum MultiThing {
+    Value(MultiValue),
+    Grapheme(MultiGrapheme),
+}
+
+impl MultiThing {
+    fn into_value(self) -> MultiValue {
+        match self {
+            Self::Value(value) => value,
+            Self::Grapheme(_) => unreachable!(),
+        }
+    }
+
+    fn into_grapheme(self) -> MultiGrapheme {
+        match self {
+            Self::Value(_) => unreachable!(),
+            Self::Grapheme(grapheme) => grapheme,
+        }
+    }
+}
+
+enum LocalOperationForRollback {
+    Set { old: Option<MultiThing> },
+    Delete { old: Option<MultiThing> },
+    Insert,
+    InsertMany { count: usize },
+    Increment { by: i64 },
+}
+
 /// `MutationTracker` is used as the context in which a mutation closure is
 /// applied. The mutation tracker implements `MutableDocument`, which is how it
 /// captures the changes that the mutation closure is making.
@@ -93,6 +124,7 @@ impl LocalChange {
 pub struct MutationTracker<'a> {
     state: &'a mut StateTree,
     ops: Vec<amp::Op>,
+    copies_for_rollback: Vec<(Path, LocalOperationForRollback)>,
     pub max_op: u64,
     actor_id: amp::ActorId,
 }
@@ -102,6 +134,7 @@ impl<'a> MutationTracker<'a> {
         Self {
             state: state_tree,
             ops: Vec::new(),
+            copies_for_rollback: Vec::new(),
             max_op,
             actor_id,
         }
@@ -198,6 +231,149 @@ impl<'a> MutationTracker<'a> {
             Err(InvalidChangeRequest::NoSuchPathError { path: path.clone() })
         }
     }
+
+    /// Undo the operations applied to this document.
+    ///
+    /// This is used in the case of an error to undo the already applied changes.
+    pub fn rollback(self) {
+        for (path, op) in self.copies_for_rollback.into_iter().rev() {
+            match op {
+                LocalOperationForRollback::Set { old } => {
+                    if let Some(key) = path.name() {
+                        if let Some(parent) = self.state.resolve_path_mut(&path.parent()) {
+                            match (key, parent) {
+                                (PathElement::Key(key), ResolvedPathMut::Root(mut map)) => {
+                                    map.rollback_set(key.clone(), old.map(|o| o.into_value()))
+                                }
+                                (PathElement::Key(key), ResolvedPathMut::Map(mut map)) => {
+                                    map.rollback_set(key.clone(), old.map(|o| o.into_value()))
+                                }
+                                (PathElement::Key(key), ResolvedPathMut::Table(mut table)) => {
+                                    table.rollback_set(key.clone(), old.map(|o| o.into_value()))
+                                }
+                                (PathElement::Key(_), ResolvedPathMut::List(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Text(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Character(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Counter(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Primitive(_)) => {
+                                    unreachable!("found non object with key")
+                                }
+                                (PathElement::Index(i), ResolvedPathMut::List(mut list)) => {
+                                    list.rollback_set(*i as usize, old.unwrap().into_value())
+                                }
+                                (PathElement::Index(i), ResolvedPathMut::Text(mut text)) => {
+                                    text.rollback_set(*i as usize, old.unwrap().into_grapheme())
+                                }
+                                (PathElement::Index(_), ResolvedPathMut::Root(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Map(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Table(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Character(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Counter(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Primitive(_)) => {
+                                    unreachable!("found non list with index")
+                                }
+                            }
+                        }
+                    }
+                }
+                LocalOperationForRollback::Delete { old } => {
+                    if let Some(key) = path.name() {
+                        if let Some(parent) = self.state.resolve_path_mut(&path.parent()) {
+                            match (key, parent) {
+                                (PathElement::Key(key), ResolvedPathMut::Root(mut map)) => {
+                                    map.rollback_delete(key.clone(), old.unwrap().into_value())
+                                }
+                                (PathElement::Key(key), ResolvedPathMut::Map(mut map)) => {
+                                    map.rollback_delete(key.clone(), old.unwrap().into_value())
+                                }
+                                (PathElement::Key(key), ResolvedPathMut::Table(mut table)) => {
+                                    table.rollback_delete(key.clone(), old.unwrap().into_value())
+                                }
+                                (PathElement::Key(_), ResolvedPathMut::List(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Text(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Character(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Counter(_))
+                                | (PathElement::Key(_), ResolvedPathMut::Primitive(_)) => {
+                                    unreachable!("found non object with key")
+                                }
+                                (PathElement::Index(i), ResolvedPathMut::List(mut list)) => {
+                                    list.rollback_delete(*i as usize, old.unwrap().into_value())
+                                }
+                                (PathElement::Index(i), ResolvedPathMut::Text(mut text)) => {
+                                    text.rollback_delete(*i as usize, old.unwrap().into_grapheme())
+                                }
+                                (PathElement::Index(_), ResolvedPathMut::Root(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Map(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Table(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Character(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Counter(_))
+                                | (PathElement::Index(_), ResolvedPathMut::Primitive(_)) => {
+                                    unreachable!("found non list with index")
+                                }
+                            }
+                        }
+                    }
+                }
+                LocalOperationForRollback::Insert => {
+                    if let Some(PathElement::Index(index)) = path.name() {
+                        if let Some(parent) = self.state.resolve_path_mut(&path.parent()) {
+                            match parent {
+                                ResolvedPathMut::List(mut list) => {
+                                    list.rollback_insert(*index as usize)
+                                }
+                                ResolvedPathMut::Text(mut text) => {
+                                    text.rollback_insert(*index as usize)
+                                }
+                                ResolvedPathMut::Root(_)
+                                | ResolvedPathMut::Map(_)
+                                | ResolvedPathMut::Table(_)
+                                | ResolvedPathMut::Character(_)
+                                | ResolvedPathMut::Counter(_)
+                                | ResolvedPathMut::Primitive(_) => {
+                                    unreachable!("Found non list object in rollback insert")
+                                }
+                            }
+                        }
+                    }
+                }
+                LocalOperationForRollback::InsertMany { count } => {
+                    if let Some(PathElement::Index(index)) = path.name() {
+                        if let Some(parent) = self.state.resolve_path_mut(&path.parent()) {
+                            match parent {
+                                ResolvedPathMut::List(mut list) => {
+                                    for _ in 0..count {
+                                        list.rollback_insert(*index as usize)
+                                    }
+                                }
+                                ResolvedPathMut::Text(mut text) => {
+                                    for _ in 0..count {
+                                        text.rollback_insert(*index as usize)
+                                    }
+                                }
+                                ResolvedPathMut::Root(_)
+                                | ResolvedPathMut::Map(_)
+                                | ResolvedPathMut::Table(_)
+                                | ResolvedPathMut::Character(_)
+                                | ResolvedPathMut::Counter(_)
+                                | ResolvedPathMut::Primitive(_) => {
+                                    unreachable!("Found non list object in rollback insert")
+                                }
+                            }
+                        }
+                    }
+                }
+                LocalOperationForRollback::Increment { by } => {
+                    if path.name().is_some() {
+                        if let Some(ResolvedPathMut::Counter(mut counter)) =
+                            self.state.resolve_path_mut(&path)
+                        {
+                            counter.rollback_increment(by)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<'a> MutableDocument for MutationTracker<'a> {
@@ -230,7 +406,7 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                 };
                 if let Some(name) = change.path.name() {
                     if let Some(parent) = self.state.resolve_path_mut(&change.path.parent()) {
-                        match (name, parent) {
+                        let (old, res) = match (name, parent) {
                             (
                                 PathElement::Key(ref k),
                                 ResolvedPathMut::Root(ref mut root_target),
@@ -240,9 +416,8 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                     actor: &self.actor_id.clone(),
                                     value,
                                 };
-                                let res = root_target.set_key(k, payload);
-                                self.apply_state_change(res);
-                                Ok(())
+                                let (old, res) = root_target.set_key(k, payload);
+                                Ok((old.map(MultiThing::Value), res))
                             }
                             (PathElement::Key(ref k), ResolvedPathMut::Map(ref mut maptarget)) => {
                                 let payload = SetOrInsertPayload {
@@ -250,9 +425,8 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                     actor: &self.actor_id.clone(),
                                     value,
                                 };
-                                let res = maptarget.set_key(k, payload);
-                                self.apply_state_change(res);
-                                Ok(())
+                                let (old, res) = maptarget.set_key(k, payload);
+                                Ok((old.map(MultiThing::Value), res))
                             }
                             (
                                 PathElement::Key(ref k),
@@ -263,14 +437,15 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                     actor: &self.actor_id.clone(),
                                     value,
                                 };
-                                let res = tabletarget.set_key(k, payload);
-                                self.apply_state_change(res);
-                                Ok(())
+                                let (old, res) = tabletarget.set_key(k, payload);
+                                Ok((old.map(MultiThing::Value), res))
                             }
                             // In this case we are trying to modify a key in something which is not
                             // an object or a table, so the path does not exist
                             (PathElement::Key(_), _) => {
-                                Err(InvalidChangeRequest::NoSuchPathError { path: change.path })
+                                Err(InvalidChangeRequest::NoSuchPathError {
+                                    path: change.path.clone(),
+                                })
                             }
                             (PathElement::Index(i), ResolvedPathMut::List(ref mut list_target)) => {
                                 let payload = SetOrInsertPayload {
@@ -278,9 +453,8 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                     actor: &self.actor_id.clone(),
                                     value,
                                 };
-                                let res = list_target.set(*i, payload)?;
-                                self.apply_state_change(res);
-                                Ok(())
+                                let (old, res) = list_target.set(*i, payload)?;
+                                Ok((Some(MultiThing::Value(old)), res))
                             }
                             (PathElement::Index(i), ResolvedPathMut::Text(ref mut text)) => {
                                 match value {
@@ -291,9 +465,8 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                                 actor: &self.actor_id.clone(),
                                                 value: s,
                                             };
-                                            let res = text.set(*i, payload)?;
-                                            self.apply_state_change(res);
-                                            Ok(())
+                                            let (old, res) = text.set(*i, payload)?;
+                                            Ok((Some(MultiThing::Grapheme(old)), res))
                                         } else {
                                             Err(InvalidChangeRequest::InsertNonTextInTextObject {
                                                 path: change.path.clone(),
@@ -312,7 +485,12 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                     path: change.path.clone(),
                                 })
                             }
-                        }
+                        }?;
+
+                        self.copies_for_rollback
+                            .push((change.path, LocalOperationForRollback::Set { old }));
+                        self.apply_state_change(res);
+                        Ok(())
                     } else {
                         Err(InvalidChangeRequest::NoSuchPathError { path: change.path })
                     }
@@ -323,14 +501,17 @@ impl<'a> MutableDocument for MutationTracker<'a> {
             LocalOperation::Delete => {
                 if let Some(name) = change.path.name() {
                     if let Some(pr) = self.state.resolve_path_mut(&change.path.parent()) {
-                        let state_change = match pr {
+                        let (old, state_change) = match pr {
                             ResolvedPathMut::Counter(_) => {
                                 return Err(InvalidChangeRequest::NoSuchPathError {
                                     path: change.path,
                                 })
                             }
                             ResolvedPathMut::List(mut l) => match name {
-                                PathElement::Index(i) => l.remove(*i)?,
+                                PathElement::Index(i) => {
+                                    let (old, res) = l.remove(*i)?;
+                                    (Some(MultiThing::Value(old)), res)
+                                }
                                 _ => {
                                     return Err(InvalidChangeRequest::NoSuchPathError {
                                         path: change.path,
@@ -338,7 +519,10 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                 }
                             },
                             ResolvedPathMut::Text(mut t) => match name {
-                                PathElement::Index(i) => t.remove(*i)?,
+                                PathElement::Index(i) => {
+                                    let (old, res) = t.remove(*i)?;
+                                    (Some(MultiThing::Grapheme(old)), res)
+                                }
                                 _ => {
                                     return Err(InvalidChangeRequest::NoSuchPathError {
                                         path: change.path,
@@ -351,7 +535,10 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                 })
                             }
                             ResolvedPathMut::Map(mut m) => match name {
-                                PathElement::Key(k) => m.delete_key(k),
+                                PathElement::Key(k) => {
+                                    let (old, res) = m.delete_key(k);
+                                    (old.map(MultiThing::Value), res)
+                                }
                                 _ => {
                                     return Err(InvalidChangeRequest::NoSuchPathError {
                                         path: change.path,
@@ -359,7 +546,10 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                 }
                             },
                             ResolvedPathMut::Table(mut t) => match name {
-                                PathElement::Key(k) => t.delete_key(k),
+                                PathElement::Key(k) => {
+                                    let (old, res) = t.delete_key(k);
+                                    (old.map(MultiThing::Value), res)
+                                }
                                 _ => {
                                     return Err(InvalidChangeRequest::NoSuchPathError {
                                         path: change.path,
@@ -372,7 +562,10 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                 })
                             }
                             ResolvedPathMut::Root(mut r) => match name {
-                                PathElement::Key(k) => r.delete_key(k),
+                                PathElement::Key(k) => {
+                                    let (old, res) = r.delete_key(k);
+                                    (old.map(MultiThing::Value), res)
+                                }
                                 _ => {
                                     return Err(InvalidChangeRequest::NoSuchPathError {
                                         path: change.path,
@@ -380,6 +573,8 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                                 }
                             },
                         };
+                        self.copies_for_rollback
+                            .push((change.path, LocalOperationForRollback::Delete { old }));
                         self.apply_state_change(state_change);
                         Ok(())
                     } else {
@@ -395,6 +590,10 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                         match pr {
                             ResolvedPathMut::Counter(mut counter_target) => {
                                 let res = counter_target.increment(by);
+                                self.copies_for_rollback.push((
+                                    change.path,
+                                    LocalOperationForRollback::Increment { by },
+                                ));
                                 self.apply_state_change(res);
                                 Ok(())
                             }
@@ -412,10 +611,25 @@ impl<'a> MutableDocument for MutationTracker<'a> {
                 }
             }
             LocalOperation::Insert(value) => {
-                self.insert_helper(&change.path, std::iter::once(value))
+                match self.insert_helper(&change.path, std::iter::once(value)) {
+                    Ok(()) => {
+                        self.copies_for_rollback
+                            .push((change.path, LocalOperationForRollback::Insert));
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
             }
             LocalOperation::InsertMany(values) => {
-                self.insert_helper(&change.path, values.into_iter())
+                let count = values.len();
+                match self.insert_helper(&change.path, values.into_iter()) {
+                    Ok(()) => {
+                        self.copies_for_rollback
+                            .push((change.path, LocalOperationForRollback::InsertMany { count }));
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
             }
         }
     }

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -372,19 +372,23 @@ where
         self.underlying.len()
     }
 
-    pub(super) fn update(&mut self, index: usize, value: T) {
-        let elem_id = if let Some(existing) = self.underlying.get(index) {
-            existing.opid.clone()
-        } else {
-            value.default_opid()
-        };
-        self.underlying.set(
-            index,
-            SequenceElement {
-                opid: elem_id,
-                value: SequenceValue::Original(value),
-            },
-        );
+    pub(super) fn set(&mut self, index: usize, value: T) -> T {
+        let elem_id = self
+            .underlying
+            .get(index)
+            .map(|existing| existing.opid.clone())
+            .expect("Failed to get existing index in set");
+        self.underlying
+            .set(
+                index,
+                SequenceElement {
+                    opid: elem_id,
+                    value: SequenceValue::Original(value),
+                },
+            )
+            .value
+            .get()
+            .clone()
     }
 
     pub(super) fn get(&self, index: usize) -> Option<(&OpId, &T)> {

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -25,7 +25,7 @@ pub(crate) struct NewValueRequest<'a, 'c> {
 
 /// A set of conflicting values for the same key, indexed by OpID
 #[derive(Debug, Clone, PartialEq, Default)]
-pub(super) struct MultiValue {
+pub struct MultiValue {
     winning_value: (amp::OpId, StateTreeValue),
     conflicts: HashMap<amp::OpId, StateTreeValue>,
 }
@@ -46,7 +46,10 @@ impl MultiValue {
         }
     }
 
-    pub fn from_statetree_value(statetree_val: StateTreeValue, opid: amp::OpId) -> MultiValue {
+    pub(super) fn from_statetree_value(
+        statetree_val: StateTreeValue,
+        opid: amp::OpId,
+    ) -> MultiValue {
         MultiValue {
             winning_value: (opid, statetree_val),
             conflicts: HashMap::new(),
@@ -340,7 +343,7 @@ impl NewValue {
 /// This struct exists to constrain the values of a text type to just containing
 /// sequences of grapheme clusters
 #[derive(Debug, Clone, PartialEq, Default)]
-pub(super) struct MultiGrapheme {
+pub struct MultiGrapheme {
     winning_value: (amp::OpId, String),
     conflicts: HashMap<amp::OpId, String>,
 }

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -691,7 +691,7 @@ impl<'a> ResolvedTextMut<'a> {
         };
         state_tree_text
             .insert(index, value)
-            .expect("Failed to rollback set");
+            .expect("Failed to rollback delete");
     }
 
     pub(crate) fn rollback_insert(&mut self, index: usize) {
@@ -875,7 +875,7 @@ impl<'a> ResolvedListMut<'a> {
         };
         state_tree_list
             .insert(index, value)
-            .expect("Failed to rollback set");
+            .expect("Failed to rollback delete");
     }
 
     pub(crate) fn rollback_insert(&mut self, index: usize) {

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -283,7 +283,7 @@ impl<'a> ResolvedRootMut<'a> {
         &mut self,
         key: &str,
         payload: SetOrInsertPayload<Value>,
-    ) -> LocalOperationResult {
+    ) -> (Option<MultiValue>, LocalOperationResult) {
         let newvalue = MultiValue::new_from_value_2(NewValueRequest {
             actor: payload.actor,
             start_op: payload.start_op,
@@ -298,24 +298,38 @@ impl<'a> ResolvedRootMut<'a> {
                 .unwrap_or_else(Vec::new),
         });
         let (multivalue, new_ops, _new_cursors) = newvalue.finish();
-        self.root.root_props.insert(key.to_string(), multivalue);
-        LocalOperationResult { new_ops }
+        let old = self.root.root_props.insert(key.to_string(), multivalue);
+        (old, LocalOperationResult { new_ops })
     }
 
-    pub(crate) fn delete_key(&mut self, key: &str) -> LocalOperationResult {
+    pub(crate) fn delete_key(&mut self, key: &str) -> (Option<MultiValue>, LocalOperationResult) {
         let existing_value = self.root.get(key);
         let pred = existing_value
             .map(|v| vec![v.default_opid()])
             .unwrap_or_else(Vec::new);
-        self.root.remove(key);
-        LocalOperationResult {
-            new_ops: vec![amp::Op {
-                action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
-                obj: amp::ObjectId::Root,
-                key: key.into(),
-                insert: false,
-                pred,
-            }],
+        let old = self.root.remove(key);
+        (
+            old,
+            LocalOperationResult {
+                new_ops: vec![amp::Op {
+                    action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
+                    obj: amp::ObjectId::Root,
+                    key: key.into(),
+                    insert: false,
+                    pred,
+                }],
+            },
+        )
+    }
+
+    pub(crate) fn rollback(&mut self, key: String, value: Option<MultiValue>) {
+        match value {
+            Some(old) => {
+                self.root.root_props.insert(key, old);
+            }
+            None => {
+                self.root.root_props.remove(&key);
+            }
         }
     }
 }
@@ -366,7 +380,7 @@ impl<'a> ResolvedMapMut<'a> {
         &mut self,
         key: &str,
         payload: SetOrInsertPayload<Value>,
-    ) -> LocalOperationResult {
+    ) -> (Option<MultiValue>, LocalOperationResult) {
         let state_tree_map = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Map(map)) => map,
             _ => unreachable!(),
@@ -381,24 +395,42 @@ impl<'a> ResolvedMapMut<'a> {
             pred: state_tree_map.pred_for_key(key),
         });
         let (multivalue, new_ops, _new_cursors) = newvalue.finish();
-        state_tree_map.props.insert(key.to_string(), multivalue);
-        LocalOperationResult { new_ops }
+        let old = state_tree_map.props.insert(key.to_string(), multivalue);
+        (old, LocalOperationResult { new_ops })
     }
 
-    pub(crate) fn delete_key(&mut self, key: &str) -> LocalOperationResult {
+    pub(crate) fn delete_key(&mut self, key: &str) -> (Option<MultiValue>, LocalOperationResult) {
         let state_tree_map = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Map(map)) => map,
             _ => unreachable!(),
         };
-        state_tree_map.props.remove(key);
-        LocalOperationResult {
-            new_ops: vec![amp::Op {
-                action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
-                obj: state_tree_map.object_id.clone(),
-                key: key.into(),
-                insert: false,
-                pred: state_tree_map.pred_for_key(key),
-            }],
+        let old = state_tree_map.props.remove(key);
+        (
+            old,
+            LocalOperationResult {
+                new_ops: vec![amp::Op {
+                    action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
+                    obj: state_tree_map.object_id.clone(),
+                    key: key.into(),
+                    insert: false,
+                    pred: state_tree_map.pred_for_key(key),
+                }],
+            },
+        )
+    }
+
+    pub(crate) fn rollback(&mut self, key: String, value: Option<MultiValue>) {
+        let state_tree_map = match self.multivalue.default_statetree_value_mut() {
+            StateTreeValue::Composite(StateTreeComposite::Map(map)) => map,
+            _ => unreachable!(),
+        };
+        match value {
+            Some(old) => {
+                state_tree_map.props.insert(key, old);
+            }
+            None => {
+                state_tree_map.props.remove(&key);
+            }
         }
     }
 }
@@ -418,7 +450,7 @@ impl<'a> ResolvedTableMut<'a> {
         &mut self,
         key: &str,
         payload: SetOrInsertPayload<Value>,
-    ) -> LocalOperationResult {
+    ) -> (Option<MultiValue>, LocalOperationResult) {
         let state_tree_table = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Table(map)) => map,
             _ => unreachable!(),
@@ -433,24 +465,42 @@ impl<'a> ResolvedTableMut<'a> {
             pred: state_tree_table.pred_for_key(key),
         });
         let (multivalue, new_ops, _new_cursors) = newvalue.finish();
-        state_tree_table.props.insert(key.to_owned(), multivalue);
-        LocalOperationResult { new_ops }
+        let old = state_tree_table.props.insert(key.to_owned(), multivalue);
+        (old, LocalOperationResult { new_ops })
     }
 
-    pub(crate) fn delete_key(&mut self, key: &str) -> LocalOperationResult {
+    pub(crate) fn delete_key(&mut self, key: &str) -> (Option<MultiValue>, LocalOperationResult) {
         let state_tree_table = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Table(map)) => map,
             _ => unreachable!(),
         };
-        state_tree_table.props.remove(key);
-        LocalOperationResult {
-            new_ops: vec![amp::Op {
-                action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
-                obj: state_tree_table.object_id.clone(),
-                key: key.into(),
-                insert: false,
-                pred: state_tree_table.pred_for_key(key),
-            }],
+        let old = state_tree_table.props.remove(key);
+        (
+            old,
+            LocalOperationResult {
+                new_ops: vec![amp::Op {
+                    action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
+                    obj: state_tree_table.object_id.clone(),
+                    key: key.into(),
+                    insert: false,
+                    pred: state_tree_table.pred_for_key(key),
+                }],
+            },
+        )
+    }
+
+    pub(crate) fn rollback(&mut self, key: String, value: Option<MultiValue>) {
+        let state_tree_map = match self.multivalue.default_statetree_value_mut() {
+            StateTreeValue::Composite(StateTreeComposite::Map(map)) => map,
+            _ => unreachable!(),
+        };
+        match value {
+            Some(old) => {
+                state_tree_map.props.insert(key, old);
+            }
+            None => {
+                state_tree_map.props.remove(&key);
+            }
         }
     }
 }
@@ -544,7 +594,7 @@ impl<'a> ResolvedTextMut<'a> {
         &mut self,
         index: u32,
         payload: SetOrInsertPayload<String>,
-    ) -> Result<LocalOperationResult, error::MissingIndexError> {
+    ) -> Result<(MultiGrapheme, LocalOperationResult), error::MissingIndexError> {
         let state_tree_text = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Text(text)) => text,
             _ => unreachable!(),
@@ -555,22 +605,25 @@ impl<'a> ResolvedTextMut<'a> {
         let update_op = amp::OpId::new(payload.start_op, payload.actor);
         let c = MultiGrapheme::new_from_grapheme_cluster(update_op, payload.value.clone());
         let pred = state_tree_text.pred_for_index(index as u32);
-        state_tree_text.set(index, c)?;
-        Ok(LocalOperationResult {
-            new_ops: vec![amp::Op {
-                action: amp::OpType::Set(amp::ScalarValue::Str(payload.value)),
-                obj: state_tree_text.object_id.clone(),
-                key: current_elemid.into(),
-                pred,
-                insert: false,
-            }],
-        })
+        let old = state_tree_text.set(index, c)?;
+        Ok((
+            old,
+            LocalOperationResult {
+                new_ops: vec![amp::Op {
+                    action: amp::OpType::Set(amp::ScalarValue::Str(payload.value)),
+                    obj: state_tree_text.object_id.clone(),
+                    key: current_elemid.into(),
+                    pred,
+                    insert: false,
+                }],
+            },
+        ))
     }
 
     pub(crate) fn remove(
         &mut self,
         index: u32,
-    ) -> Result<LocalOperationResult, error::MissingIndexError> {
+    ) -> Result<(MultiGrapheme, LocalOperationResult), error::MissingIndexError> {
         let state_tree_text = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Text(text)) => text,
             _ => unreachable!(),
@@ -578,16 +631,19 @@ impl<'a> ResolvedTextMut<'a> {
         let (current_elemid, _) = state_tree_text.elem_at(index.try_into().unwrap())?;
         let current_elemid = current_elemid.clone();
         let pred = state_tree_text.pred_for_index(index as u32);
-        state_tree_text.remove(index.try_into().unwrap())?;
-        Ok(LocalOperationResult {
-            new_ops: vec![amp::Op {
-                action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
-                obj: state_tree_text.object_id.clone(),
-                key: current_elemid.into(),
-                insert: false,
-                pred,
-            }],
-        })
+        let old = state_tree_text.remove(index.try_into().unwrap())?;
+        Ok((
+            old,
+            LocalOperationResult {
+                new_ops: vec![amp::Op {
+                    action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
+                    obj: state_tree_text.object_id.clone(),
+                    key: current_elemid.into(),
+                    insert: false,
+                    pred,
+                }],
+            },
+        ))
     }
 }
 
@@ -621,7 +677,7 @@ impl<'a> ResolvedListMut<'a> {
         &mut self,
         index: u32,
         payload: SetOrInsertPayload<Value>,
-    ) -> Result<LocalOperationResult, error::MissingIndexError> {
+    ) -> Result<(MultiValue, LocalOperationResult), error::MissingIndexError> {
         let state_tree_list = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::List(list)) => list,
             _ => unreachable!(),
@@ -637,8 +693,8 @@ impl<'a> ResolvedListMut<'a> {
             insert: false,
         });
         let (multivalue, new_ops, _new_cursors) = newvalue.finish();
-        state_tree_list.set(index as usize, multivalue)?;
-        Ok(LocalOperationResult { new_ops })
+        let old = state_tree_list.set(index as usize, multivalue)?;
+        Ok((old, LocalOperationResult { new_ops }))
     }
 
     #[allow(dead_code)]
@@ -721,7 +777,7 @@ impl<'a> ResolvedListMut<'a> {
     pub(crate) fn remove(
         &mut self,
         index: u32,
-    ) -> Result<LocalOperationResult, error::MissingIndexError> {
+    ) -> Result<(MultiValue, LocalOperationResult), error::MissingIndexError> {
         let state_tree_list = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::List(list)) => list,
             _ => unreachable!(),
@@ -729,16 +785,19 @@ impl<'a> ResolvedListMut<'a> {
         let (current_elemid, _) = state_tree_list.elem_at(index.try_into().unwrap())?;
         let current_elemid = current_elemid.clone();
         let pred = state_tree_list.pred_for_index(index);
-        state_tree_list.remove(index as usize)?;
-        Ok(LocalOperationResult {
-            new_ops: vec![amp::Op {
-                action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
-                obj: state_tree_list.object_id.clone(),
-                key: current_elemid.into(),
-                insert: false,
-                pred,
-            }],
-        })
+        let old = state_tree_list.remove(index as usize)?;
+        Ok((
+            old,
+            LocalOperationResult {
+                new_ops: vec![amp::Op {
+                    action: amp::OpType::Del(NonZeroU32::new(1).unwrap()),
+                    obj: state_tree_list.object_id.clone(),
+                    key: current_elemid.into(),
+                    insert: false,
+                    pred,
+                }],
+            },
+        ))
     }
 }
 

--- a/automerge-frontend/src/state_tree/resolved_path.rs
+++ b/automerge-frontend/src/state_tree/resolved_path.rs
@@ -302,12 +302,15 @@ impl<'a> ResolvedRootMut<'a> {
         (old, LocalOperationResult { new_ops })
     }
 
-    pub(crate) fn delete_key(&mut self, key: &str) -> (Option<MultiValue>, LocalOperationResult) {
+    pub(crate) fn delete_key(&mut self, key: &str) -> (MultiValue, LocalOperationResult) {
         let existing_value = self.root.get(key);
         let pred = existing_value
             .map(|v| vec![v.default_opid()])
             .unwrap_or_else(Vec::new);
-        let old = self.root.remove(key);
+        let old = self
+            .root
+            .remove(key)
+            .expect("Removing non existent key from map");
         (
             old,
             LocalOperationResult {
@@ -411,12 +414,15 @@ impl<'a> ResolvedMapMut<'a> {
         (old, LocalOperationResult { new_ops })
     }
 
-    pub(crate) fn delete_key(&mut self, key: &str) -> (Option<MultiValue>, LocalOperationResult) {
+    pub(crate) fn delete_key(&mut self, key: &str) -> (MultiValue, LocalOperationResult) {
         let state_tree_map = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Map(map)) => map,
             _ => unreachable!(),
         };
-        let old = state_tree_map.props.remove(key);
+        let old = state_tree_map
+            .props
+            .remove(key)
+            .expect("Removing non existent key from map");
         (
             old,
             LocalOperationResult {
@@ -489,12 +495,15 @@ impl<'a> ResolvedTableMut<'a> {
         (old, LocalOperationResult { new_ops })
     }
 
-    pub(crate) fn delete_key(&mut self, key: &str) -> (Option<MultiValue>, LocalOperationResult) {
+    pub(crate) fn delete_key(&mut self, key: &str) -> (MultiValue, LocalOperationResult) {
         let state_tree_table = match self.multivalue.default_statetree_value_mut() {
             StateTreeValue::Composite(StateTreeComposite::Table(map)) => map,
             _ => unreachable!(),
         };
-        let old = state_tree_table.props.remove(key);
+        let old = state_tree_table
+            .props
+            .remove(key)
+            .expect("Removing non existent key from table");
         (
             old,
             LocalOperationResult {


### PR DESCRIPTION
This implements rollback on a `MutableDocument`. This is useful to handle when the user applies a change to the document that causes an error (e.g. missing index in insert). This mainly avoids us having to clone the current state each time and lets us make the hot path quicker and cheaper.

Thankfully when we overwrite a value in the document (map or seq), including deletes, we get the old value back so we can get away with not having to clone things and this ends up just delaying the drop call until we have finished with all of our changes.

tldr: cloning a large document for each change is expensive, tracking the individual changes for rollback is much cheaper