### PR TITLE
Add building docs to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ jobs:
   - rust: nightly
   fast_finish: true
   include:
-    - name: Stable - Format and Clippy
+    - name: Stable - Format, Clippy and Docs
       rust: stable
       script:
       - cargo fmt --all -- --check
       - cargo clippy --all-targets --all-features -- -D warnings
+      - cargo doc --workspace --all-features
     - name: Stable - Build and Test
       rust: stable
       script:
@@ -34,11 +35,12 @@ jobs:
       - yarn release
       - yarn test:js
 
-    - name: Beta - Format and Clippy
+    - name: Beta - Format, Clippy and Docs
       rust: beta
       script:
       - cargo fmt --all -- --check
       - cargo clippy --all-targets --all-features -- -D warnings
+      - cargo doc --workspace --all-features
     - name: Beta - Build and Test
       rust: beta
       script:
@@ -52,11 +54,12 @@ jobs:
       - yarn release
       - yarn test:js
 
-    - name: Nightly - Format and Clippy
+    - name: Nightly - Format, Clippy and Docs
       rust: nightly
       script:
       - cargo fmt --all -- --check
       - cargo clippy --all-targets --all-features -- -D warnings
+      - cargo doc --workspace --all-features
     - name: Nightly - Build and Test
       rust: nightly
       script:


### PR DESCRIPTION
If we want to self-host them then we should also check that we don't break building them.