### PR TITLE
Add send feature flag

### DIFF
--- a/automerge-backend/Cargo.toml
+++ b/automerge-backend/Cargo.toml
@@ -40,5 +40,4 @@ tracing-subscriber = {version = "0.2", features = ["chrono", "env-filter", "fmt"
 pretty_assertions = "0.7.1"
 
 [features]
-default = ["send"]
 send = []

--- a/automerge-backend/Cargo.toml
+++ b/automerge-backend/Cargo.toml
@@ -38,3 +38,7 @@ test-env-log = "0.2.6"
 env_logger = "*"
 tracing-subscriber = {version = "0.2", features = ["chrono", "env-filter", "fmt"]}
 pretty_assertions = "0.7.1"
+
+[features]
+default = ["send"]
+send = []

--- a/automerge-backend/src/event_handlers.rs
+++ b/automerge-backend/src/event_handlers.rs
@@ -52,7 +52,10 @@ impl EventHandlers {
 }
 
 /// A handler for changes.
+#[cfg(feature = "send")]
 pub struct ChangeEventHandler(pub Box<dyn FnMut(&Change) + Send>);
+#[cfg(not(feature = "send"))]
+pub struct ChangeEventHandler(pub Box<dyn FnMut(&Change)>);
 
 /// An general event handler.
 pub enum EventHandler {

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -57,6 +57,7 @@ pub use event_handlers::{ChangeEventHandler, EventHandler, EventHandlerId};
 pub use sync::{BloomFilter, SyncHave, SyncMessage, SyncState};
 
 #[cfg(test)]
+#[cfg(feature = "send")]
 mod tests {
     use std::{
         sync::{Arc, Mutex},

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -35,6 +35,10 @@ unicode-segmentation = "1.7.1"
 maplit = "^1.0.2"
 smol_str = "0.1.17"
 
+[features]
+default = ["send"]
+send = ["automerge-backend/send"]
+
 [[bench]]
 name = "crdt_benchmarks"
 harness = false

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -36,7 +36,6 @@ maplit = "^1.0.2"
 smol_str = "0.1.17"
 
 [features]
-default = ["send"]
 send = ["automerge-backend/send"]
 
 [[bench]]


### PR DESCRIPTION
Some situations require use of a non-`Send` event handler, this makes the entire backend non-`Send` so it is behind a feature flag.