### PR TITLE
Add sendable backend

### DIFF
--- a/automerge-backend/src/event_handlers.rs
+++ b/automerge-backend/src/event_handlers.rs
@@ -53,7 +53,14 @@ impl<H: EventHandler> EventHandlers<H> {
     }
 }
 
-pub trait EventHandler {
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for super::UnsendableEventHandler {}
+    impl Sealed for super::SendableEventHandler {}
+}
+
+pub trait EventHandler: private::Sealed {
     fn before_apply_change(&mut self, change: &Change);
 
     fn after_apply_change(&mut self, change: &Change);

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -53,7 +53,9 @@ pub use change::Change;
 pub use decoding::Error as DecodingError;
 pub use encoding::Error as EncodingError;
 pub use error::AutomergeError;
-pub use event_handlers::{EventHandlerId, SendableEventHandler, UnsendableEventHandler};
+pub use event_handlers::{
+    EventHandler, EventHandlerId, SendableEventHandler, UnsendableEventHandler,
+};
 pub use sync::{BloomFilter, SyncHave, SyncMessage, SyncState};
 
 #[cfg(test)]

--- a/automerge-backend/src/lib.rs
+++ b/automerge-backend/src/lib.rs
@@ -48,12 +48,12 @@ mod ordered_set;
 mod patches;
 mod sync;
 
-pub use backend::Backend;
+pub use backend::{Backend, GenericBackend, SendableBackend};
 pub use change::Change;
 pub use decoding::Error as DecodingError;
 pub use encoding::Error as EncodingError;
 pub use error::AutomergeError;
-pub use event_handlers::{ChangeEventHandler, EventHandler, EventHandlerId};
+pub use event_handlers::{EventHandlerId, SendableEventHandler, UnsendableEventHandler};
 pub use sync::{BloomFilter, SyncHave, SyncMessage, SyncState};
 
 #[cfg(test)]
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn sync_and_send_backend() {
-        let b = crate::Backend::new();
+        let b = crate::SendableBackend::new();
         let mb = Arc::new(Mutex::new(b));
         thread::spawn(move || {
             let b = mb.lock().unwrap();

--- a/automerge-backend/src/sync.rs
+++ b/automerge-backend/src/sync.rs
@@ -9,7 +9,8 @@ use std::{
 use automerge_protocol::{ChangeHash, Patch};
 
 use crate::{
-    decoding, decoding::Decoder, encoding, encoding::Encodable, AutomergeError, Backend, Change,
+    backend::GenericBackend, decoding, decoding::Decoder, encoding, encoding::Encodable,
+    event_handlers::EventHandler, AutomergeError, Change,
 };
 
 mod bloom;
@@ -21,7 +22,7 @@ pub use state::{SyncHave, SyncState};
 const HASH_SIZE: usize = 32; // 256 bits = 32 bytes
 const MESSAGE_TYPE_SYNC: u8 = 0x42; // first byte of a sync message, for identification
 
-impl Backend {
+impl<H: EventHandler> GenericBackend<H> {
     pub fn generate_sync_message(&self, sync_state: &mut SyncState) -> Option<SyncMessage> {
         let our_heads = self.get_heads();
 

--- a/automerge/src/lib.rs
+++ b/automerge/src/lib.rs
@@ -1,3 +1,3 @@
-pub use automerge_backend::{Backend, Change};
+pub use automerge_backend::{Backend, Change, SendableBackend};
 pub use automerge_frontend::{Frontend, InvalidChangeRequest, LocalChange, Path, Primitive, Value};
 pub use automerge_protocol::{MapType, ObjType, ScalarValue, SequenceType};


### PR DESCRIPTION
This introduces both a `Send`able and non-`Send`able backend by sharing a
common `GenericBackend`. This currently just changes the event handler
to require `Send` or not. This is preferred to a mutually exclusive
feature as features should be additive and so both can exist at the same
time (for instance two crates in a workspace with one needing `Send` and
the other not).