### PR TITLE
Reduce deflate compression on the hot path

### DIFF
--- a/automerge-backend/Cargo.toml
+++ b/automerge-backend/Cargo.toml
@@ -16,7 +16,7 @@ js-sys = "^0.3"
 hex = "^0.4.2"
 rand = { version = "^0.7.3", features=["small_rng"] }
 maplit = "^1.0.2"
-sha2 = "^0.8.1"
+sha2 = "0.9.5"
 leb128 = "^0.2.4"
 automerge-protocol = { path = "../automerge-protocol" }
 fxhash = "^0.2.1"

--- a/automerge-backend/src/sync.rs
+++ b/automerge-backend/src/sync.rs
@@ -261,7 +261,8 @@ impl SyncMessage {
         }
 
         (self.changes.len() as u32).encode(&mut buf)?;
-        for change in self.changes {
+        for mut change in self.changes {
+            change.compress();
             change.raw_bytes().encode(&mut buf)?;
         }
 

--- a/perf/src/main.rs
+++ b/perf/src/main.rs
@@ -16,21 +16,39 @@ fn f() {
 
     let start = Instant::now();
 
-    let m = hashmap! {
-        "a".into() =>
+    let mut m = hashmap! {
+        "arstarstoien".into() =>
         Value::Map(hashmap!{
-            "b".into()=>
+            "aboairentssroien".into()=>
             Value::Map(
                 hashmap! {
-                    "abc".into() => Value::Primitive(Primitive::Str("hello world".into()))
+                    "arostnaritsnabc".into() => Value::Primitive(Primitive::Str("hello world".into()))
                 },
             ),
-            "d".into() => Value::Primitive(Primitive::Uint(20)),
+            "arsotind".into() => Value::Primitive(Primitive::Uint(20)),
         },)
     };
 
+    for _ in 0..10 {
+        let random_key: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect();
+        let random_value: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(50)
+            .map(char::from)
+            .collect();
+        m.insert(
+            random_key.into(),
+            Value::Primitive(Primitive::Str(random_value.into())),
+        );
+    }
+
     let mut changes = Vec::new();
-    let mut applys = Vec::new();
+    let mut apply_changes = Vec::new();
+    let mut apply_patches = Vec::new();
 
     let iterations = 10_000;
     for _ in 0..iterations {
@@ -51,10 +69,12 @@ fn f() {
             .1
             .unwrap();
         changes.push(a.elapsed());
+        let a = Instant::now();
         let (patch, _) = backend.apply_local_change(change).unwrap();
+        apply_changes.push(a.elapsed());
         let a = Instant::now();
         doc.apply_patch(patch).unwrap();
-        applys.push(a.elapsed());
+        apply_patches.push(a.elapsed());
     }
 
     let save = Instant::now();
@@ -65,11 +85,12 @@ fn f() {
     let load = load.elapsed();
 
     println!(
-        "maps x{} total:{:?} change:{:?} apply:{:?} save:{:?} load:{:?}",
+        "maps x{} total:{:?} change:{:?} apply_change:{:?} apply_patch:{:?} save:{:?} load:{:?}",
         iterations,
         start.elapsed(),
         changes.iter().sum::<Duration>(),
-        applys.iter().sum::<Duration>(),
+        apply_changes.iter().sum::<Duration>(),
+        apply_patches.iter().sum::<Duration>(),
         save,
         load,
     );


### PR DESCRIPTION
Currently all changes get compressed when converting from a protocol change to a backend change.

This compression is actually quite costly time-wise and some use cases might not want to always compress changes, rather they can tolerate the slightly larger size. (For instance I am happy to save the changes in larger format and just save an entire document when space gets too much).

This PR makes the change to have compression as an opt-in. Users just call `compress` on a change they have and then the `raw_bytes` call will return the compressed version.

I've added compression to changes to be synced as this is a use case I can imagine it may be more acceptable to run compression on. Also note that this is likely to be a lot fewer changes getting compressed.

Some other question points:
- [ ] Should the wasm interface call compress by default to maintain the previous behaviour?
- [ ] Should the C library do the same? 
- [ ] Rather than mutating the `ChangeBytes` would it be better to have it do the compression in the function call and return that data directly?