### PR TITLE
Remove MapType from Map and add Table variant

### DIFF
--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -1,6 +1,4 @@
-use automerge_protocol::{
-    ActorId, ChangeHash, MapType, ObjectId, Op, OpId, Patch, UncompressedChange,
-};
+use automerge_protocol::{ActorId, ChangeHash, ObjectId, Op, OpId, Patch, UncompressedChange};
 
 mod error;
 mod mutation;
@@ -396,7 +394,7 @@ impl Frontend {
         initial_state: Value,
     ) -> Result<(Self, UncompressedChange), InvalidInitialStateError> {
         match &initial_state {
-            Value::Map(kvs, MapType::Map) => {
+            Value::Map(kvs) => {
                 let mut front = Frontend::new();
                 let (init_ops, _) =
                     kvs.iter()

--- a/automerge-frontend/src/mutation.rs
+++ b/automerge-frontend/src/mutation.rs
@@ -115,7 +115,7 @@ impl<'a> MutationTracker<'a> {
     /// the root object
     fn wrap_root_assignment(&mut self, value: Value) -> Result<(), InvalidChangeRequest> {
         match value {
-            Value::Map(kvs, amp::MapType::Map) => {
+            Value::Map(kvs) => {
                 for (k, v) in kvs.iter() {
                     self.add_change(LocalChange::set(Path::root().key(k), v.clone()))?;
                 }

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, convert::TryInto};
 
-use amp::{ElementId, MapType};
+use amp::ElementId;
 use automerge_protocol as amp;
 use automerge_protocol::RootDiff;
 use diffable_sequence::DiffableSequence;
@@ -172,7 +172,7 @@ impl StateTree {
         for (k, v) in &self.root_props {
             m.insert(k.clone(), v.default_value());
         }
-        Value::Map(m, MapType::Map)
+        Value::Map(m)
     }
 }
 
@@ -336,14 +336,12 @@ impl StateTreeComposite {
                     .iter()
                     .map(|(k, v)| (k.clone(), v.default_value()))
                     .collect(),
-                amp::MapType::Map,
             ),
-            Self::Table(StateTreeTable { props, .. }) => Value::Map(
+            Self::Table(StateTreeTable { props, .. }) => Value::Table(
                 props
                     .iter()
                     .map(|(k, v)| (k.clone(), v.default_value()))
                     .collect(),
-                amp::MapType::Table,
             ),
             Self::List(StateTreeList {
                 elements: elems, ..

--- a/automerge-frontend/src/state_tree/multivalue.rs
+++ b/automerge-frontend/src/state_tree/multivalue.rs
@@ -555,7 +555,8 @@ where
 {
     fn create(self, value: Value) -> NewValue {
         match value {
-            Value::Map(props, map_type) => self.new_map_or_table(props, map_type),
+            Value::Map(props) => self.new_map_or_table(props, amp::MapType::Map),
+            Value::Table(props) => self.new_map_or_table(props, amp::MapType::Table),
             Value::Sequence(values) => self.new_list(values),
             Value::Text(graphemes) => self.new_text(graphemes),
             Value::Primitive(p) => self.new_primitive(p),

--- a/automerge-frontend/tests/test_apply_patch.rs
+++ b/automerge-frontend/tests/test_apply_patch.rs
@@ -1072,9 +1072,6 @@ fn test_unchanged_diff_creates_empty_objects() {
     doc.apply_patch(patch).unwrap();
     assert_eq!(
         doc.state(),
-        &Value::Map(
-            hashmap! {"text".to_string() => Value::Text(Vec::new())},
-            amp::MapType::Map
-        ),
+        &Value::Map(hashmap! {"text".to_string() => Value::Text(Vec::new())},),
     );
 }

--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -507,22 +507,16 @@ fn handle_counters_inside_maps() {
 
     assert_eq!(
         state_after_first_change,
-        Value::Map(
-            hashmap! {
-                "wrens".into() => Value::Primitive(Primitive::Counter(0))
-            },
-            amp::MapType::Map
-        )
+        Value::Map(hashmap! {
+            "wrens".into() => Value::Primitive(Primitive::Counter(0))
+        },)
     );
 
     assert_eq!(
         state_after_second_change,
-        Value::Map(
-            hashmap! {
-                "wrens".into() => Value::Primitive(Primitive::Counter(1))
-            },
-            amp::MapType::Map
-        )
+        Value::Map(hashmap! {
+            "wrens".into() => Value::Primitive(Primitive::Counter(1))
+        },)
     );
 
     let expected_change_request_1 = amp::UncompressedChange {
@@ -595,22 +589,16 @@ fn handle_counters_inside_lists() {
 
     assert_eq!(
         state_after_first_change,
-        Value::Map(
-            hashmap! {
-                "counts".into() => vec![Value::Primitive(Primitive::Counter(1))].into()
-            },
-            amp::MapType::Map
-        )
+        Value::Map(hashmap! {
+            "counts".into() => vec![Value::Primitive(Primitive::Counter(1))].into()
+        },)
     );
 
     assert_eq!(
         state_after_second_change,
-        Value::Map(
-            hashmap! {
-                "counts".into() => vec![Value::Primitive(Primitive::Counter(3))].into()
-            },
-            amp::MapType::Map
-        )
+        Value::Map(hashmap! {
+            "counts".into() => vec![Value::Primitive(Primitive::Counter(3))].into()
+        },)
     );
 
     let counts_id = doc.get_object_id(&Path::root().key("counts")).unwrap();
@@ -738,12 +726,9 @@ fn test_sets_characters_in_text() {
     assert_eq!(request, expected_change_request);
 
     let value = doc.get_value(&Path::root()).unwrap();
-    let expected_value: Value = Value::Map(
-        hashmap! {
-            "text".into() => Value::Text(vec!["s".to_owned(), "a".to_owned(), "m".to_owned(), "e".to_owned()]),
-        },
-        amp::MapType::Map,
-    );
+    let expected_value: Value = Value::Map(hashmap! {
+        "text".into() => Value::Text(vec!["s".to_owned(), "a".to_owned(), "m".to_owned(), "e".to_owned()]),
+    });
     assert_eq!(value, expected_value);
 }
 
@@ -795,12 +780,9 @@ fn test_inserts_characters_in_text() {
     assert_eq!(request, expected_change_request);
 
     let value = doc.get_value(&Path::root()).unwrap();
-    let expected_value: Value = Value::Map(
-        hashmap! {
-            "text".into() => Value::Text(vec!["s".to_owned(), "h".to_owned(), "a".to_owned(), "m".to_owned(), "e".to_owned()]),
-        },
-        amp::MapType::Map,
-    );
+    let expected_value: Value = Value::Map(hashmap! {
+        "text".into() => Value::Text(vec!["s".to_owned(), "h".to_owned(), "a".to_owned(), "m".to_owned(), "e".to_owned()]),
+    });
     assert_eq!(value, expected_value);
 }
 
@@ -852,12 +834,9 @@ fn test_inserts_characters_at_start_of_text() {
     assert_eq!(request, expected_change_request);
 
     let value = doc.get_value(&Path::root()).unwrap();
-    let expected_value: Value = Value::Map(
-        hashmap! {
-            "text".into() => Value::Text(vec!["i".to_owned()]),
-        },
-        amp::MapType::Map,
-    );
+    let expected_value: Value = Value::Map(hashmap! {
+        "text".into() => Value::Text(vec!["i".to_owned()]),
+    });
     assert_eq!(value, expected_value);
 }
 
@@ -922,11 +901,8 @@ fn test_inserts_at_end_of_lists() {
     assert_eq!(request, expected_change_request);
 
     let value = doc.get_value(&Path::root()).unwrap();
-    let expected_value: Value = Value::Map(
-        hashmap! {
-            "birds".into() => Value::Sequence(vec!["greenfinch".into(), "bullfinch".into()]),
-        },
-        amp::MapType::Map,
-    );
+    let expected_value: Value = Value::Map(hashmap! {
+        "birds".into() => Value::Sequence(vec!["greenfinch".into(), "bullfinch".into()]),
+    });
     assert_eq!(value, expected_value);
 }

--- a/automerge/benches/crdt_benchmarks.rs
+++ b/automerge/benches/crdt_benchmarks.rs
@@ -148,7 +148,7 @@ pub fn b3_1(c: &mut Criterion) {
                     .change::<_, _, InvalidChangeRequest>(None, |d| {
                         d.add_change(LocalChange::set(
                             Path::root().key("map"),
-                            Value::Map(HashMap::new(), automerge_protocol::MapType::Map),
+                            Value::Map(HashMap::new()),
                         ))
                     })
                     .unwrap()

--- a/automerge/benches/save_load.rs
+++ b/automerge/benches/save_load.rs
@@ -1,6 +1,4 @@
-use automerge::{
-    Backend, Frontend, InvalidChangeRequest, LocalChange, MapType, Path, Primitive, Value,
-};
+use automerge::{Backend, Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn small_change_backend() -> Backend {
@@ -115,17 +113,15 @@ fn medium_change_backend() -> Backend {
                 ),
                 (
                     "\u{1}".to_owned(),
-                    Value::Map(
+                    Value::Table(
                         vec![("".to_owned(), Value::Primitive(Primitive::F64(0.0)))]
                             .into_iter()
                             .collect(),
-                        MapType::Table,
                     ),
                 ),
             ]
             .into_iter()
             .collect(),
-            MapType::Map,
         ),
     )];
     let changes2 = vec![

--- a/automerge/tests/frontend_backend_roundtrip.rs
+++ b/automerge/tests/frontend_backend_roundtrip.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use automerge::{
-    Backend, InvalidChangeRequest, LocalChange, MapType, ObjType, Path, Primitive, ScalarValue,
+    Backend, InvalidChangeRequest, LocalChange, ObjType, Path, Primitive, ScalarValue,
     SequenceType, Value,
 };
 use automerge_protocol::{ActorId, ElementId, Key, ObjectId, Op, OpType, UncompressedChange};
@@ -19,8 +19,7 @@ fn test_frontend_uses_correct_elem_ids() {
     let mut backend = automerge::Backend::new();
 
     let (mut frontend, change) =
-        automerge::Frontend::new_with_initial_state(Value::Map(hm, automerge::MapType::Map))
-            .unwrap();
+        automerge::Frontend::new_with_initial_state(Value::Map(hm)).unwrap();
 
     println!("change1 {:?}", change);
 
@@ -51,7 +50,7 @@ fn test_frontend_uses_correct_elem_ids() {
             automerge::Value::Primitive(automerge::Primitive::Boolean(false)),
         ]),
     );
-    let expected = automerge::Value::Map(ehm.clone(), automerge::MapType::Map);
+    let expected = automerge::Value::Map(ehm.clone());
 
     assert_eq!(expected, frontend.get_value(&Path::root()).unwrap());
 
@@ -62,7 +61,7 @@ fn test_frontend_uses_correct_elem_ids() {
     }
     let v = frontend.get_value(&Path::root()).unwrap();
 
-    let expected = automerge::Value::Map(ehm, automerge::MapType::Map);
+    let expected = automerge::Value::Map(ehm);
     assert_eq!(expected, v);
 }
 
@@ -112,26 +111,23 @@ fn test_multi_insert_expands_to_correct_indices() {
         extra_bytes: vec![],
     };
 
-    let val = Value::Map(
-        hashmap! {
-            "a".to_owned() => Value::Sequence(
-                vec![
-                    Value::Sequence(
-                        vec![],
+    let val = Value::Map(hashmap! {
+        "a".to_owned() => Value::Sequence(
+            vec![
+                Value::Sequence(
+                    vec![],
+                ),
+                Value::Primitive(
+                    Primitive::Null,
+                ),
+                Value::Primitive(
+                    Primitive::Uint(
+                        0
                     ),
-                    Value::Primitive(
-                        Primitive::Null,
-                    ),
-                    Value::Primitive(
-                        Primitive::Uint(
-                            0
-                        ),
-                    ),
-                ],
-            ),
-        },
-        MapType::Map,
-    );
+                ),
+            ],
+        ),
+    });
 
     let mut doc = automerge::Frontend::new_with_actor_id(uuid);
 
@@ -164,41 +160,29 @@ fn test_multi_insert_expands_to_correct_indices() {
 #[test]
 fn test_frontend_doesnt_wait_for_empty_changes() {
     let vals = vec![
-        Value::Map(hashmap! {}, MapType::Map),
-        Value::Map(
-            hashmap! {
-                "0".to_owned() => Value::Map(
-                    hashmap! {},
-                    MapType::Map,
-                ),
-                "a".to_owned() => Value::Map(
-                    hashmap!{
-                        "b".to_owned() => Value::Map(
-                            hashmap!{},
-                            MapType::Map,
-                        ),
-                    },
-                    MapType::Map,
-                ),
-            },
-            MapType::Map,
-        ),
-        Value::Map(hashmap! {}, MapType::Map),
+        Value::Map(hashmap! {}),
+        Value::Map(hashmap! {
+            "0".to_owned() => Value::Map(
+                hashmap! {},
+            ),
+            "a".to_owned() => Value::Map(
+                hashmap!{
+                    "b".to_owned() => Value::Map(
+                        hashmap!{},
+                    ),
+                },
+            ),
+        }),
+        Value::Map(hashmap! {}),
     ];
 
     let changes = vec![
         vec![],
         vec![
-            LocalChange::set(
-                Path::root().key("0"),
-                Value::Map(HashMap::new(), MapType::Map),
-            ),
+            LocalChange::set(Path::root().key("0"), Value::Map(HashMap::new())),
             LocalChange::set(
                 Path::root().key("a"),
-                Value::Map(
-                    hashmap! {"b".to_owned() => Value::Map(HashMap::new(), MapType::Map)},
-                    MapType::Map,
-                ),
+                Value::Map(hashmap! {"b".to_owned() => Value::Map(HashMap::new() )}),
             ),
         ],
         vec![

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -104,17 +104,15 @@ fn missing_object_error_flaky_null_rle_decoding() {
                 ),
                 (
                     "\u{1}".to_owned(),
-                    Value::Map(
+                    Value::Table(
                         vec![("".to_owned(), Value::Primitive(Primitive::F64(0.0)))]
                             .into_iter()
                             .collect(),
-                        MapType::Table,
                     ),
                 ),
             ]
             .into_iter()
             .collect(),
-            MapType::Map,
         ),
     )];
     let changes2 = vec![

--- a/automerge/tests/text_grapheme_clusters.rs
+++ b/automerge/tests/text_grapheme_clusters.rs
@@ -7,11 +7,8 @@ fn create_frontend_with_grapheme_clusters() {
         String::new(),
         automerge::Value::Text("\u{80}".graphemes(true).map(|s| s.to_owned()).collect()),
     );
-    let (mut f, c) = automerge::Frontend::new_with_initial_state(automerge::Value::Map(
-        hm,
-        automerge::MapType::Map,
-    ))
-    .unwrap();
+    let (mut f, c) =
+        automerge::Frontend::new_with_initial_state(automerge::Value::Map(hm)).unwrap();
     let mut b = automerge::Backend::new();
     let (p, _) = b.apply_local_change(c).unwrap();
     f.apply_patch(p).unwrap();

--- a/perf/src/main.rs
+++ b/perf/src/main.rs
@@ -6,7 +6,6 @@ use std::{
 
 use automerge::{Backend, Frontend, InvalidChangeRequest, LocalChange, Path, Primitive};
 use automerge_frontend::Value;
-use automerge_protocol::MapType;
 use maplit::hashmap;
 use rand::Rng;
 
@@ -24,10 +23,9 @@ fn f() {
                 hashmap! {
                     "abc".to_owned() => Value::Primitive(Primitive::Str("hello world".to_owned()))
                 },
-                MapType::Map,
             ),
             "d".to_owned() => Value::Primitive(Primitive::Uint(20)),
-        },MapType::Map)
+        },)
     };
 
     let mut changes = Vec::new();
@@ -45,7 +43,7 @@ fn f() {
             .change::<_, _, InvalidChangeRequest>(None, |d| {
                 d.add_change(LocalChange::set(
                     Path::root().key(random_string),
-                    Value::Map(m.clone(), MapType::Map),
+                    Value::Map(m.clone()),
                 ))
             })
             .unwrap()


### PR DESCRIPTION
This simplifies the `Value` enum and hides the protocol internals from the
variants.

Fixes #158 