### PR TITLE
Rename UncompressedChange to Change

### DIFF
--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use automerge_backend::{AutomergeError, Backend, Change, SyncMessage, SyncState};
-use automerge_protocol::{ChangeHash, UncompressedChange};
+use automerge_protocol as amp;
+use automerge_protocol::ChangeHash;
 use js_sys::Array;
 use serde::{de::DeserializeOwned, Serialize};
 use types::{BinaryChange, BinaryDocument, BinarySyncMessage, BinarySyncState, RawSyncMessage};
@@ -127,7 +128,7 @@ pub fn free(input: Object) -> Result<(), JsValue> {
 pub fn apply_local_change(input: Object, change: JsValue) -> Result<JsValue, JsValue> {
     get_mut_input(input, |state| {
         // FIXME unwrap
-        let change: UncompressedChange = js_to_rust(&change).unwrap();
+        let change: amp::Change = js_to_rust(&change).unwrap();
         let (patch, change) = state.0.apply_local_change(change)?;
         let result = Array::new();
         let change_bytes = types::BinaryChange(change.raw_bytes().to_vec());

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -107,7 +107,7 @@ impl Backend {
 
     pub fn apply_local_change(
         &mut self,
-        mut change: amp::UncompressedChange,
+        mut change: amp::Change,
     ) -> Result<(amp::Patch, Change), AutomergeError> {
         self.check_for_duplicate(&change)?; // Change has already been applied
 
@@ -126,7 +126,7 @@ impl Backend {
         Ok((patch, bin_change))
     }
 
-    fn check_for_duplicate(&self, change: &amp::UncompressedChange) -> Result<(), AutomergeError> {
+    fn check_for_duplicate(&self, change: &amp::Change) -> Result<(), AutomergeError> {
         if self
             .states
             .get(&change.actor_id)
@@ -311,8 +311,7 @@ impl Backend {
     }
 
     pub fn save(&self) -> Result<Vec<u8>, AutomergeError> {
-        let changes: Vec<amp::UncompressedChange> =
-            self.history.iter().map(Change::decode).collect();
+        let changes: Vec<amp::Change> = self.history.iter().map(Change::decode).collect();
         //self.history.iter().map(|change| change.decode()).collect();
         Ok(encode_document(&changes)?)
     }
@@ -463,7 +462,7 @@ impl Backend {
 mod tests {
     use std::convert::TryInto;
 
-    use automerge_protocol::{ActorId, ObjectId, Op, OpType, UncompressedChange};
+    use automerge_protocol::{ActorId, ObjectId, Op, OpType};
 
     use super::*;
 
@@ -471,7 +470,7 @@ mod tests {
     fn test_get_changes_fast_behavior() {
         let actor_a: ActorId = "7b7723afd9e6480397a4d467b7693156".try_into().unwrap();
         let actor_b: ActorId = "37704788917a499cb0206fa8519ac4d9".try_into().unwrap();
-        let change_a1: Change = UncompressedChange {
+        let change_a1: Change = amp::Change {
             actor_id: actor_a.clone(),
             seq: 1,
             start_op: 1,
@@ -490,7 +489,7 @@ mod tests {
         }
         .try_into()
         .unwrap();
-        let change_a2: Change = UncompressedChange {
+        let change_a2: Change = amp::Change {
             actor_id: actor_a,
             seq: 2,
             start_op: 2,
@@ -509,7 +508,7 @@ mod tests {
         }
         .try_into()
         .unwrap();
-        let change_b1: Change = UncompressedChange {
+        let change_b1: Change = amp::Change {
             actor_id: actor_b.clone(),
             seq: 1,
             start_op: 1,
@@ -528,7 +527,7 @@ mod tests {
         }
         .try_into()
         .unwrap();
-        let change_b2: Change = UncompressedChange {
+        let change_b2: Change = amp::Change {
             actor_id: actor_b.clone(),
             seq: 2,
             start_op: 2,
@@ -547,7 +546,7 @@ mod tests {
         }
         .try_into()
         .unwrap();
-        let change_b3: Change = UncompressedChange {
+        let change_b3: Change = amp::Change {
             actor_id: actor_b,
             seq: 3,
             start_op: 3,

--- a/automerge-backend/src/columnar.rs
+++ b/automerge-backend/src/columnar.rs
@@ -798,7 +798,7 @@ impl ChangeEncoder {
     #[instrument(level = "debug", skip(changes, actors))]
     pub fn encode_changes<'a, 'b, I>(changes: I, actors: &'a [amp::ActorId]) -> (Vec<u8>, Vec<u8>)
     where
-        I: IntoIterator<Item = &'b amp::UncompressedChange>,
+        I: IntoIterator<Item = &'b amp::Change>,
     {
         let mut e = Self::new();
         e.encode(changes, actors);
@@ -821,7 +821,7 @@ impl ChangeEncoder {
 
     fn encode<'a, 'b, 'c, I>(&'a mut self, changes: I, actors: &'b [amp::ActorId])
     where
-        I: IntoIterator<Item = &'c amp::UncompressedChange>,
+        I: IntoIterator<Item = &'c amp::Change>,
     {
         let mut index_by_hash: HashMap<amp::ChangeHash, usize> = HashMap::new();
         for (index, change) in changes.into_iter().enumerate() {

--- a/automerge-backend/tests/apply_change.rs
+++ b/automerge-backend/tests/apply_change.rs
@@ -6,7 +6,7 @@ use automerge_backend::{AutomergeError, Backend, Change};
 use automerge_protocol as amp;
 use automerge_protocol::{
     ActorId, CursorDiff, Diff, DiffEdit, ElementId, MapDiff, MapType, ObjectId, Op, Patch,
-    ScalarValue, SeqDiff, SequenceType, UncompressedChange,
+    ScalarValue, SeqDiff, SequenceType,
 };
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
@@ -14,7 +14,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn test_incremental_diffs_in_a_map() {
     let actor: ActorId = "7b7723afd9e6480397a4d467b7693156".try_into().unwrap();
-    let change: Change = UncompressedChange {
+    let change: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -53,7 +53,7 @@ fn test_incremental_diffs_in_a_map() {
 #[test]
 fn test_bytes() {
     let actor: ActorId = "7b7723afd9e6480397a4d467b7693156".try_into().unwrap();
-    let change: Change = UncompressedChange {
+    let change: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -96,7 +96,7 @@ fn test_bytes() {
 #[test]
 fn test_increment_key_in_map() {
     let actor: ActorId = "cdee6963c1664645920be8b41a933c2b".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -116,7 +116,7 @@ fn test_increment_key_in_map() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 2,
@@ -159,7 +159,7 @@ fn test_increment_key_in_map() {
 #[test]
 fn test_conflict_on_assignment_to_same_map_key() {
     let actor_1 = ActorId::from_str("ac11").unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor_1.clone(),
         seq: 1,
         message: None,
@@ -180,7 +180,7 @@ fn test_conflict_on_assignment_to_same_map_key() {
     .unwrap();
 
     let actor_2 = ActorId::from_str("ac22").unwrap();
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor_2.clone(),
         start_op: 2,
         seq: 1,
@@ -229,7 +229,7 @@ fn test_conflict_on_assignment_to_same_map_key() {
 #[test]
 fn delete_key_from_map() {
     let actor: ActorId = "cd86c07f109348f494af5be30fdc4c71".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -249,7 +249,7 @@ fn delete_key_from_map() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 2,
@@ -292,7 +292,7 @@ fn delete_key_from_map() {
 #[test]
 fn create_nested_maps() {
     let actor: ActorId = "d6226fcd55204b82b396f2473da3e26f".try_into().unwrap();
-    let change: Change = UncompressedChange {
+    let change: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -353,7 +353,7 @@ fn create_nested_maps() {
 #[test]
 fn test_assign_to_nested_keys_in_map() {
     let actor: ActorId = "3c39c994039042778f4779a01a59a917".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -382,7 +382,7 @@ fn test_assign_to_nested_keys_in_map() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 3,
@@ -437,7 +437,7 @@ fn test_assign_to_nested_keys_in_map() {
 #[test]
 fn test_create_lists() {
     let actor: ActorId = "f82cb62dabe64372ab87466b77792010".try_into().unwrap();
-    let change: Change = UncompressedChange {
+    let change: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -502,7 +502,7 @@ fn test_create_lists() {
 #[test]
 fn test_apply_updates_inside_lists() {
     let actor: ActorId = "4ee4a0d033b841c4b26d73d70a879547".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -531,7 +531,7 @@ fn test_apply_updates_inside_lists() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 3,
@@ -586,7 +586,7 @@ fn test_apply_updates_inside_lists() {
 #[test]
 fn test_delete_list_elements() {
     let actor: ActorId = "8a3d4716fdca49f4aa5835901f2034c7".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -615,7 +615,7 @@ fn test_delete_list_elements() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 3,
@@ -666,7 +666,7 @@ fn test_delete_list_elements() {
 #[test]
 fn test_handle_list_element_insertion_and_deletion_in_same_change() {
     let actor: ActorId = "ca95bc759404486bbe7b9dd2be779fa8".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -686,7 +686,7 @@ fn test_handle_list_element_insertion_and_deletion_in_same_change() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 2,
@@ -755,7 +755,7 @@ fn test_handle_list_element_insertion_and_deletion_in_same_change() {
 fn test_handle_changes_within_conflicted_objects() {
     let actor1: ActorId = "9f17517523e54ee888e9cd51dfd7a572".try_into().unwrap();
     let actor2: ActorId = "83768a19a13842beb6dde8c68a662fad".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor1.clone(),
         seq: 1,
         start_op: 1,
@@ -775,7 +775,7 @@ fn test_handle_changes_within_conflicted_objects() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor2.clone(),
         seq: 1,
         start_op: 1,
@@ -795,7 +795,7 @@ fn test_handle_changes_within_conflicted_objects() {
     .try_into()
     .unwrap();
 
-    let change3: Change = UncompressedChange {
+    let change3: Change = amp::Change {
         actor_id: actor2.clone(),
         seq: 2,
         start_op: 2,
@@ -858,7 +858,7 @@ fn test_handle_changes_within_conflicted_objects() {
 fn test_handle_changes_within_conflicted_lists() {
     let actor1: ActorId = "01234567".try_into().unwrap();
     let actor2: ActorId = "89abcdef".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor1.clone(),
         seq: 1,
         start_op: 1,
@@ -887,7 +887,7 @@ fn test_handle_changes_within_conflicted_lists() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor1.clone(),
         seq: 2,
         start_op: 3,
@@ -923,7 +923,7 @@ fn test_handle_changes_within_conflicted_lists() {
     .try_into()
     .unwrap();
 
-    let change3: Change = UncompressedChange {
+    let change3: Change = amp::Change {
         actor_id: actor2.clone(),
         seq: 1,
         start_op: 3,
@@ -962,7 +962,7 @@ fn test_handle_changes_within_conflicted_lists() {
     let mut change4_deps = vec![change2.hash, change3.hash];
     change4_deps.sort();
 
-    let change4: Change = UncompressedChange {
+    let change4: Change = amp::Change {
         actor_id: actor1.clone(),
         seq: 3,
         start_op: 6,
@@ -1040,7 +1040,7 @@ fn test_handle_changes_within_conflicted_lists() {
 #[test]
 fn test_support_date_objects_at_root() {
     let actor: ActorId = "955afa3bbcc140b3b4bac8836479d650".try_into().unwrap();
-    let change: Change = UncompressedChange {
+    let change: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -1086,7 +1086,7 @@ fn test_support_date_objects_at_root() {
 #[test]
 fn test_support_date_objects_in_a_list() {
     let actor: ActorId = "27d467ecb1a640fb9bed448ce7cf6a44".try_into().unwrap();
-    let change: Change = UncompressedChange {
+    let change: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -1150,7 +1150,7 @@ fn test_support_date_objects_in_a_list() {
 #[test]
 fn test_cursor_objects() {
     let actor = ActorId::random();
-    let change = UncompressedChange {
+    let change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -1225,7 +1225,7 @@ fn test_cursor_objects() {
 #[test]
 fn test_throws_on_attempt_to_create_missing_cursor() {
     let actor = ActorId::random();
-    let change = UncompressedChange {
+    let change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -1262,7 +1262,7 @@ fn test_throws_on_attempt_to_create_missing_cursor() {
 #[test]
 fn test_updating_sequences_updates_referring_cursors() {
     let actor = ActorId::random();
-    let change1 = UncompressedChange {
+    let change1 = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -1296,7 +1296,7 @@ fn test_updating_sequences_updates_referring_cursors() {
         extra_bytes: Vec::new(),
     };
     let binchange1: Change = (&change1).try_into().unwrap();
-    let change2 = UncompressedChange {
+    let change2 = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 4,
@@ -1356,7 +1356,7 @@ fn test_updating_sequences_updates_referring_cursors() {
 #[test]
 fn test_updating_sequences_updates_referring_cursors_with_deleted_items() {
     let actor = ActorId::random();
-    let change1 = UncompressedChange {
+    let change1 = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -1397,7 +1397,7 @@ fn test_updating_sequences_updates_referring_cursors_with_deleted_items() {
         extra_bytes: Vec::new(),
     };
     let binchange1: Change = (&change1).try_into().unwrap();
-    let change2 = UncompressedChange {
+    let change2 = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 5,

--- a/automerge-backend/tests/get_patch.rs
+++ b/automerge-backend/tests/get_patch.rs
@@ -6,7 +6,7 @@ use automerge_backend::{Backend, Change};
 use automerge_protocol as amp;
 use automerge_protocol::{
     ActorId, Diff, DiffEdit, ElementId, MapDiff, MapType, ObjectId, Op, Patch, ScalarValue,
-    SeqDiff, SequenceType, UncompressedChange,
+    SeqDiff, SequenceType,
 };
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
@@ -14,7 +14,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn test_include_most_recent_value_for_key() {
     let actor: ActorId = "ec28cfbcdb9e4f32ad24b3c776e651b0".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -34,7 +34,7 @@ fn test_include_most_recent_value_for_key() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 2,
@@ -82,7 +82,7 @@ fn test_include_most_recent_value_for_key() {
 fn test_includes_conflicting_values_for_key() {
     let actor1: ActorId = "111111".try_into().unwrap();
     let actor2: ActorId = "222222".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor1.clone(),
         seq: 1,
         start_op: 1,
@@ -102,7 +102,7 @@ fn test_includes_conflicting_values_for_key() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor2.clone(),
         seq: 1,
         start_op: 1,
@@ -151,7 +151,7 @@ fn test_includes_conflicting_values_for_key() {
 #[test]
 fn test_handles_counter_increment_at_keys_in_a_map() {
     let actor: ActorId = "46c92088e4484ae5945dc63bf606a4a5".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -171,7 +171,7 @@ fn test_handles_counter_increment_at_keys_in_a_map() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 2,
@@ -218,7 +218,7 @@ fn test_handles_counter_increment_at_keys_in_a_map() {
 #[test]
 fn test_creates_nested_maps() {
     let actor: ActorId = "06148f9422cb40579fd02f1975c34a51".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -247,7 +247,7 @@ fn test_creates_nested_maps() {
     .try_into()
     .unwrap();
 
-    let change2: Change = UncompressedChange {
+    let change2: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 2,
         start_op: 3,
@@ -311,7 +311,7 @@ fn test_creates_nested_maps() {
 #[test]
 fn test_create_lists() {
     let actor: ActorId = "90bf7df682f747fa82ac604b35010906".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -376,7 +376,7 @@ fn test_create_lists() {
 #[test]
 fn test_includes_latests_state_of_list() {
     let actor: ActorId = "6caaa2e433de42ae9c3fa65c9ff3f03e".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -466,7 +466,7 @@ fn test_includes_latests_state_of_list() {
 #[test]
 fn test_includes_date_objects_at_root() {
     let actor: ActorId = "90f5dd5d4f524e95ad5929e08d1194f1".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -513,7 +513,7 @@ fn test_includes_date_objects_at_root() {
 #[test]
 fn test_includes_date_objects_in_a_list() {
     let actor: ActorId = "08b050f976a249349021a2e63d99c8e8".try_into().unwrap();
-    let change1: Change = UncompressedChange {
+    let change1: Change = amp::Change {
         actor_id: actor.clone(),
         seq: 1,
         start_op: 1,
@@ -580,7 +580,7 @@ fn test_includes_updates_for_conflicting_list_elements() {
     let local_actor = ActorId::random();
     let actor1: ActorId = "da45d93f2b18456f8318c723d1430563".try_into().unwrap();
     let actor2: ActorId = "6caaa2e433de42ae9c3fa65c9ff3f03e".try_into().unwrap();
-    let local_change = UncompressedChange {
+    let local_change = amp::Change {
         actor_id: local_actor.clone(),
         seq: 1,
         start_op: 1,
@@ -608,7 +608,7 @@ fn test_includes_updates_for_conflicting_list_elements() {
     };
     let binchange: Change = local_change.clone().try_into().unwrap();
 
-    let remote_change_1: Change = UncompressedChange {
+    let remote_change_1: Change = amp::Change {
         actor_id: actor1.clone(),
         seq: 1,
         start_op: 1,
@@ -628,7 +628,7 @@ fn test_includes_updates_for_conflicting_list_elements() {
     .try_into()
     .unwrap();
 
-    let remote_change_2: Change = UncompressedChange {
+    let remote_change_2: Change = amp::Change {
         actor_id: actor2.clone(),
         seq: 1,
         start_op: 1,

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -13,7 +13,8 @@ use std::{
 };
 
 use automerge_backend::{AutomergeError, Change};
-use automerge_protocol::{ChangeHash, UncompressedChange};
+use automerge_protocol as amp;
+use automerge_protocol::ChangeHash;
 use errno::{set_errno, Errno};
 use serde::ser::Serialize;
 
@@ -189,7 +190,7 @@ pub unsafe extern "C" fn automerge_apply_local_change(
 ) -> isize {
     let request: &CStr = CStr::from_ptr(request);
     let request = request.to_string_lossy();
-    let request: Result<UncompressedChange, _> = serde_json::from_str(&request);
+    let request: Result<amp::Change, _> = serde_json::from_str(&request);
     match request {
         Ok(request) => {
             let result = (*backend).apply_local_change(request);
@@ -332,7 +333,7 @@ pub unsafe extern "C" fn automerge_encode_change(
 ) -> isize {
     let change: &CStr = CStr::from_ptr(change);
     let change = change.to_string_lossy();
-    let uncomp_change: UncompressedChange = serde_json::from_str(&change).unwrap();
+    let uncomp_change: amp::Change = serde_json::from_str(&change).unwrap();
     let change: Change = uncomp_change.try_into().unwrap();
     (*backend).handle_binary(Ok(change.raw_bytes().into()))
 }

--- a/automerge-cli/src/examine.rs
+++ b/automerge-cli/src/examine.rs
@@ -1,5 +1,5 @@
 use automerge_backend as amb;
-use automerge_protocol::UncompressedChange;
+use automerge_protocol as amp;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -32,8 +32,7 @@ pub fn examine(
         .map_err(|e| ExamineError::ErrReadingChanges { source: e })?;
     let changes = amb::Change::load_document(&buf)
         .map_err(|e| ExamineError::ErrApplyingInitialChanges { source: e })?;
-    let uncompressed_changes: Vec<UncompressedChange> =
-        changes.iter().map(|c| c.decode()).collect();
+    let uncompressed_changes: Vec<amp::Change> = changes.iter().map(|c| c.decode()).collect();
     if is_tty {
         let json_changes = serde_json::to_value(uncompressed_changes).unwrap();
         colored_json::write_colored_json(&json_changes, &mut output).unwrap();

--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -1,4 +1,5 @@
-use automerge_protocol::{ActorId, ChangeHash, ObjectId, Op, OpId, Patch, UncompressedChange};
+use automerge_protocol as amp;
+use automerge_protocol::{ActorId, ChangeHash, ObjectId, Op, OpId, Patch};
 
 mod error;
 mod mutation;
@@ -392,7 +393,7 @@ impl Frontend {
     #[cfg(feature = "std")]
     pub fn new_with_initial_state(
         initial_state: Value,
-    ) -> Result<(Self, UncompressedChange), InvalidInitialStateError> {
+    ) -> Result<(Self, amp::Change), InvalidInitialStateError> {
         match &initial_state {
             Value::Map(kvs) => {
                 let mut front = Frontend::new();
@@ -411,7 +412,7 @@ impl Frontend {
                             (ops, max_op)
                         });
 
-                let init_change_request = UncompressedChange {
+                let init_change_request = amp::Change {
                     actor_id: front.actor_id.clone(),
                     start_op: 1,
                     time: (front.timestamper)().unwrap_or(0),
@@ -449,7 +450,7 @@ impl Frontend {
         &mut self,
         message: Option<String>,
         change_closure: F,
-    ) -> Result<(O, Option<UncompressedChange>), E>
+    ) -> Result<(O, Option<amp::Change>), E>
     where
         E: Error,
         F: FnOnce(&mut dyn MutableDocument) -> Result<O, E>,
@@ -461,7 +462,7 @@ impl Frontend {
         self.cached_value = None;
         if !change_result.ops.is_empty() {
             self.seq += 1;
-            let change = UncompressedChange {
+            let change = amp::Change {
                 start_op,
                 actor_id: self.actor_id.clone(),
                 seq: self.seq,

--- a/automerge-frontend/tests/test_backend_concurrency.rs
+++ b/automerge-frontend/tests/test_backend_concurrency.rs
@@ -56,7 +56,7 @@ fn use_version_and_sequence_number_from_backend() {
         .1
         .unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id,
         seq: 5,
         start_op: 5,
@@ -500,7 +500,7 @@ fn allow_interleaving_of_patches_and_changes() {
 
     assert_eq!(
         req1,
-        amp::UncompressedChange {
+        amp::Change {
             actor_id: doc.actor_id.clone(),
             seq: 1,
             start_op: 1,
@@ -521,7 +521,7 @@ fn allow_interleaving_of_patches_and_changes() {
 
     assert_eq!(
         req2,
-        amp::UncompressedChange {
+        amp::Change {
             actor_id: doc.actor_id.clone(),
             seq: 2,
             start_op: 2,
@@ -558,7 +558,7 @@ fn allow_interleaving_of_patches_and_changes() {
 
     assert_eq!(
         req3,
-        amp::UncompressedChange {
+        amp::Change {
             actor_id: doc.actor_id.clone(),
             seq: 3,
             start_op: 3,
@@ -653,7 +653,7 @@ fn test_deps_are_filled_in_if_frontend_does_not_have_latest_patch() {
         .1
         .unwrap();
 
-    let expected_change2 = amp::UncompressedChange {
+    let expected_change2 = amp::Change {
         actor_id: doc2.actor_id.clone(),
         start_op: 2,
         seq: 1,
@@ -672,7 +672,7 @@ fn test_deps_are_filled_in_if_frontend_does_not_have_latest_patch() {
     };
     assert_eq!(change2, expected_change2);
 
-    let expected_change3 = amp::UncompressedChange {
+    let expected_change3 = amp::Change {
         actor_id: doc2.actor_id.clone(),
         start_op: 3,
         seq: 2,
@@ -714,7 +714,7 @@ fn test_deps_are_filled_in_if_frontend_does_not_have_latest_patch() {
         .1
         .unwrap();
 
-    let expected_change4 = amp::UncompressedChange {
+    let expected_change4 = amp::Change {
         actor_id: doc2.actor_id.clone(),
         start_op: 4,
         seq: 3,

--- a/automerge-frontend/tests/test_frontend.rs
+++ b/automerge-frontend/tests/test_frontend.rs
@@ -61,7 +61,7 @@ fn test_set_root_object_properties() {
             cr.time = 0;
             cr
         });
-    let expected_change = amp::UncompressedChange {
+    let expected_change = amp::Change {
         actor_id: doc.actor_id,
         start_op: 1,
         seq: 1,
@@ -99,7 +99,7 @@ fn test_set_bytes() {
             cr.time = 0;
             cr
         });
-    let expected_change = amp::UncompressedChange {
+    let expected_change = amp::Change {
         actor_id: doc.actor_id,
         start_op: 1,
         seq: 1,
@@ -146,7 +146,7 @@ fn it_should_create_nested_maps() {
         .1
         .unwrap();
     let birds_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
-    let expected_change = amp::UncompressedChange {
+    let expected_change = amp::Change {
         actor_id: doc.actor_id,
         start_op: 1,
         seq: 1,
@@ -222,7 +222,7 @@ fn apply_updates_inside_nested_maps() {
     );
     let birds_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id,
         seq: 2,
         start_op: 3,
@@ -281,7 +281,7 @@ fn delete_keys_in_a_map() {
         }))
     );
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 3,
@@ -338,7 +338,7 @@ fn create_lists() {
 
     let birds_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id,
         seq: 1,
         start_op: 1,
@@ -404,7 +404,7 @@ fn apply_updates_inside_lists() {
 
     let birds_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 3,
@@ -458,7 +458,7 @@ fn delete_list_elements() {
 
     let birds_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 4,
@@ -519,7 +519,7 @@ fn handle_counters_inside_maps() {
         },)
     );
 
-    let expected_change_request_1 = amp::UncompressedChange {
+    let expected_change_request_1 = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 1,
         start_op: 1,
@@ -538,7 +538,7 @@ fn handle_counters_inside_maps() {
     };
     assert_eq!(req1, expected_change_request_1);
 
-    let expected_change_request_2 = amp::UncompressedChange {
+    let expected_change_request_2 = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 2,
@@ -603,7 +603,7 @@ fn handle_counters_inside_lists() {
 
     let counts_id = doc.get_object_id(&Path::root().key("counts")).unwrap();
 
-    let expected_change_request_1 = amp::UncompressedChange {
+    let expected_change_request_1 = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 1,
         time: req1.time,
@@ -631,7 +631,7 @@ fn handle_counters_inside_lists() {
     };
     assert_eq!(req1, expected_change_request_1);
 
-    let expected_change_request_2 = amp::UncompressedChange {
+    let expected_change_request_2 = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 3,
@@ -706,7 +706,7 @@ fn test_sets_characters_in_text() {
 
     let text_id = doc.get_object_id(&Path::root().key("text")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 6,
@@ -760,7 +760,7 @@ fn test_inserts_characters_in_text() {
 
     let text_id = doc.get_object_id(&Path::root().key("text")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 6,
@@ -814,7 +814,7 @@ fn test_inserts_characters_at_start_of_text() {
 
     let text_id = doc.get_object_id(&Path::root().key("text")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 2,
@@ -872,7 +872,7 @@ fn test_inserts_at_end_of_lists() {
 
     let list_id = doc.get_object_id(&Path::root().key("birds")).unwrap();
 
-    let expected_change_request = amp::UncompressedChange {
+    let expected_change_request = amp::Change {
         actor_id: doc.actor_id.clone(),
         seq: 2,
         start_op: 2,

--- a/automerge-frontend/tests/test_mutation.rs
+++ b/automerge-frontend/tests/test_mutation.rs
@@ -64,7 +64,7 @@ fn test_multiple_primitive_inserts() {
 
     assert_eq!(
         cr,
-        amp::UncompressedChange {
+        amp::Change {
             message: None,
             seq: 1,
             actor_id: frontend.actor_id.clone(),
@@ -118,7 +118,7 @@ fn test_multiple_non_primitive_inserts() {
 
     assert_eq!(
         cr,
-        amp::UncompressedChange {
+        amp::Change {
             message: None,
             seq: 1,
             actor_id: actor.clone(),

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -497,7 +497,7 @@ pub struct RootDiff {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct UncompressedChange {
+pub struct Change {
     #[serde(rename = "ops")]
     pub operations: Vec<Op>,
     #[serde(rename = "actor")]
@@ -514,7 +514,7 @@ pub struct UncompressedChange {
     pub extra_bytes: Vec<u8>,
 }
 
-impl PartialEq for UncompressedChange {
+impl PartialEq for Change {
     // everything but hash (its computed and not always present)
     fn eq(&self, other: &Self) -> bool {
         self.operations == other.operations
@@ -528,7 +528,7 @@ impl PartialEq for UncompressedChange {
     }
 }
 
-impl UncompressedChange {
+impl Change {
     pub fn op_id_of(&self, index: u64) -> Option<OpId> {
         if let Ok(index_usize) = usize::try_from(index) {
             if index_usize < self.operations.len() {

--- a/automerge-protocol/tests/serde_round_trip_proptest.rs
+++ b/automerge-protocol/tests/serde_round_trip_proptest.rs
@@ -102,8 +102,8 @@ prop_compose! {
              message in proptest::option::of(any::<String>()),
              deps in proptest::collection::vec(arb_changehash(), 0..10),
              extra_bytes in proptest::collection::vec(any::<u8>(), 0..10),
-             operations in proptest::collection::vec(arb_op(), 0..10)) -> amp::UncompressedChange {
-            amp::UncompressedChange{
+             operations in proptest::collection::vec(arb_op(), 0..10)) -> amp::Change {
+            amp::Change{
                 seq,
                 actor_id,
                 start_op,
@@ -126,7 +126,7 @@ enum Mode {
 /// This means that inputs with f32 values will round trip into 64 bit floats, and any
 /// positive i64's will round trip into u64's. This function performs that normalisation on an
 /// existing change so  it can be compared with a round tripped change.
-fn normalize_change(change: &amp::UncompressedChange, mode: Mode) -> amp::UncompressedChange {
+fn normalize_change(change: &amp::Change, mode: Mode) -> amp::Change {
     let mut result = change.clone();
     for op in result.operations.iter_mut() {
         let new_action = match &op.action {
@@ -169,14 +169,14 @@ proptest! {
     #[test]
     fn test_round_trip_serialization_json(change in arb_change()) {
         let serialized = serde_json::to_string(&change)?;
-        let deserialized: amp::UncompressedChange = serde_json::from_str(&serialized)?;
+        let deserialized: amp::Change = serde_json::from_str(&serialized)?;
         prop_assert_eq!(normalize_change(&change, Mode::Json), deserialized);
     }
 
     #[test]
     fn test_round_trip_serialization_msgpack(change in arb_change()) {
         let serialized = rmp_serde::to_vec_named(&change).unwrap();
-        let deserialized: amp::UncompressedChange = rmp_serde::from_slice(&serialized)?;
+        let deserialized: amp::Change = rmp_serde::from_slice(&serialized)?;
         prop_assert_eq!(normalize_change(&change, Mode::MessagePack), deserialized);
     }
 }

--- a/automerge/tests/frontend_backend_roundtrip.rs
+++ b/automerge/tests/frontend_backend_roundtrip.rs
@@ -4,7 +4,8 @@ use automerge::{
     Backend, InvalidChangeRequest, LocalChange, ObjType, Path, Primitive, ScalarValue,
     SequenceType, Value,
 };
-use automerge_protocol::{ActorId, ElementId, Key, ObjectId, Op, OpType, UncompressedChange};
+use automerge_protocol as amp;
+use automerge_protocol::{ActorId, ElementId, Key, ObjectId, Op, OpType};
 use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use test_env_log::test;
@@ -70,7 +71,7 @@ fn test_multi_insert_expands_to_correct_indices() {
     let uuid = uuid::Uuid::new_v4();
     let actor = ActorId::from_bytes(uuid.as_bytes());
 
-    let change = UncompressedChange {
+    let change = amp::Change {
         operations: vec![
             Op {
                 action: OpType::Make(ObjType::Sequence(SequenceType::List)),

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -1,9 +1,9 @@
 use automerge::{
     Backend, Frontend, InvalidChangeRequest, LocalChange, MapType, Path, Primitive, Value,
 };
+use automerge_protocol as amp;
 use automerge_protocol::{
     ActorId, ElementId, Key, ObjType, ObjectId, Op, OpId, OpType, ScalarValue, SequenceType,
-    UncompressedChange,
 };
 use test_env_log::test;
 
@@ -196,7 +196,7 @@ fn missing_object_error_null_rle_decoding() {
     let actor_uuid = uuid::Uuid::new_v4();
     let actor_id = ActorId::from_bytes(actor_uuid.as_bytes());
 
-    let raw_change = UncompressedChange {
+    let raw_change = amp::Change {
         operations: vec![
             Op {
                 action: OpType::Make(ObjType::Sequence(SequenceType::List)),


### PR DESCRIPTION
It wasn't really uncompressed as we have compressed and uncompressed
changes in the backend. It is just not encoded into the binary format.
The module separation (protocol vs backend) should help with the
distinction.

Fixes #114 