### PR TITLE
Tidy up arbitrary features and smol_str

### DIFF
--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0.16"
 im-rc = "15.0.0"
 unicode-segmentation = "1.7.1"
 arbitrary = { version = "1", features = ["derive"], optional = true }
-smol_str = "0.1.17"
+smol_str = { version = "0.1.18", features = ["arbitrary"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2.2", features=["js"] }

--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -44,5 +44,4 @@ harness = false
 
 [features]
 default = ["std"]
-derive-arbitrary = ["arbitrary"]
 std = []

--- a/automerge-frontend/src/value.rs
+++ b/automerge-frontend/src/value.rs
@@ -17,7 +17,7 @@ impl From<HashMap<amp::OpId, Value>> for Conflicts {
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(untagged)]
 pub enum Value {
     Map(HashMap<SmolStr, Value>),
@@ -29,7 +29,7 @@ pub enum Value {
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Primitive {
     Bytes(Vec<u8>),
     Str(SmolStr),
@@ -45,7 +45,7 @@ pub enum Primitive {
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Cursor {
     pub index: u32,
     pub(crate) object: amp::ObjectId,

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -22,6 +22,3 @@ serde_json = { version = "^1.0.61", features=["float_roundtrip"], default-featur
 proptest = "0.10.1"
 rmp = "0.8.10"
 rmp-serde = "0.15.4"
-
-[features]
-derive-arbitrary = ["arbitrary"]

--- a/automerge-protocol/Cargo.toml
+++ b/automerge-protocol/Cargo.toml
@@ -14,7 +14,7 @@ uuid = { version = "^0.8.2", features=["v4"] }
 thiserror = "1.0.16"
 serde = { version = "^1.0", features=["derive"] }
 arbitrary = { version = "1", features = ["derive"], optional = true }
-smol_str = { version = "0.1.17", features = ["serde"] }
+smol_str = { version = "0.1.18", features = ["serde", "arbitrary"] }
 
 [dev-dependencies]
 maplit = "^1.0.2"

--- a/automerge-protocol/src/lib.rs
+++ b/automerge-protocol/src/lib.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
 #[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord, Default)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ActorId(Vec<u8>);
 
 impl fmt::Debug for ActorId {
@@ -89,7 +89,7 @@ impl fmt::Display for ObjType {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Copy, Hash)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(rename_all = "camelCase")]
 pub enum MapType {
     Map,
@@ -104,7 +104,7 @@ pub enum SequenceType {
 }
 
 #[derive(Eq, PartialEq, Hash, Clone, Default)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OpId(pub u64, pub ActorId);
 
 impl OpId {
@@ -128,7 +128,7 @@ impl OpId {
 }
 
 #[derive(Eq, PartialEq, Debug, Hash, Clone)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ObjectId {
     Id(OpId),
     Root,


### PR DESCRIPTION
We don't need the derive-arbitrary feature as we can just use arbitrary
directly.