### PR TITLE
Remove queue from backend

### DIFF
--- a/automerge-backend/src/error.rs
+++ b/automerge-backend/src/error.rs
@@ -60,6 +60,8 @@ pub enum AutomergeError {
     InvalidCursor { opid: amp::OpId },
     #[error("A compressed chunk could not be decompressed")]
     BadCompressedChunk,
+    #[error("A change with missing dependencies cannot be applied")]
+    MissingChangeDependencies,
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This also adds a check for any missing dependencies when applying the
changes.

Currently the JS tests are failing so we could either implement the queue for them in the WASM lib or wait for the tests to be updated in the JS repo, thoughts?