### PR TITLE
Make apply_local_change return ref to change

### DIFF
--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -129,7 +129,7 @@ pub fn apply_local_change(input: Object, change: JsValue) -> Result<JsValue, JsV
         let change: amp::Change = change
             .into_serde()
             .map_err(|_| AutomergeError::DecodeFailed)?;
-        let (patch, mut change) = state.0.apply_local_change(change)?;
+        let (patch, change) = state.0.apply_local_change_mut(change)?;
         change.compress();
         let result = Array::new();
         let change_bytes = types::BinaryChange(change.raw_bytes().to_vec());

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -119,6 +119,12 @@ impl Backend {
             .ok_or(AutomergeError::InvalidSeq(seq))
     }
 
+    /// Apply a change from a local frontend.
+    ///
+    /// The change is expected to be the next in the sequence from the frontend.
+    ///
+    /// If successful then it returns the patch to update the frontend with alongside the binary
+    /// change that this application produced.
     pub fn apply_local_change(
         &mut self,
         mut change: amp::Change,
@@ -139,11 +145,17 @@ impl Backend {
 
         let patch: amp::Patch = self.apply(vec![bin_change], Some(actor_seq))?;
 
-        let change = self.get_change_by_hash(&hash).unwrap();
+        let change = self
+            .get_change_by_hash(&hash)
+            .expect("Change wasn't in the backend");
 
         Ok((patch, change))
     }
 
+    /// Like [`apply_local_change`] but returns a mutable reference to the change.
+    ///
+    /// This mutable reference is useful if you intend to compress the change using
+    /// [`Change::compress`].
     pub fn apply_local_change_mut(
         &mut self,
         change: amp::Change,
@@ -151,7 +163,9 @@ impl Backend {
         let (patch, change) = self.apply_local_change(change)?;
         let hash = change.hash;
 
-        let change = self.get_change_by_hash_mut(&hash).unwrap();
+        let change = self
+            .get_change_by_hash_mut(&hash)
+            .expect("change wasn't in the backend");
 
         Ok((patch, change))
     }

--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -146,7 +146,7 @@ impl Backend {
 
     pub fn apply_local_change_mut(
         &mut self,
-        mut change: amp::Change,
+        change: amp::Change,
     ) -> Result<(amp::Patch, &mut Change), AutomergeError> {
         let (patch, change) = self.apply_local_change(change)?;
         let hash = change.hash;

--- a/automerge-c-v2/src/lib.rs
+++ b/automerge-c-v2/src/lib.rs
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn automerge_apply_local_change(
     let backend = get_backend_mut!(backend);
     let buffs = get_buff_mut!(buffs);
     let request: amp::Change = from_msgpack!(backend, request, len);
-    let (patch, mut change) = call_automerge!(backend, backend.apply_local_change(request));
+    let (patch, change) = call_automerge!(backend, backend.apply_local_change_mut(request));
     change.compress();
     backend.last_local_change = Some(change.raw_bytes().to_vec());
     backend.write_msgpack(&patch, buffs)

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -209,11 +209,11 @@ pub unsafe extern "C" fn automerge_apply_local_change(
     let request: Result<amp::Change, _> = serde_json::from_str(&request);
     match request {
         Ok(request) => {
-            let result = (*backend).apply_local_change(request);
+            let result = (*backend).apply_local_change_mut(request);
             match result {
-                Ok((patch, mut change)) => {
+                Ok((patch, change)) => {
                     change.compress();
-                    (*backend).last_local_change = Some(change);
+                    (*backend).last_local_change = Some(change.clone());
                     (*backend).generate_json(Ok(patch))
                 }
                 Err(err) => (*backend).handle_error(err),

--- a/automerge-frontend/tests/test_backend_concurrency.rs
+++ b/automerge-frontend/tests/test_backend_concurrency.rs
@@ -689,10 +689,13 @@ fn test_deps_are_filled_in_if_frontend_does_not_have_latest_patch() {
     assert_eq!(change3, expected_change3);
 
     let (patch2, binchange2) = backend2.apply_local_change(change2).unwrap();
-    let (patch3, binchange3) = backend2.apply_local_change(change3).unwrap();
 
     assert_eq!(binchange2.deps, vec![binchange1.hash]);
-    assert_eq!(binchange3.deps, vec![binchange2.hash]);
+    let binchange2_hash = binchange2.hash;
+
+    let (patch3, binchange3) = backend2.apply_local_change(change3).unwrap();
+
+    assert_eq!(binchange3.deps, vec![binchange2_hash]);
     assert_eq!(patch1.deps, vec![binchange1.hash]);
     assert_eq!(patch2.deps, Vec::new());
 

--- a/automerge/benches/crdt_benchmarks.rs
+++ b/automerge/benches/crdt_benchmarks.rs
@@ -124,7 +124,9 @@ pub fn b1_2(c: &mut Criterion) {
                         backend1.apply_local_change(doc1_insert_change).unwrap();
                     doc1.apply_patch(patch).unwrap();
 
-                    let patch2 = backend2.apply_changes(vec![change_to_send]).unwrap();
+                    let patch2 = backend2
+                        .apply_changes(vec![change_to_send.clone()])
+                        .unwrap();
                     doc2.apply_patch(patch2).unwrap();
                     (doc1, backend1, doc2, backend2)
                 })
@@ -173,7 +175,7 @@ pub fn b3_1(c: &mut Criterion) {
                             .unwrap()
                             .1
                             .unwrap();
-                        backend.apply_local_change(change).unwrap().1
+                        backend.apply_local_change(change).unwrap().1.clone()
                     })
                     .collect();
                 (local_doc, local_backend, updates)

--- a/automerge/examples/cards.rs
+++ b/automerge/examples/cards.rs
@@ -29,7 +29,7 @@ impl Automerge {
         if let Some(change) = change {
             let (patch, change) = self.backend.apply_local_change(change)?;
             self.frontend.apply_patch(patch)?;
-            self.stream.push(change);
+            self.stream.push(change.clone());
         }
         Ok(output)
     }


### PR DESCRIPTION
The `_mut` variant is used so that people can `compress` after.