### PR TITLE
Don't document automerge-c-v2 due to name clash

### DIFF
--- a/automerge-c-v2/Cargo.toml
+++ b/automerge-c-v2/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 name = "automerge"
 crate-type = ["cdylib", "staticlib"]
 bench = false
+doc = false
 
 [dependencies]
 automerge-backend = { path = "../automerge-backend" }


### PR DESCRIPTION
In the future we should rename it or find another way around this.