### PR TITLE
Use tinyvec for actor id

### DIFF
--- a/automerge-backend/src/expanded_op.rs
+++ b/automerge-backend/src/expanded_op.rs
@@ -137,7 +137,7 @@ impl<'a> ExpandedOpIterator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::TryInto, num::NonZeroU32};
+    use std::{convert::TryInto, num::NonZeroU32, str::FromStr};
 
     use amp::{ObjectId, Op, OpType, ScalarValue, SortedVec};
     use pretty_assertions::assert_eq;
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn expand_multi_set() {
-        let actor = ActorId::from_bytes(b"7f12a4d3567c4257af34f216aa16fe48");
+        let actor = ActorId::from_str("7f12a4d3567c4257af34f216aa16fe48").unwrap();
         let ops = [Op {
             action: OpType::MultiSet(
                 vec![
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn expand_multi_set_double() {
-        let actor = ActorId::from_bytes(b"7f12a4d3567c4257af34f216aa16fe48");
+        let actor = ActorId::from_str("7f12a4d3567c4257af34f216aa16fe48").unwrap();
         let ops = [
             Op {
                 action: OpType::MultiSet(
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn expand_multi_del() {
-        let actor = ActorId::from_bytes(b"7f12a4d3567c4257af34f216aa16fe48");
+        let actor = ActorId::from_str("7f12a4d3567c4257af34f216aa16fe48").unwrap();
         let pred = OpId(1, actor.clone());
         let ops = [Op {
             action: OpType::Del(NonZeroU32::new(3).unwrap()),

--- a/automerge-frontend/src/lib.rs
+++ b/automerge-frontend/src/lib.rs
@@ -383,7 +383,7 @@ impl Frontend {
     ) -> Self {
         let root_state = state_tree::StateTree::new();
         Frontend {
-            actor_id: ActorId::from_bytes(actor_id),
+            actor_id: ActorId::from(actor_id),
             seq: 0,
             state: FrontendState::Reconciled {
                 reconciled_root_state: root_state.clone(),

--- a/automerge-frontend/tests/test_apply_patch.rs
+++ b/automerge-frontend/tests/test_apply_patch.rs
@@ -66,16 +66,10 @@ fn set_bytes_value() {
 fn reveal_conflicts_on_root_properties() {
     // We don't just use random actor IDs because we need to have a specific
     // ordering (actor1 > actor2)
-    let actor1 = amp::ActorId::from_bytes(
-        uuid::Uuid::parse_str("02ef21f3-c9eb-4087-880e-bedd7c4bbe43")
-            .unwrap()
-            .as_bytes(),
-    );
-    let actor2 = amp::ActorId::from_bytes(
-        uuid::Uuid::parse_str("2a1d376b-24f7-4400-8d4a-f58252d644dd")
-            .unwrap()
-            .as_bytes(),
-    );
+    let actor1 =
+        amp::ActorId::from(uuid::Uuid::parse_str("02ef21f3-c9eb-4087-880e-bedd7c4bbe43").unwrap());
+    let actor2 =
+        amp::ActorId::from(uuid::Uuid::parse_str("2a1d376b-24f7-4400-8d4a-f58252d644dd").unwrap());
     let patch = amp::Patch {
         actor: None,
         seq: None,
@@ -220,16 +214,10 @@ fn apply_updates_inside_nested_maps() {
 fn apply_updates_inside_map_conflicts() {
     // We don't just use random actor IDs because we need to have a specific
     // ordering (actor1 < actor2)
-    let actor1 = amp::ActorId::from_bytes(
-        uuid::Uuid::parse_str("02ef21f3-c9eb-4087-880e-bedd7c4bbe43")
-            .unwrap()
-            .as_bytes(),
-    );
-    let actor2 = amp::ActorId::from_bytes(
-        uuid::Uuid::parse_str("2a1d376b-24f7-4400-8d4a-f58252d644dd")
-            .unwrap()
-            .as_bytes(),
-    );
+    let actor1 =
+        amp::ActorId::from(uuid::Uuid::parse_str("02ef21f3-c9eb-4087-880e-bedd7c4bbe43").unwrap());
+    let actor2 =
+        amp::ActorId::from(uuid::Uuid::parse_str("2a1d376b-24f7-4400-8d4a-f58252d644dd").unwrap());
     let patch1 = amp::Patch {
         actor: None,
         seq: None,
@@ -526,16 +514,10 @@ fn apply_multi_insert_updates_inside_lists() {
 fn apply_updates_inside_list_conflicts() {
     // We don't just use random actor IDs because we need to have a specific
     // ordering (actor1 < actor2)
-    let actor1 = amp::ActorId::from_bytes(
-        uuid::Uuid::parse_str("02ef21f3-c9eb-4087-880e-bedd7c4bbe43")
-            .unwrap()
-            .as_bytes(),
-    );
-    let actor2 = amp::ActorId::from_bytes(
-        uuid::Uuid::parse_str("2a1d376b-24f7-4400-8d4a-f58252d644dd")
-            .unwrap()
-            .as_bytes(),
-    );
+    let actor1 =
+        amp::ActorId::from(uuid::Uuid::parse_str("02ef21f3-c9eb-4087-880e-bedd7c4bbe43").unwrap());
+    let actor2 =
+        amp::ActorId::from(uuid::Uuid::parse_str("2a1d376b-24f7-4400-8d4a-f58252d644dd").unwrap());
 
     let other_actor = amp::ActorId::random();
 

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "^1.0", features=["derive"] }
 strum = { version = "0.21.0", features=["derive"]}
 arbitrary = { version = "1", features = ["derive"], optional = true }
 smol_str = { version = "0.1.18", features = ["serde"] }
+tinyvec = { version = "1.2.0", features = ["alloc"] }
 
 [dev-dependencies]
 maplit = "^1.0.2"

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "^1.0", features=["derive"] }
 strum = { version = "0.21.0", features=["derive"]}
 arbitrary = { version = "1", features = ["derive"], optional = true }
 smol_str = { version = "0.1.18", features = ["serde"] }
-tinyvec = { version = "1.2.0", features = ["alloc"] }
+tinyvec = { version = "1.2.1-alpha.0", git = "https://github.com/Lokathor/tinyvec", features = ["alloc"] }
 
 [dev-dependencies]
 maplit = "^1.0.2"
@@ -26,4 +26,4 @@ rmp = "0.8.10"
 rmp-serde = "0.15.4"
 
 [features]
-derive-arbitrary = ["arbitrary"]
+derive-arbitrary = ["arbitrary", "tinyvec/arbitrary"]

--- a/automerge-protocol/src/utility_impls/actor_id.rs
+++ b/automerge-protocol/src/utility_impls/actor_id.rs
@@ -1,5 +1,7 @@
 use std::{convert::TryFrom, fmt, str::FromStr};
 
+use tinyvec::{ArrayVec, TinyVec};
+
 use crate::{error::InvalidActorId, ActorId};
 
 impl TryFrom<&str> for ActorId {
@@ -7,20 +9,37 @@ impl TryFrom<&str> for ActorId {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         hex::decode(s)
-            .map(ActorId)
+            .map(ActorId::from)
             .map_err(|_| InvalidActorId(s.into()))
+    }
+}
+
+impl From<uuid::Uuid> for ActorId {
+    fn from(u: uuid::Uuid) -> Self {
+        ActorId(TinyVec::from(*u.as_bytes()))
     }
 }
 
 impl From<&[u8]> for ActorId {
     fn from(b: &[u8]) -> Self {
-        ActorId(b.to_vec())
+        ActorId(TinyVec::from(b))
+    }
+}
+
+impl From<&Vec<u8>> for ActorId {
+    fn from(b: &Vec<u8>) -> Self {
+        ActorId::from(b.as_slice())
     }
 }
 
 impl From<Vec<u8>> for ActorId {
     fn from(b: Vec<u8>) -> Self {
-        ActorId(b)
+        let inner = if let Ok(arr) = ArrayVec::try_from(b.as_slice()) {
+            TinyVec::Inline(arr)
+        } else {
+            TinyVec::Heap(b)
+        };
+        ActorId(inner)
     }
 }
 

--- a/automerge-protocol/tests/serde_round_trip.rs
+++ b/automerge-protocol/tests/serde_round_trip.rs
@@ -4,7 +4,7 @@ use maplit::hashmap;
 // This was not caught in the proptests
 #[test]
 fn test_msgpack_roundtrip_diff() {
-    let actor = amp::ActorId::from_bytes("bd1850df21004038a8141a98473ff142".as_bytes());
+    let actor = amp::ActorId::from("bd1850df21004038a8141a98473ff142".as_bytes());
     let diff = amp::RootDiff {
         props: hashmap! {
             "bird".into() => hashmap! {

--- a/automerge-protocol/tests/serde_round_trip_proptest.rs
+++ b/automerge-protocol/tests/serde_round_trip_proptest.rs
@@ -38,7 +38,7 @@ fn arb_optype() -> impl Strategy<Value = amp::OpType> {
 }
 
 fn arb_actorid() -> impl Strategy<Value = amp::ActorId> {
-    proptest::collection::vec(any::<u8>(), 32).prop_map(|bytes| amp::ActorId::from_bytes(&bytes))
+    proptest::collection::vec(any::<u8>(), 16).prop_map(|bytes| amp::ActorId::from(&bytes))
 }
 
 fn arb_opid() -> impl Strategy<Value = amp::OpId> {

--- a/automerge/tests/frontend_backend_roundtrip.rs
+++ b/automerge/tests/frontend_backend_roundtrip.rs
@@ -68,7 +68,7 @@ fn test_frontend_uses_correct_elem_ids() {
 #[test]
 fn test_multi_insert_expands_to_correct_indices() {
     let uuid = uuid::Uuid::new_v4();
-    let actor = ActorId::from_bytes(uuid.as_bytes());
+    let actor = ActorId::from(uuid);
 
     let change = amp::Change {
         operations: vec![

--- a/automerge/tests/save_load.rs
+++ b/automerge/tests/save_load.rs
@@ -190,7 +190,7 @@ fn missing_object_error_flaky_null_rle_decoding() {
 #[test]
 fn missing_object_error_null_rle_decoding() {
     let actor_uuid = uuid::Uuid::new_v4();
-    let actor_id = ActorId::from_bytes(actor_uuid.as_bytes());
+    let actor_id = ActorId::from(actor_uuid);
 
     let raw_change = amp::Change {
         operations: vec![


### PR DESCRIPTION
Most of the time users will not be using their own identifiers and so
use random uuids. These can fit nicely on the stack for a speedup.
TinyVec allows us to capture this mostly stack, sometimes heap
behaviour.