### PR TITLE
Remove debug info for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ members = [
     "fuzz",
     "perf",
 ]
-
-[profile.release]
-debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
     "fuzz",
     "perf",
 ]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This should help fix the size of compiled library.