### PR TITLE
Sequence tree

### DIFF
--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -10,13 +10,11 @@ bench = false
 
 [dependencies]
 automerge-protocol = { path = "../automerge-protocol" }
-futures = "0.3.4"
 serde = { version = "^1.0", features=["derive"] }
 serde_json = "^1.0"
 uuid = { version = "^0.8.2", features=["v4"] }
 maplit = "1.0.2"
 thiserror = "1.0.16"
-im-rc = "15.0.0"
 unicode-segmentation = "1.7.1"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 smol_str = "0.1.18"

--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -33,6 +33,7 @@ env_logger = "0.8.3"
 log = "0.4.14"
 wasm-bindgen-test = "0.3.22"
 pretty_assertions = "0.7.1"
+proptest = "0.10.1"
 
 [[bench]]
 name = "statetree_apply_diff"

--- a/automerge-frontend/Cargo.toml
+++ b/automerge-frontend/Cargo.toml
@@ -31,7 +31,7 @@ env_logger = "0.8.3"
 log = "0.4.14"
 wasm-bindgen-test = "0.3.22"
 pretty_assertions = "0.7.1"
-proptest = "0.10.1"
+proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 
 [[bench]]
 name = "statetree_apply_diff"

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -315,7 +315,7 @@ where
                 amp::DiffEdit::Remove { index, count } => {
                     let index = index as usize;
                     let count = count as usize;
-                    for i in index..(index + count) {
+                    for _ in index..(index + count) {
                         self.underlying.remove(index);
                     }
 
@@ -390,7 +390,7 @@ where
                     value,
                     op_id,
                 } => {
-                    if let Some((opid, v)) = self.underlying.get_mut(index as usize) {
+                    if let Some((_opid, v)) = self.underlying.get_mut(index as usize) {
                         v.value.apply_diff(op_id, value);
                     }
                     changed_indices.push(index);
@@ -431,7 +431,7 @@ where
         let elem_id = self
             .underlying
             .get(index)
-            .map(|(opid, existing)| existing.opid.clone())
+            .map(|(_opid, existing)| existing.opid.clone())
             .expect("Failed to get existing index in set");
         self.underlying
             .set(
@@ -449,13 +449,13 @@ where
     pub(crate) fn get(&self, index: usize) -> Option<(&OpId, &T)> {
         self.underlying
             .get(index)
-            .map(|(opid, e)| (&e.opid, e.value.get()))
+            .map(|(_opid, e)| (&e.opid, e.value.get()))
     }
 
     pub(crate) fn get_mut(&mut self, index: usize) -> Option<(&mut OpId, &mut T)> {
         self.underlying
             .get_mut(index)
-            .map(|(opid, e)| (&mut e.opid, e.value.get_mut()))
+            .map(|(_opid, e)| (&mut e.opid, e.value.get_mut()))
     }
 
     pub(super) fn insert(&mut self, index: usize, value: T) {

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -219,7 +219,7 @@ where
     {
         let mut s = SequenceTree::new();
         for i in i {
-            s.push_back(i.default_opid(), SequenceElement::original(i))
+            s.push(i.default_opid(), SequenceElement::original(i))
         }
         DiffableSequence {
             underlying: Box::new(s),
@@ -342,7 +342,7 @@ where
                     let node = T::construct(op_id, value);
                     if (index as usize) == self.underlying.len() {
                         self.underlying
-                            .push_back(node.default_opid(), SequenceElement::new(node));
+                            .push(node.default_opid(), SequenceElement::new(node));
                     } else {
                         self.underlying.insert(
                             index as usize,

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -197,7 +197,7 @@ where
     T: Debug,
 {
     // stores the opid that created the element and the diffable value
-    underlying: Box<SequenceTree<SequenceElement<T>>>,
+    underlying: Box<SequenceTree<SequenceElement<T>, 9>>,
 }
 
 impl<T> DiffableSequence<T>

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -404,12 +404,12 @@ where
             }
         }
 
-        // debug_assert!(
-        //     self.underlying
-        //         .iter()
-        //         .all(|u| matches!(u.value, SequenceValue::Original(_))),
-        //     "diffable sequence apply_diff_iter didn't call finish on all values"
-        // );
+        debug_assert!(
+            self.underlying
+                .iter()
+                .all(|u| matches!(u.value, SequenceValue::Original(_))),
+            "diffable sequence apply_diff_iter didn't call finish on all values"
+        );
     }
 
     pub(super) fn remove(&mut self, index: usize) -> T {
@@ -467,9 +467,7 @@ where
     }
 
     pub(crate) fn iter(&self) -> impl std::iter::Iterator<Item = &T> {
-        // Making this unwrap safe is the entire point of this data structure
-        // self.underlying.iter().map(|i| i.value.get())
-        std::iter::empty()
+        self.underlying.iter().map(|i| i.value.get())
     }
 }
 

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -197,7 +197,7 @@ where
     T: Debug,
 {
     // stores the opid that created the element and the diffable value
-    underlying: Box<SequenceTree<SequenceElement<T>, 25>>,
+    underlying: Box<SequenceTree<SequenceElement<T>>>,
 }
 
 impl<T> DiffableSequence<T>

--- a/automerge-frontend/src/state_tree/diffable_sequence.rs
+++ b/automerge-frontend/src/state_tree/diffable_sequence.rs
@@ -197,7 +197,7 @@ where
     T: Debug,
 {
     // stores the opid that created the element and the diffable value
-    underlying: Box<SequenceTree<SequenceElement<T>, 9>>,
+    underlying: Box<SequenceTree<SequenceElement<T>, 25>>,
 }
 
 impl<T> DiffableSequence<T>

--- a/automerge-frontend/src/state_tree/mod.rs
+++ b/automerge-frontend/src/state_tree/mod.rs
@@ -13,6 +13,7 @@ mod diffable_sequence;
 mod multivalue;
 mod optimistic;
 mod resolved_path;
+mod sequence_tree;
 
 pub use multivalue::{MultiGrapheme, MultiValue};
 pub(crate) use optimistic::{LocalOperationForRollback, OptimisticStateTree};

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use automerge_protocol::OpId;
 
-const T: usize = 5;
+const T: usize = 3;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceTree<T> {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -7,15 +7,6 @@ pub struct SequenceTree<T> {
     root_node: Option<SequenceTreeNode<T, 25>>,
 }
 
-impl<T> Default for SequenceTree<T>
-where
-    T: Clone + Debug,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 struct SequenceTreeNode<T, const B: usize> {
     elements: Vec<Box<(OpId, T)>>,
@@ -557,12 +548,37 @@ where
     }
 }
 
+impl<T> Default for SequenceTree<T>
+where
+    T: Clone + Debug,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> PartialEq for SequenceTree<T>
 where
     T: Clone + Debug + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().zip(other.iter()).all(|(a, b)| a == b)
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SequenceTree<T>
+where
+    T: Clone + Debug,
+{
+    type Item = &'a T;
+
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter {
+            inner: self,
+            index: 0,
+        }
     }
 }
 

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -419,24 +419,21 @@ where
     }
 
     pub fn set(&mut self, mut index: usize, element: T) -> T {
-        let mut i = 0;
         if self.is_leaf() {
-            let (_, old_element) = &mut **self.elements.get_mut(i).unwrap();
+            let (_, old_element) = &mut **self.elements.get_mut(index).unwrap();
             mem::replace(old_element, element)
         } else {
-            for c in &mut self.children {
-                let c_len = c.len();
-                match index.cmp(&c_len) {
+            for (child_index, child) in self.children.iter_mut().enumerate() {
+                match index.cmp(&child.len()) {
                     Ordering::Less => {
-                        return c.set(index, element);
+                        return child.set(index, element);
                     }
                     Ordering::Equal => {
-                        let (_, old_element) = &mut **self.elements.get_mut(i).unwrap();
+                        let (_, old_element) = &mut **self.elements.get_mut(child_index).unwrap();
                         return mem::replace(old_element, element);
                     }
                     Ordering::Greater => {
-                        index -= c_len;
-                        i += 1;
+                        index -= child.len() + 1;
                     }
                 }
             }
@@ -445,22 +442,19 @@ where
     }
 
     pub fn get(&self, mut index: usize) -> Option<(OpId, &T)> {
-        let mut i = 0;
         if self.is_leaf() {
             return self.elements.get(index).map(|b| (b.0.clone(), &b.1));
         } else {
-            for c in &self.children {
-                let c_len = c.len();
-                match index.cmp(&c_len) {
+            for (child_index, child) in self.children.iter().enumerate() {
+                match index.cmp(&child.len()) {
                     Ordering::Less => {
-                        return c.get(index);
+                        return child.get(index);
                     }
                     Ordering::Equal => {
-                        return self.elements.get(i).map(|b| (b.0.clone(), &b.1));
+                        return self.elements.get(child_index).map(|b| (b.0.clone(), &b.1));
                     }
                     Ordering::Greater => {
-                        index -= c_len + 1;
-                        i += 1;
+                        index -= child.len() + 1;
                     }
                 }
             }
@@ -469,25 +463,25 @@ where
     }
 
     pub fn get_mut(&mut self, mut index: usize) -> Option<(OpId, &mut T)> {
-        let mut i = 0;
         if self.is_leaf() {
             return self
                 .elements
                 .get_mut(index)
                 .map(|b| (b.0.clone(), &mut b.1));
         } else {
-            for c in &mut self.children {
-                let c_len = c.len();
-                match index.cmp(&c_len) {
+            for (child_index, child) in self.children.iter_mut().enumerate() {
+                match index.cmp(&child.len()) {
                     Ordering::Less => {
-                        return c.get_mut(index);
+                        return child.get_mut(index);
                     }
                     Ordering::Equal => {
-                        return self.elements.get_mut(i).map(|b| (b.0.clone(), &mut b.1));
+                        return self
+                            .elements
+                            .get_mut(child_index)
+                            .map(|b| (b.0.clone(), &mut b.1));
                     }
                     Ordering::Greater => {
-                        index -= c_len + 1;
-                        i += 1;
+                        index -= child.len() + 1;
                     }
                 }
             }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -43,7 +43,6 @@ where
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
-        println!("insert {}", index);
         self.root_node.insert(index, opid, element);
     }
 
@@ -61,7 +60,6 @@ where
     }
 
     pub fn remove(&mut self, index: usize) -> T {
-        println!("remove {}", index);
         self.root_node.remove(index)
     }
 
@@ -112,7 +110,7 @@ where
             SequenceTreeNode::Node { left, right, len } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 *len += 1;
-                if index > left_len {
+                if index >= left_len {
                     if let Some(right_child) = right {
                         if let Some((index, opid, element)) =
                             right_child.insert(index - left_len, opid, element)
@@ -126,7 +124,6 @@ where
                             {
                                 assert!(!elements.is_empty());
                                 let right_elements = elements.split_off(index);
-                                dbg!("{} {}", elements.len(), right_elements.len());
                                 let len = elements.len() + right_elements.len() + 1;
 
                                 let l = if elements.is_empty() {
@@ -190,7 +187,6 @@ where
                         {
                             assert!(!elements.is_empty());
                             let right_elements = elements.split_off(index);
-                            dbg!("{} {}", elements.len(), right_elements.len());
                             let len = elements.len() + right_elements.len() + 1;
 
                             let l = if elements.is_empty() {
@@ -259,8 +255,6 @@ where
                     if let Some(right_child) = right {
                         if let SequenceTreeNode::Leaf { opid, elements } = &mut **right_child {
                             assert!(!elements.is_empty());
-                            dbg!(index - left_len + 1);
-                            dbg!(elements.len());
                             if index - left_len + 1 == elements.len() {
                                 // removing from the end, no split needed
                                 elements.remove(index - left_len)
@@ -269,7 +263,6 @@ where
                                 let mut right_elements = elements.split_off(index - left_len);
                                 let old_element = right_elements.remove(0);
                                 let len = elements.len() + right_elements.len();
-                                dbg!("{} {}", elements.len(), right_elements.len());
                                 let l = if elements.is_empty() {
                                     None
                                 } else {
@@ -307,8 +300,6 @@ where
                 } else if let Some(left_child) = left {
                     if let SequenceTreeNode::Leaf { opid, elements } = &mut **left_child {
                         assert!(!elements.is_empty());
-                        dbg!(index + 1);
-                        dbg!(elements.len());
                         if index + 1 == elements.len() {
                             // removing from the end, no split needed
                             elements.remove(index)
@@ -317,7 +308,6 @@ where
                             let mut right_elements = elements.split_off(index);
                             let old_element = right_elements.remove(0);
                             let len = elements.len() + right_elements.len();
-                            dbg!("{} {}", elements.len(), right_elements.len());
                             let l = if elements.is_empty() {
                                 None
                             } else {
@@ -366,7 +356,7 @@ where
                 len: _,
             } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
-                if index > left_len {
+                if index >= left_len {
                     if let Some(right) = right {
                         right.set(index - left_len, element)
                     } else {
@@ -392,7 +382,7 @@ where
                 len: _,
             } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
-                if index > left_len {
+                if index >= left_len {
                     right.as_ref().and_then(|r| r.get(index - left_len))
                 } else {
                     left.as_ref().and_then(|l| l.get(index))
@@ -416,7 +406,7 @@ where
                 len: _,
             } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
-                if index > left_len {
+                if index >= left_len {
                     right.as_mut().and_then(|r| r.get_mut(index - left_len))
                 } else {
                     left.as_mut().and_then(|l| l.get_mut(index))

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -3,11 +3,11 @@ use std::{cmp::Ordering, fmt::Debug};
 use automerge_protocol::OpId;
 
 #[derive(Clone, Debug)]
-pub struct SequenceTree<T, const B: usize> {
-    root_node: Option<SequenceTreeNode<T, B>>,
+pub struct SequenceTree<T> {
+    root_node: Option<SequenceTreeNode<T, 25>>,
 }
 
-impl<T> Default for SequenceTree<T, 25>
+impl<T> Default for SequenceTree<T>
 where
     T: Clone + Debug,
 {
@@ -23,7 +23,7 @@ struct SequenceTreeNode<T, const B: usize> {
     length: usize,
 }
 
-impl<T, const B: usize> SequenceTree<T, B>
+impl<T> SequenceTree<T>
 where
     T: Clone + Debug,
 {
@@ -39,7 +39,7 @@ where
         self.len() == 0
     }
 
-    pub fn iter(&self) -> Iter<'_, T, B> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             inner: self,
             index: 0,
@@ -557,7 +557,7 @@ where
     }
 }
 
-impl<T, const B: usize> PartialEq for SequenceTree<T, B>
+impl<T> PartialEq for SequenceTree<T>
 where
     T: Clone + Debug + PartialEq,
 {
@@ -566,12 +566,12 @@ where
     }
 }
 
-pub struct Iter<'a, T, const B: usize> {
-    inner: &'a SequenceTree<T, B>,
+pub struct Iter<'a, T> {
+    inner: &'a SequenceTree<T>,
     index: usize,
 }
 
-impl<'a, T, const B: usize> Iterator for Iter<'a, T, B>
+impl<'a, T> Iterator for Iter<'a, T>
 where
     T: Clone + Debug,
 {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -142,13 +142,9 @@ where
     fn insert_non_full(&mut self, index: usize, opid: OpId, element: T) {
         assert!(!self.is_full());
         if self.is_leaf() {
-            // leaf
-
             self.length += 1;
             self.elements.insert(index, Box::new((opid, element)));
         } else {
-            // not a leaf
-
             let num_children = self.children.len();
             let mut cumulative_len = 0;
             for (child_index, c) in self.children.iter_mut().enumerate() {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -12,6 +12,7 @@ enum SequenceTreeNode<T> {
     Leaf {
         opid: OpId,
         element: T,
+        len: usize,
     },
     Node {
         left: Option<Box<SequenceTreeNode<T>>>,
@@ -74,7 +75,7 @@ where
 {
     pub fn len(&self) -> usize {
         match self {
-            SequenceTreeNode::Leaf { .. } => 1,
+            SequenceTreeNode::Leaf { len, .. } => *len,
             SequenceTreeNode::Node { len, .. } => *len,
         }
     }
@@ -84,6 +85,7 @@ where
             SequenceTreeNode::Leaf {
                 opid: _,
                 element: _,
+                len: _,
             } => {
                 let leaf = std::mem::replace(
                     self,
@@ -97,13 +99,19 @@ where
                 if let SequenceTreeNode::Leaf {
                     opid: old_opid,
                     element: old_element,
+                    len: _,
                 } = leaf
                 {
                     let left = Some(Box::new(SequenceTreeNode::Leaf {
                         opid: old_opid,
                         element: old_element,
+                        len: 1,
                     }));
-                    let right = Some(Box::new(SequenceTreeNode::Leaf { opid, element }));
+                    let right = Some(Box::new(SequenceTreeNode::Leaf {
+                        opid,
+                        element,
+                        len: 1,
+                    }));
                     *self = SequenceTreeNode::Node {
                         left,
                         right,
@@ -120,13 +128,21 @@ where
                     if let Some(right) = right {
                         right.insert(index - left_len, opid, element)
                     } else {
-                        *right = Some(Box::new(SequenceTreeNode::Leaf { opid, element }))
+                        *right = Some(Box::new(SequenceTreeNode::Leaf {
+                            opid,
+                            element,
+                            len: 1,
+                        }))
                     }
                 } else {
                     if let Some(left) = left {
                         left.insert(index, opid, element)
                     } else {
-                        *left = Some(Box::new(SequenceTreeNode::Leaf { opid, element }))
+                        *left = Some(Box::new(SequenceTreeNode::Leaf {
+                            opid,
+                            element,
+                            len: 1,
+                        }))
                     }
                 }
             }
@@ -138,6 +154,7 @@ where
             SequenceTreeNode::Leaf {
                 opid: _,
                 element: _,
+                len: _,
             } => {
                 unreachable!("shouldn't be calling remove on a leaf, just a node")
             }
@@ -149,11 +166,15 @@ where
                         if let SequenceTreeNode::Leaf {
                             opid: _,
                             element: _,
+                            len: _,
                         } = &**right_child
                         {
                             let right_child = std::mem::take(right);
-                            if let SequenceTreeNode::Leaf { opid: _, element } =
-                                *right_child.unwrap()
+                            if let SequenceTreeNode::Leaf {
+                                opid: _,
+                                element,
+                                len: _,
+                            } = *right_child.unwrap()
                             {
                                 element
                             } else {
@@ -170,11 +191,15 @@ where
                         if let SequenceTreeNode::Leaf {
                             opid: _,
                             element: _,
+                            len: _,
                         } = &**left_child
                         {
                             let left_child = std::mem::take(left);
-                            if let SequenceTreeNode::Leaf { opid: _, element } =
-                                *left_child.unwrap()
+                            if let SequenceTreeNode::Leaf {
+                                opid: _,
+                                element,
+                                len: _,
+                            } = *left_child.unwrap()
                             {
                                 element
                             } else {
@@ -196,6 +221,7 @@ where
             SequenceTreeNode::Leaf {
                 opid: _,
                 element: old_element,
+                len: _,
             } => std::mem::replace(old_element, element),
             SequenceTreeNode::Node {
                 left,
@@ -222,7 +248,11 @@ where
 
     pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
         match &self {
-            SequenceTreeNode::Leaf { opid, element } => Some((opid.clone(), element)),
+            SequenceTreeNode::Leaf {
+                opid,
+                element,
+                len: _,
+            } => Some((opid.clone(), element)),
             SequenceTreeNode::Node {
                 left,
                 right,
@@ -240,7 +270,11 @@ where
 
     pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
         match self {
-            SequenceTreeNode::Leaf { opid, element } => Some((opid.clone(), element)),
+            SequenceTreeNode::Leaf {
+                opid,
+                element,
+                len: _,
+            } => Some((opid.clone(), element)),
             SequenceTreeNode::Node {
                 left,
                 right,

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use automerge_protocol::{ActorId, OpId};
+use automerge_protocol::OpId;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceTree<T> {
@@ -8,7 +8,7 @@ pub struct SequenceTree<T> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-enum SequenceTreeInner<T> {
+enum SequenceTreeNode<T> {
     Leaf(OpId, T),
     Node {
         left: Option<Box<SequenceTreeNode<T>>>,
@@ -17,23 +17,16 @@ enum SequenceTreeInner<T> {
     },
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct SequenceTreeNode<T> {
-    inner: SequenceTreeInner<T>,
-}
-
 impl<T> SequenceTree<T>
 where
     T: Clone + Debug,
 {
     pub fn new() -> Self {
         Self {
-            root_node: SequenceTreeNode {
-                inner: SequenceTreeInner::Node {
-                    left: None,
-                    right: None,
-                    len: 0,
-                },
+            root_node: SequenceTreeNode::Node {
+                left: None,
+                right: None,
+                len: 0,
             },
         }
     }
@@ -77,32 +70,28 @@ where
     T: Clone + Debug,
 {
     pub fn len(&self) -> usize {
-        match self.inner {
-            SequenceTreeInner::Leaf(..) => 1,
-            SequenceTreeInner::Node { len, .. } => len,
+        match self {
+            SequenceTreeNode::Leaf(..) => 1,
+            SequenceTreeNode::Node { len, .. } => *len,
         }
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
-        match &mut self.inner {
-            SequenceTreeInner::Leaf(old_opid, old_element) => {
+        match self {
+            SequenceTreeNode::Leaf(_old_opid, _old_element) => {
                 let leaf = std::mem::replace(
-                    &mut self.inner,
-                    SequenceTreeInner::Node {
+                    self,
+                    SequenceTreeNode::Node {
                         left: None,
                         right: None,
                         len: 0,
                     },
                 );
 
-                if let SequenceTreeInner::Leaf(old_opid, old_element) = leaf {
-                    let left = Some(Box::new(SequenceTreeNode {
-                        inner: SequenceTreeInner::Leaf(old_opid, old_element),
-                    }));
-                    let right = Some(Box::new(SequenceTreeNode {
-                        inner: SequenceTreeInner::Leaf(opid, element),
-                    }));
-                    self.inner = SequenceTreeInner::Node {
+                if let SequenceTreeNode::Leaf(old_opid, old_element) = leaf {
+                    let left = Some(Box::new(SequenceTreeNode::Leaf(old_opid, old_element)));
+                    let right = Some(Box::new(SequenceTreeNode::Leaf(opid, element)));
+                    *self = SequenceTreeNode::Node {
                         left,
                         right,
                         len: 2,
@@ -111,24 +100,20 @@ where
                     unreachable!("was leaf then not a leaf")
                 }
             }
-            SequenceTreeInner::Node { left, right, len } => {
+            SequenceTreeNode::Node { left, right, len } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 *len += 1;
                 if index > left_len {
                     if let Some(right) = right {
                         right.insert(index - left_len, opid, element)
                     } else {
-                        *right = Some(Box::new(SequenceTreeNode {
-                            inner: SequenceTreeInner::Leaf(opid, element),
-                        }))
+                        *right = Some(Box::new(SequenceTreeNode::Leaf(opid, element)))
                     }
                 } else {
                     if let Some(left) = left {
                         left.insert(index, opid, element)
                     } else {
-                        *left = Some(Box::new(SequenceTreeNode {
-                            inner: SequenceTreeInner::Leaf(opid, element),
-                        }))
+                        *left = Some(Box::new(SequenceTreeNode::Leaf(opid, element)))
                     }
                 }
             }
@@ -136,19 +121,18 @@ where
     }
 
     pub fn remove(&mut self, index: usize) -> T {
-        match &mut self.inner {
-            SequenceTreeInner::Leaf(old_opid, old_element) => {
+        match self {
+            SequenceTreeNode::Leaf(_old_opid, _old_element) => {
                 unreachable!("shouldn't be calling remove on a leaf, just a node")
             }
-            SequenceTreeInner::Node { left, right, len } => {
+            SequenceTreeNode::Node { left, right, len } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 *len -= 1;
                 if index > left_len {
                     if let Some(right_child) = right {
-                        if let SequenceTreeInner::Leaf(_opid, element) = &right_child.inner {
+                        if let SequenceTreeNode::Leaf(_opid, _element) = &**right_child {
                             let right_child = std::mem::take(right);
-                            if let SequenceTreeInner::Leaf(_, element) = right_child.unwrap().inner
-                            {
+                            if let SequenceTreeNode::Leaf(_, element) = *right_child.unwrap() {
                                 element
                             } else {
                                 unreachable!("was leaf then wasn't leaf")
@@ -161,9 +145,9 @@ where
                     }
                 } else {
                     if let Some(left_child) = left {
-                        if let SequenceTreeInner::Leaf(opid, element) = &left_child.inner {
+                        if let SequenceTreeNode::Leaf(_opid, _element) = &**left_child {
                             let left_child = std::mem::take(left);
-                            if let SequenceTreeInner::Leaf(_, element) = left_child.unwrap().inner {
+                            if let SequenceTreeNode::Leaf(_, element) = *left_child.unwrap() {
                                 element
                             } else {
                                 unreachable!("was leaf then wasn't leaf")
@@ -180,9 +164,13 @@ where
     }
 
     pub fn set(&mut self, index: usize, element: T) -> T {
-        match &mut self.inner {
-            SequenceTreeInner::Leaf(_, old_element) => std::mem::replace(old_element, element),
-            SequenceTreeInner::Node { left, right, len } => {
+        match self {
+            SequenceTreeNode::Leaf(_, old_element) => std::mem::replace(old_element, element),
+            SequenceTreeNode::Node {
+                left,
+                right,
+                len: _,
+            } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 if index > left_len {
                     if let Some(right) = right {
@@ -202,9 +190,13 @@ where
     }
 
     pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
-        match &self.inner {
-            SequenceTreeInner::Leaf(opid, element) => Some((opid.clone(), element)),
-            SequenceTreeInner::Node { left, right, len } => {
+        match &self {
+            SequenceTreeNode::Leaf(opid, element) => Some((opid.clone(), element)),
+            SequenceTreeNode::Node {
+                left,
+                right,
+                len: _,
+            } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 if index > left_len {
                     right.as_ref().and_then(|r| r.get(index - left_len))
@@ -216,9 +208,13 @@ where
     }
 
     pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
-        match &mut self.inner {
-            SequenceTreeInner::Leaf(opid, element) => Some((opid.clone(), element)),
-            SequenceTreeInner::Node { left, right, len } => {
+        match self {
+            SequenceTreeNode::Leaf(opid, element) => Some((opid.clone(), element)),
+            SequenceTreeNode::Node {
+                left,
+                right,
+                len: _,
+            } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 if index > left_len {
                     right.as_mut().and_then(|r| r.get_mut(index - left_len))

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -253,7 +253,7 @@ where
     fn remove_from_internal_child(
         &mut self,
         mut index: usize,
-        child_index: usize,
+        mut child_index: usize,
     ) -> Box<(OpId, T)> {
         self.length -= 1;
         if self.children[child_index].elements.len() < T
@@ -277,6 +277,7 @@ where
             if child_index > 0 {
                 // use the predessor sibling
                 let predecessor = self.children.remove(child_index - 1);
+                child_index -= 1;
 
                 self.children[child_index].elements.insert(0, middle);
                 self.children[child_index].length += 1;

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -127,7 +127,7 @@ where
 
                         let mut cumulative_len = 0;
                         for c in self.children.iter_mut() {
-                            cumulative_len += c.len();
+                            cumulative_len += c.len() + 1;
                             if cumulative_len > index {
                                 c.insert_non_full(index - i, opid, element);
                                 break;

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -658,14 +658,14 @@ mod tests {
 
         #[test]
         fn proptest_insert(indices in arb_indices()) {
-            let mut t = SequenceTree::default();
+            let mut t = SequenceTree::<usize, 3>::new();
             let actor = ActorId::random();
             let mut v = Vec::new();
 
             for i in indices{
                 if i <= v.len() {
-                    t.insert(i % 3, actor.op_id_at(1), ());
-                    v.insert(i % 3, ());
+                    t.insert(i % 3, actor.op_id_at(1), i);
+                    v.insert(i % 3, i);
                 } else {
                     return Err(proptest::test_runner::TestCaseError::reject("index out of bounds"))
                 }
@@ -680,14 +680,14 @@ mod tests {
 
         #[test]
         fn proptest_remove(inserts in arb_indices(), removes in arb_indices()) {
-            let mut t = SequenceTree::default();
+            let mut t = SequenceTree::<usize, 3>::new();
             let actor = ActorId::random();
             let mut v = Vec::new();
 
             for i in inserts {
                 if i <= v.len() {
-                    t.insert(i , actor.op_id_at(1), ());
-                    v.insert(i , ());
+                    t.insert(i , actor.op_id_at(1), i);
+                    v.insert(i , i);
                 } else {
                     return Err(proptest::test_runner::TestCaseError::reject("index out of bounds"))
                 }
@@ -697,8 +697,9 @@ mod tests {
 
             for i in removes {
                 if i < v.len() {
-                    t.remove(i );
-                    v.remove(i );
+                    let tr = t.remove(i);
+                    let vr = v.remove(i);
+                    assert_eq!(tr, vr);
                 } else {
                     return Err(proptest::test_runner::TestCaseError::reject("index out of bounds"))
                 }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -10,7 +10,7 @@ pub struct SequenceTree<T, const B: usize> {
     root_node: Option<SequenceTreeNode<T, B>>,
 }
 
-impl<T> Default for SequenceTree<T, 9>
+impl<T> Default for SequenceTree<T, 25>
 where
     T: Clone + Debug,
 {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -2,22 +2,17 @@ use std::fmt::Debug;
 
 use automerge_protocol::OpId;
 
+const FULL_AMOUNT: usize = 9;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceTree<T> {
     root_node: SequenceTreeNode<T>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-enum SequenceTreeNode<T> {
-    Leaf {
-        opid: OpId,
-        elements: Vec<T>,
-    },
-    Node {
-        left: Option<Box<SequenceTreeNode<T>>>,
-        right: Option<Box<SequenceTreeNode<T>>>,
-        len: usize,
-    },
+struct SequenceTreeNode<T> {
+    elements: Vec<(OpId, T)>,
+    children: Vec<Box<SequenceTreeNode<T>>>,
 }
 
 impl<T> SequenceTree<T>
@@ -26,10 +21,9 @@ where
 {
     pub fn new() -> Self {
         Self {
-            root_node: SequenceTreeNode::Node {
-                left: None,
-                right: None,
-                len: 0,
+            root_node: SequenceTreeNode {
+                elements: Vec::new(),
+                children: Vec::new(),
             },
         }
     }
@@ -43,6 +37,7 @@ where
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
+        println!("insert {}", index);
         self.root_node.insert(index, opid, element);
     }
 
@@ -60,6 +55,7 @@ where
     }
 
     pub fn remove(&mut self, index: usize) -> T {
+        println!("remove {}", index);
         self.root_node.remove(index)
     }
 
@@ -73,345 +69,84 @@ where
     T: Clone + Debug,
 {
     pub fn len(&self) -> usize {
-        match self {
-            SequenceTreeNode::Leaf { elements, .. } => elements.len(),
-            SequenceTreeNode::Node { len, .. } => *len,
-        }
+        self.elements.len() + self.children.iter().map(|c| c.len()).sum::<usize>()
     }
 
-    pub fn insert(&mut self, index: usize, opid: OpId, element: T) -> Option<(usize, OpId, T)> {
-        match self {
-            SequenceTreeNode::Leaf {
-                opid: leaf_opid,
-                elements,
-            } => {
-                assert!(!elements.is_empty());
-                if leaf_opid.1 == opid.1 {
-                    // has our actor, see if the sequence counter fits in
-                    if index == elements.len() {
-                        // pushing onto the end so index may be rle-able
-                        if leaf_opid.0 + elements.len() as u64 == opid.0 {
-                            // is the next in sequence so just append
-                            elements.push(element);
-                            None
-                        } else {
-                            // may need to split the node
-                            Some((index, opid, element))
-                        }
-                    } else {
-                        // need to split
-                        Some((index, opid, element))
-                    }
+    pub fn insert(&mut self, mut index: usize, opid: OpId, element: T) {
+        self.try_split();
+        if self.children.is_empty() {
+            // leaf node
+            self.elements.insert(index, (opid, element));
+        } else {
+            // internal node
+            for c in &mut self.children {
+                let c_len = c.len();
+                if index < c_len {
+                    c.insert(index, opid, element);
+                    break;
+                } else if index == c_len {
+                    self.elements.insert(index, (opid, element));
+                    break;
                 } else {
-                    // need to make a new node
-                    Some((index, opid, element))
-                }
-            }
-            SequenceTreeNode::Node { left, right, len } => {
-                let left_len = left.as_ref().map_or(0, |l| l.len());
-                *len += 1;
-                if index >= left_len {
-                    if let Some(right_child) = right {
-                        if let Some((index, opid, element)) =
-                            right_child.insert(index - left_len, opid, element)
-                        {
-                            // failed to insert, need to split the node
-                            let right_child = std::mem::take(right);
-                            if let SequenceTreeNode::Leaf {
-                                opid: leaf_opid,
-                                mut elements,
-                            } = *right_child.unwrap()
-                            {
-                                assert!(!elements.is_empty());
-                                let right_elements = elements.split_off(index);
-                                let len = elements.len() + right_elements.len() + 1;
-
-                                let l = if elements.is_empty() {
-                                    None
-                                } else {
-                                    Some(Box::new(SequenceTreeNode::Leaf {
-                                        elements,
-                                        opid: leaf_opid.clone(),
-                                    }))
-                                };
-                                let r = if right_elements.is_empty() {
-                                    Some(Box::new(SequenceTreeNode::Leaf {
-                                        opid,
-                                        elements: vec![element],
-                                    }))
-                                } else {
-                                    let right_len = right_elements.len();
-                                    Some(Box::new(SequenceTreeNode::Node {
-                                        left: Some(Box::new(SequenceTreeNode::Leaf {
-                                            opid,
-                                            elements: vec![element],
-                                        })),
-                                        right: Some(Box::new(SequenceTreeNode::Leaf {
-                                            opid: OpId(
-                                                leaf_opid.0 + (index) as u64 + 1,
-                                                leaf_opid.1,
-                                            ),
-                                            elements: right_elements,
-                                        })),
-                                        len: 1 + right_len,
-                                    }))
-                                };
-                                *right = Some(Box::new(SequenceTreeNode::Node {
-                                    left: l,
-                                    right: r,
-                                    len,
-                                }));
-                                None
-                            } else {
-                                unreachable!("found non leaf on split")
-                            }
-                        } else {
-                            // added to elements
-                            None
-                        }
-                    } else {
-                        *right = Some(Box::new(SequenceTreeNode::Leaf {
-                            opid,
-                            elements: vec![element],
-                        }));
-                        None
-                    }
-                } else if let Some(left_child) = left {
-                    if let Some((index, opid, element)) = left_child.insert(index, opid, element) {
-                        // failed to insert, need to split the node
-                        let left_child = std::mem::take(left);
-                        if let SequenceTreeNode::Leaf {
-                            opid: leaf_opid,
-                            mut elements,
-                        } = *left_child.unwrap()
-                        {
-                            assert!(!elements.is_empty());
-                            let right_elements = elements.split_off(index);
-                            let len = elements.len() + right_elements.len() + 1;
-
-                            let l = if elements.is_empty() {
-                                None
-                            } else {
-                                Some(Box::new(SequenceTreeNode::Leaf {
-                                    elements,
-                                    opid: leaf_opid.clone(),
-                                }))
-                            };
-                            let r = if right_elements.is_empty() {
-                                Some(Box::new(SequenceTreeNode::Leaf {
-                                    opid,
-                                    elements: vec![element],
-                                }))
-                            } else {
-                                let right_len = right_elements.len();
-                                Some(Box::new(SequenceTreeNode::Node {
-                                    left: Some(Box::new(SequenceTreeNode::Leaf {
-                                        opid,
-                                        elements: vec![element],
-                                    })),
-                                    right: Some(Box::new(SequenceTreeNode::Leaf {
-                                        opid: OpId(leaf_opid.0 + (index) as u64 + 1, leaf_opid.1),
-                                        elements: right_elements,
-                                    })),
-                                    len: 1 + right_len,
-                                }))
-                            };
-                            *left = Some(Box::new(SequenceTreeNode::Node {
-                                left: l,
-                                right: r,
-                                len,
-                            }));
-                            None
-                        } else {
-                            unreachable!("found non leaf on split")
-                        }
-                    } else {
-                        // added to elements
-                        None
-                    }
-                } else {
-                    *left = Some(Box::new(SequenceTreeNode::Leaf {
-                        opid,
-                        elements: vec![element],
-                    }));
-                    None
+                    index -= c_len;
                 }
             }
         }
     }
 
     pub fn remove(&mut self, index: usize) -> T {
-        match self {
-            SequenceTreeNode::Leaf {
-                opid: _,
-                elements: _,
-            } => {
-                unreachable!("shouldn't be calling remove on a leaf, just a node")
-            }
-            SequenceTreeNode::Node { left, right, len } => {
-                let left_len = left.as_ref().map_or(0, |l| l.len());
-                *len -= 1;
-                if index >= left_len {
-                    if let Some(right_child) = right {
-                        if let SequenceTreeNode::Leaf { opid, elements } = &mut **right_child {
-                            assert!(!elements.is_empty());
-                            if index - left_len + 1 == elements.len() {
-                                // removing from the end, no split needed
-                                elements.remove(index - left_len)
-                            } else {
-                                // need to split
-                                let mut right_elements = elements.split_off(index - left_len);
-                                let old_element = right_elements.remove(0);
-                                let len = elements.len() + right_elements.len();
-                                let l = if elements.is_empty() {
-                                    None
-                                } else {
-                                    Some(Box::new(SequenceTreeNode::Leaf {
-                                        opid: OpId(opid.0, opid.1.clone()),
-                                        elements: std::mem::take(elements),
-                                    }))
-                                };
-
-                                let r = if right_elements.is_empty() {
-                                    None
-                                } else {
-                                    Some(Box::new(SequenceTreeNode::Leaf {
-                                        opid: OpId(
-                                            opid.0 + (index - left_len) as u64 + 1,
-                                            opid.1.clone(),
-                                        ),
-                                        elements: right_elements,
-                                    }))
-                                };
-
-                                *right = Some(Box::new(SequenceTreeNode::Node {
-                                    left: l,
-                                    right: r,
-                                    len,
-                                }));
-                                old_element
-                            }
-                        } else {
-                            right_child.remove(index - left_len)
-                        }
-                    } else {
-                        unreachable!("no right child")
-                    }
-                } else if let Some(left_child) = left {
-                    if let SequenceTreeNode::Leaf { opid, elements } = &mut **left_child {
-                        assert!(!elements.is_empty());
-                        if index + 1 == elements.len() {
-                            // removing from the end, no split needed
-                            elements.remove(index)
-                        } else {
-                            // need to split
-                            let mut right_elements = elements.split_off(index);
-                            let old_element = right_elements.remove(0);
-                            let len = elements.len() + right_elements.len();
-                            let l = if elements.is_empty() {
-                                None
-                            } else {
-                                Some(Box::new(SequenceTreeNode::Leaf {
-                                    opid: OpId(opid.0, opid.1.clone()),
-                                    elements: std::mem::take(elements),
-                                }))
-                            };
-
-                            let r = if right_elements.is_empty() {
-                                None
-                            } else {
-                                Some(Box::new(SequenceTreeNode::Leaf {
-                                    opid: OpId(opid.0 + index as u64 + 1, opid.1.clone()),
-                                    elements: right_elements,
-                                }))
-                            };
-
-                            *left = Some(Box::new(SequenceTreeNode::Node {
-                                left: l,
-                                right: r,
-                                len,
-                            }));
-                            old_element
-                        }
-                    } else {
-                        left_child.remove(index)
-                    }
-                } else {
-                    unreachable!("no left child")
-                }
-            }
-        }
+        todo!()
     }
 
     pub fn set(&mut self, index: usize, element: T) -> T {
-        match self {
-            SequenceTreeNode::Leaf { opid: _, elements } => {
-                assert!(!elements.is_empty());
-                let old = elements.get_mut(index).unwrap();
-                std::mem::replace(old, element)
-            }
-            SequenceTreeNode::Node {
-                left,
-                right,
-                len: _,
-            } => {
-                let left_len = left.as_ref().map_or(0, |l| l.len());
-                if index >= left_len {
-                    if let Some(right) = right {
-                        right.set(index - left_len, element)
-                    } else {
-                        unreachable!("set on non existant index")
-                    }
-                } else if let Some(left) = left {
-                    left.set(index, element)
-                } else {
-                    unreachable!("set on non existant index")
-                }
-            }
+        todo!()
+    }
+
+    // try to split this node if it is full
+    fn try_split(&mut self) {
+        if self.elements.len() == FULL_AMOUNT {
+            // do the split
+            todo!("split")
         }
     }
 
-    pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
-        match &self {
-            SequenceTreeNode::Leaf { opid, elements } => elements
-                .get(index)
-                .map(|e| (OpId(opid.0 + elements.len() as u64, opid.1.clone()), e)),
-            SequenceTreeNode::Node {
-                left,
-                right,
-                len: _,
-            } => {
-                let left_len = left.as_ref().map_or(0, |l| l.len());
-                if index >= left_len {
-                    right.as_ref().and_then(|r| r.get(index - left_len))
+    pub fn get(&self, mut index: usize) -> Option<(OpId, &T)> {
+        let mut i = 0;
+        if self.children.is_empty() {
+            return self.elements.get(index).map(|(o, t)| (o.clone(), t));
+        } else {
+            for c in &self.children {
+                let c_len = c.len();
+                if index < c_len {
+                    return c.get(index);
+                } else if index == c_len {
+                    return self.elements.get(i).map(|(o, t)| (o.clone(), t));
                 } else {
-                    left.as_ref().and_then(|l| l.get(index))
+                    index -= c_len;
+                    i += 1;
                 }
             }
         }
+        None
     }
 
-    pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
-        match self {
-            SequenceTreeNode::Leaf { opid, elements } => {
-                let len = elements.len();
-
-                elements
-                    .get_mut(index)
-                    .map(|e| (OpId(opid.0 + len as u64, opid.1.clone()), e))
-            }
-            SequenceTreeNode::Node {
-                left,
-                right,
-                len: _,
-            } => {
-                let left_len = left.as_ref().map_or(0, |l| l.len());
-                if index >= left_len {
-                    right.as_mut().and_then(|r| r.get_mut(index - left_len))
+    pub fn get_mut(&mut self, mut index: usize) -> Option<(OpId, &mut T)> {
+        let mut i = 0;
+        if self.children.is_empty() {
+            return self.elements.get_mut(index).map(|(o, t)| (o.clone(), t));
+        } else {
+            for c in &mut self.children {
+                let c_len = c.len();
+                if index < c_len {
+                    return c.get_mut(index);
+                } else if index == c_len {
+                    return self.elements.get_mut(i).map(|(o, t)| (o.clone(), t));
                 } else {
-                    left.as_mut().and_then(|l| l.get_mut(index))
+                    index -= c_len;
+                    i += 1;
                 }
             }
         }
+        None
     }
 }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -294,23 +294,25 @@ where
                 self.length -= 1;
 
                 // use the predessor sibling
-                let predecessor = self.children.remove(child_index - 1);
-                self.length -= predecessor.len();
+                let child_to_merge_from = self.children.remove(child_index);
+                self.length -= child_to_merge_from.len();
                 child_index -= 1;
 
-                self.children[child_index].elements.insert(0, middle);
-                self.children[child_index].length += 1;
+                let predecessor = &mut self.children[child_index];
+
+                predecessor.elements.push(middle);
+                predecessor.length += 1;
                 self.length += 1;
 
-                for element in predecessor.elements.into_iter().rev() {
-                    self.children[child_index].elements.insert(0, element);
-                    self.children[child_index].length += 1;
+                for element in child_to_merge_from.elements {
+                    predecessor.elements.push(element);
+                    predecessor.length += 1;
                     self.length += 1;
                 }
-                for child in predecessor.children.into_iter().rev() {
-                    self.children[child_index].length += child.len();
+                for child in child_to_merge_from.children {
+                    predecessor.length += child.len();
                     self.length += child.len();
-                    self.children[child_index].children.insert(0, child);
+                    predecessor.children.push(child);
                 }
             } else {
                 let middle = self.elements.remove(child_index);

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -43,6 +43,7 @@ where
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
+        println!("insert {}", index);
         self.root_node.insert(index, opid, element);
     }
 
@@ -60,6 +61,7 @@ where
     }
 
     pub fn remove(&mut self, index: usize) -> T {
+        println!("remove {}", index);
         self.root_node.remove(index)
     }
 
@@ -80,12 +82,12 @@ where
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) -> Option<(usize, OpId, T)> {
-        println!("insert");
         match self {
             SequenceTreeNode::Leaf {
                 opid: leaf_opid,
                 elements,
             } => {
+                assert!(!elements.is_empty());
                 if leaf_opid.1 == opid.1 {
                     // has our actor, see if the sequence counter fits in
                     if index == elements.len() {
@@ -122,9 +124,10 @@ where
                                 mut elements,
                             } = *right_child.unwrap()
                             {
+                                assert!(!elements.is_empty());
                                 let right_elements = elements.split_off(index);
                                 dbg!("{} {}", elements.len(), right_elements.len());
-                                let len = elements.len() + right_elements.len();
+                                let len = elements.len() + right_elements.len() + 1;
 
                                 let l = if elements.is_empty() {
                                     None
@@ -185,9 +188,10 @@ where
                             mut elements,
                         } = *left_child.unwrap()
                         {
+                            assert!(!elements.is_empty());
                             let right_elements = elements.split_off(index);
                             dbg!("{} {}", elements.len(), right_elements.len());
-                            let len = elements.len() + right_elements.len();
+                            let len = elements.len() + right_elements.len() + 1;
 
                             let l = if elements.is_empty() {
                                 None
@@ -241,7 +245,6 @@ where
     }
 
     pub fn remove(&mut self, index: usize) -> T {
-        println!("remove");
         match self {
             SequenceTreeNode::Leaf {
                 opid: _,
@@ -252,9 +255,10 @@ where
             SequenceTreeNode::Node { left, right, len } => {
                 let left_len = left.as_ref().map_or(0, |l| l.len());
                 *len -= 1;
-                if index > left_len {
+                if index >= left_len {
                     if let Some(right_child) = right {
                         if let SequenceTreeNode::Leaf { opid, elements } = &mut **right_child {
+                            assert!(!elements.is_empty());
                             dbg!(index - left_len + 1);
                             dbg!(elements.len());
                             if index - left_len + 1 == elements.len() {
@@ -302,6 +306,7 @@ where
                     }
                 } else if let Some(left_child) = left {
                     if let SequenceTreeNode::Leaf { opid, elements } = &mut **left_child {
+                        assert!(!elements.is_empty());
                         dbg!(index + 1);
                         dbg!(elements.len());
                         if index + 1 == elements.len() {
@@ -351,6 +356,7 @@ where
     pub fn set(&mut self, index: usize, element: T) -> T {
         match self {
             SequenceTreeNode::Leaf { opid: _, elements } => {
+                assert!(!elements.is_empty());
                 let old = elements.get_mut(index).unwrap();
                 std::mem::replace(old, element)
             }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -209,3 +209,39 @@ where
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use automerge_protocol::ActorId;
+
+    use super::*;
+
+    #[test]
+    fn push_back() {
+        let mut t = SequenceTree::new();
+        let actor = ActorId::random();
+
+        t.push_back(actor.op_id_at(1), ());
+        t.push_back(actor.op_id_at(2), ());
+        t.push_back(actor.op_id_at(3), ());
+        t.push_back(actor.op_id_at(4), ());
+        t.push_back(actor.op_id_at(5), ());
+        t.push_back(actor.op_id_at(6), ());
+        t.push_back(actor.op_id_at(8), ());
+        t.push_back(actor.op_id_at(100), ());
+    }
+
+    #[test]
+    fn insert() {
+        let mut t = SequenceTree::new();
+        let actor = ActorId::random();
+
+        t.insert(0, actor.op_id_at(1), ());
+        t.insert(1, actor.op_id_at(1), ());
+        t.insert(0, actor.op_id_at(1), ());
+        t.insert(0, actor.op_id_at(1), ());
+        t.insert(0, actor.op_id_at(1), ());
+        t.insert(3, actor.op_id_at(1), ());
+        t.insert(4, actor.op_id_at(1), ());
+    }
+}

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -48,7 +48,7 @@ where
                 let mut i = 0;
                 if root.children[0].len() < index {
                     i += 1;
-                    index -= root.children[0].len()
+                    index -= root.children[0].len() + 1
                 }
                 root.children[i].insert_non_full(index, opid, element)
             } else {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -24,18 +24,22 @@ impl<T, const B: usize> SequenceTreeInternal<T, B>
 where
     T: Clone + Debug,
 {
+    /// Construct a new, empty, sequence.
     pub fn new() -> Self {
         Self { root_node: None }
     }
 
+    /// Get the length of the sequence.
     pub fn len(&self) -> usize {
         self.root_node.as_ref().map_or(0, |n| n.len())
     }
 
+    /// Check if the sequence is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Create an iterator through the sequence.
     pub fn iter(&self) -> Iter<'_, T, B> {
         Iter {
             inner: self,
@@ -43,6 +47,11 @@ where
         }
     }
 
+    /// Insert the `opid` and `element` into the sequence at `index`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
     pub fn insert(&mut self, mut index: usize, opid: OpId, element: T) {
         let old_len = self.len();
         if let Some(root) = self.root_node.as_mut() {
@@ -83,19 +92,27 @@ where
         assert_eq!(self.len(), old_len + 1, "{:#?}", self);
     }
 
-    pub fn push_back(&mut self, opid: OpId, element: T) {
+    /// Push the `opid` and `element` onto the back of the sequence.
+    pub fn push(&mut self, opid: OpId, element: T) {
         let l = self.len();
         self.insert(l, opid, element)
     }
 
+    /// Get the `OpId` and `element` at `index` in the sequence.
     pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
         self.root_node.as_ref().and_then(|n| n.get(index))
     }
 
+    /// Get the `OpId` and `element` at `index` in the sequence.
     pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
         self.root_node.as_mut().and_then(|n| n.get_mut(index))
     }
 
+    /// Removes the element at `index` from the sequence.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
     pub fn remove(&mut self, index: usize) -> T {
         if let Some(root) = self.root_node.as_mut() {
             #[cfg(debug_assertions)]
@@ -118,6 +135,11 @@ where
         }
     }
 
+    /// Update the `element` at `index` in the sequence, returning the old value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`
     pub fn set(&mut self, index: usize, element: T) -> T {
         self.root_node.as_mut().unwrap().set(index, element)
     }
@@ -552,14 +574,14 @@ mod tests {
         let mut t = SequenceTree::new();
         let actor = ActorId::random();
 
-        t.push_back(actor.op_id_at(1), ());
-        t.push_back(actor.op_id_at(2), ());
-        t.push_back(actor.op_id_at(3), ());
-        t.push_back(actor.op_id_at(4), ());
-        t.push_back(actor.op_id_at(5), ());
-        t.push_back(actor.op_id_at(6), ());
-        t.push_back(actor.op_id_at(8), ());
-        t.push_back(actor.op_id_at(100), ());
+        t.push(actor.op_id_at(1), ());
+        t.push(actor.op_id_at(2), ());
+        t.push(actor.op_id_at(3), ());
+        t.push(actor.op_id_at(4), ());
+        t.push(actor.op_id_at(5), ());
+        t.push(actor.op_id_at(6), ());
+        t.push(actor.op_id_at(8), ());
+        t.push(actor.op_id_at(100), ());
     }
 
     #[test]

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use automerge_protocol::OpId;
 
 const T: usize = 5;
-const FULL_AMOUNT: usize = 9;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceTree<T> {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -441,22 +441,23 @@ where
         assert!(self.is_full());
     }
 
-    pub fn set(&mut self, mut index: usize, element: T) -> T {
+    pub fn set(&mut self, index: usize, element: T) -> T {
         if self.is_leaf() {
             let (_, old_element) = &mut **self.elements.get_mut(index).unwrap();
             mem::replace(old_element, element)
         } else {
+            let mut cumulative_len = 0;
             for (child_index, child) in self.children.iter_mut().enumerate() {
-                match index.cmp(&child.len()) {
+                match (cumulative_len + child.len()).cmp(&index) {
                     Ordering::Less => {
-                        return child.set(index, element);
+                        cumulative_len += child.len() + 1;
                     }
                     Ordering::Equal => {
                         let (_, old_element) = &mut **self.elements.get_mut(child_index).unwrap();
                         return mem::replace(old_element, element);
                     }
                     Ordering::Greater => {
-                        index -= child.len() + 1;
+                        return child.set(index - cumulative_len, element);
                     }
                 }
             }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::{min, Ordering},
-    fmt::Debug,
-};
+use std::{cmp::Ordering, fmt::Debug};
 
 use automerge_protocol::OpId;
 

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -120,10 +120,11 @@ where
     }
 
     fn is_full(&self) -> bool {
-        self.elements.len() == 2 * T - 1
+        self.elements.len() >= 2 * T - 1
     }
 
     fn insert_non_full(&mut self, index: usize, opid: OpId, element: T) {
+        assert!(!self.is_full());
         if self.is_leaf() {
             // leaf
 
@@ -134,7 +135,7 @@ where
             let num_children = self.children.len();
             let mut cumulative_len = 0;
             for (child_index, c) in self.children.iter_mut().enumerate() {
-                if cumulative_len + c.len() > index {
+                if cumulative_len + c.len() >= index {
                     // insert into c
                     if c.is_full() {
                         self.split_child(child_index);
@@ -175,6 +176,7 @@ where
         };
 
         let y = &mut self.children[i];
+        assert!(y.is_full());
         z.elements = y.elements.split_off(T);
         if !y.is_leaf() {
             z.children = y.children.split_off(T);

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -1,57 +1,255 @@
-use std::collections::HashMap;
+use std::fmt::Debug;
 
 use automerge_protocol::{ActorId, OpId};
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct SequenceTree<T> {
     nodes: Vec<SequenceTreeNode<T>>,
+    length: usize,
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub struct SequenceTreeNode<T> {
-        actor: ActorId,
-        start_counter:usize,
-        start_index: usize,
-        elements: Vec<T>,
+    actor: ActorId,
+    start_counter: u64,
+    start_index: usize,
+    elements: Vec<T>,
 }
 
-impl<T> SequenceTree<T> {
+impl<T> SequenceTree<T>
+where
+    T: Clone + Debug,
+{
     pub fn new() -> Self {
         Self {
-            nodes:Vec::new(),
+            nodes: Vec::new(),
+            length: 0,
         }
     }
 
     pub fn len(&self) -> usize {
-        todo!()
+        self.length
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
-        // add 1 to length
-        //
-        // go through nodes trying to insert
-
-        for node in nodes {
-            if node.
+        if index == self.len() {
+            self.push_back(opid, element);
+            return;
         }
-    }
-}
+        self.length += 1;
+        let mut new_node_needed = false;
+        let mut split_node = None;
 
-impl<T> SequenceTreeNode<T> {
-    pub fn new() -> Self {
-        Self::Children { nodes: Vec::new() }
-    }
-
-    pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
-        match self {
-            SequenceTreeNode::Items {
-                actor,
-                start_index,
-                elements,
-            } => todo!(),
-            SequenceTreeNode::Children { nodes } => {
-                for node in nodes {
-                    if node
+        for node in &mut self.nodes {
+            if index < node.start_index {
+                node.start_index += 1
+            } else if index == node.start_index {
+                node.start_index += 1;
+                new_node_needed = true;
+            } else if index > node.start_index && index < node.start_index + node.elements.len() {
+                let other_elements = node.elements.split_off(index - node.start_index);
+                assert!(!node.elements.is_empty());
+                if !other_elements.is_empty() {
+                    split_node = Some(SequenceTreeNode {
+                        actor: node.actor.clone(),
+                        start_counter: node.start_counter + (index - node.start_index) as u64,
+                        start_index: index + 1,
+                        elements: other_elements,
+                    });
                 }
-            },
+
+                new_node_needed = true
+            } else if index > node.start_index && index == node.start_index + node.elements.len() {
+                // at the end, may be able to add it if correct actorid and counter
+                if opid.1 == node.actor && opid.0 == node.start_counter + node.elements.len() as u64
+                {
+                    node.elements.push(element.clone())
+                } else {
+                    new_node_needed = true
+                }
+            } else {
+                // do nothing
+            }
         }
+
+        if new_node_needed {
+            self.nodes.push(SequenceTreeNode {
+                actor: opid.1,
+                start_counter: opid.0,
+                start_index: index,
+                elements: vec![element],
+            })
+        }
+
+        if let Some(node) = split_node {
+            self.nodes.push(node)
+        }
+
+        let any_empty = self.nodes.iter().any(|n| n.elements.is_empty());
+        if any_empty {
+            let mut indices = self
+                .nodes
+                .iter()
+                .map(|i| (i.start_index, i.elements.len()))
+                .collect::<Vec<_>>();
+            indices.sort_unstable_by_key(|v| v.0);
+            dbg!(&self, index, indices);
+            panic!("empty insert {:?}", index)
+        }
+    }
+
+    pub fn push_back(&mut self, opid: OpId, element: T) {
+        let mut new_node_needed = false;
+        let len = self.len();
+        self.length += 1;
+        if self.nodes.is_empty() {
+            new_node_needed = true
+        } else {
+            for node in &mut self.nodes {
+                if node.start_index + node.elements.len() == len {
+                    if opid.1 == node.actor
+                        && opid.0 == node.start_counter + node.elements.len() as u64
+                    {
+                        node.elements.push(element.clone())
+                    } else {
+                        new_node_needed = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if new_node_needed {
+            self.nodes.push(SequenceTreeNode {
+                actor: opid.1,
+                start_counter: opid.0,
+                start_index: self.len() - 1,
+                elements: vec![element],
+            })
+        }
+        let any_empty = self.nodes.iter().any(|n| n.elements.is_empty());
+        if any_empty {
+            let mut indices = self
+                .nodes
+                .iter()
+                .map(|i| (i.start_index, i.elements.len()))
+                .collect::<Vec<_>>();
+            indices.sort_unstable_by_key(|v| v.0);
+            dbg!(&self, indices);
+            panic!("empty push_back")
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
+        for node in &self.nodes {
+            if index >= node.start_index && index < node.start_index + node.elements.len() {
+                return node.elements.get(index - node.start_index).map(|v| {
+                    (
+                        OpId(
+                            node.start_counter + (index - node.start_index) as u64,
+                            node.actor.clone(),
+                        ),
+                        v,
+                    )
+                });
+            }
+        }
+        let mut indices = self
+            .nodes
+            .iter()
+            .map(|i| (i.start_index, i.elements.len()))
+            .collect::<Vec<_>>();
+        indices.sort_unstable_by_key(|v| v.0);
+        dbg!(&self, index, indices);
+        None
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
+        for node in &mut self.nodes {
+            if index >= node.start_index && index < node.start_index + node.elements.len() {
+                let counter = node.start_counter + (index - node.start_index) as u64;
+                let actor = node.actor.clone();
+                return node
+                    .elements
+                    .get_mut(index - node.start_index)
+                    .map(|v| (OpId(counter, actor), v));
+            }
+        }
+        None
+    }
+
+    pub fn remove(&mut self, index: usize) -> T {
+        self.length -= 1;
+        let mut split_node = None;
+
+        let mut to_return = None;
+        let mut node_to_remove = None;
+
+        for (i, node) in self.nodes.iter_mut().enumerate() {
+            if index < node.start_index {
+                node.start_index -= 1
+            } else if index == node.start_index {
+                node.start_counter += 1;
+                node.start_index -= 1;
+                if node.elements.len() == 1 {
+                    node_to_remove = Some(i)
+                }
+                to_return = Some(node.elements.remove(0))
+            } else if index > node.start_index && index < node.start_index + node.elements.len() {
+                let other_elements = node.elements.split_off((index - node.start_index) + 1);
+                if !other_elements.is_empty() {
+                    split_node = Some(SequenceTreeNode {
+                        actor: node.actor.clone(),
+                        start_counter: node.start_counter + (index - node.start_index) as u64,
+                        start_index: index,
+                        elements: other_elements,
+                    });
+                }
+
+                if node.elements.len() == 1 {
+                    node_to_remove = Some(i)
+                }
+                to_return = Some(node.elements.remove(index - node.start_index))
+            } else if index > node.start_index && index == node.start_index + node.elements.len() {
+                // at the end, may be able to add it if correct actorid and counter
+                if node.elements.len() == 1 {
+                    node_to_remove = Some(i)
+                }
+                to_return = Some(node.elements.remove(node.elements.len() - 1))
+            } else {
+                // do nothing
+            }
+        }
+
+        if let Some(i) = node_to_remove {
+            self.nodes.remove(i);
+        }
+
+        if let Some(node) = split_node {
+            self.nodes.push(node)
+        }
+
+        let any_empty = self.nodes.iter().any(|n| n.elements.is_empty());
+        if any_empty {
+            let mut indices = self
+                .nodes
+                .iter()
+                .map(|i| (i.start_index, i.elements.len()))
+                .collect::<Vec<_>>();
+            indices.sort_unstable_by_key(|v| v.0);
+            dbg!(&self, index, indices);
+            panic!("empty remove {:?}", index)
+        }
+
+        to_return.unwrap()
+    }
+
+    pub fn set(&mut self, index: usize, element: T) -> T {
+        // TODO
+        todo!()
     }
 }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -7,6 +7,15 @@ pub struct SequenceTree<T, const B: usize> {
     root_node: Option<SequenceTreeNode<T, B>>,
 }
 
+impl<T> Default for SequenceTree<T, 9>
+where
+    T: Clone + Debug,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 struct SequenceTreeNode<T, const B: usize> {
     elements: Vec<Box<(OpId, T)>>,
@@ -561,7 +570,7 @@ mod tests {
 
     #[test]
     fn push_back() {
-        let mut t = SequenceTree::new();
+        let mut t = SequenceTree::default();
         let actor = ActorId::random();
 
         t.push_back(actor.op_id_at(1), ());
@@ -576,7 +585,7 @@ mod tests {
 
     #[test]
     fn insert() {
-        let mut t = SequenceTree::new();
+        let mut t = SequenceTree::default();
         let actor = ActorId::random();
 
         t.insert(0, actor.op_id_at(1), ());
@@ -590,7 +599,7 @@ mod tests {
 
     #[test]
     fn insert_book() {
-        let mut t = SequenceTree::new();
+        let mut t = SequenceTree::default();
         let actor = ActorId::random();
 
         for i in 0..100 {
@@ -600,7 +609,7 @@ mod tests {
 
     #[test]
     fn insert_book_vec() {
-        let mut t = SequenceTree::new();
+        let mut t = SequenceTree::default();
         let actor = ActorId::random();
         let mut v = Vec::new();
 
@@ -630,7 +639,7 @@ mod tests {
 
         #[test]
         fn proptest_insert(indices in arb_indices()) {
-            let mut t = SequenceTree::new();
+            let mut t = SequenceTree::default();
             let actor = ActorId::random();
             let mut v = Vec::new();
 
@@ -652,7 +661,7 @@ mod tests {
 
         #[test]
         fn proptest_remove(inserts in arb_indices(), removes in arb_indices()) {
-            let mut t = SequenceTree::new();
+            let mut t = SequenceTree::default();
             let actor = ActorId::random();
             let mut v = Vec::new();
 

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -80,7 +80,7 @@ where
             let old = root.remove(index);
 
             if root.elements.is_empty() {
-                if root.children.is_empty() {
+                if root.is_leaf() {
                     self.root_node = None;
                 } else {
                     self.root_node = Some(root.children[0].clone());
@@ -106,8 +106,12 @@ where
         self.elements.len() + self.children.iter().map(|c| c.len()).sum::<usize>()
     }
 
+    fn is_leaf(&self) -> bool {
+        self.children.is_empty()
+    }
+
     fn insert_non_full(&mut self, index: usize, opid: OpId, element: T) {
-        if self.children.is_empty() {
+        if self.is_leaf() {
             // leaf
 
             self.elements.insert(index, (opid, element));
@@ -153,7 +157,7 @@ where
         let y = &mut self.children[i];
         dbg!(&y);
         z.elements = y.elements.split_off(T);
-        if !y.children.is_empty() {
+        if !y.is_leaf() {
             z.children = y.children.split_off(T);
         }
 
@@ -180,7 +184,7 @@ where
                 todo!("remove in a child")
             } else if total_index + child.len() == index {
                 // in this node
-                if self.children.is_empty() {
+                if self.is_leaf() {
                     return self.remove_from_leaf(ci);
                 } else {
                     todo!("delete internal key")
@@ -196,7 +200,7 @@ where
 
     pub fn set(&mut self, mut index: usize, element: T) -> T {
         let mut i = 0;
-        if self.children.is_empty() {
+        if self.is_leaf() {
             let (_, old_element) = self.elements.get_mut(i).unwrap();
             std::mem::replace(old_element, element)
         } else {
@@ -218,7 +222,7 @@ where
 
     pub fn get(&self, mut index: usize) -> Option<(OpId, &T)> {
         let mut i = 0;
-        if self.children.is_empty() {
+        if self.is_leaf() {
             return self.elements.get(index).map(|(o, t)| (o.clone(), t));
         } else {
             for c in &self.children {
@@ -228,7 +232,7 @@ where
                 } else if index == c_len {
                     return self.elements.get(i).map(|(o, t)| (o.clone(), t));
                 } else {
-                    index -= c_len;
+                    index -= c_len + 1;
                     i += 1;
                 }
             }
@@ -238,7 +242,7 @@ where
 
     pub fn get_mut(&mut self, mut index: usize) -> Option<(OpId, &mut T)> {
         let mut i = 0;
-        if self.children.is_empty() {
+        if self.is_leaf() {
             return self.elements.get_mut(index).map(|(o, t)| (o.clone(), t));
         } else {
             for c in &mut self.children {
@@ -248,7 +252,7 @@ where
                 } else if index == c_len {
                     return self.elements.get_mut(i).map(|(o, t)| (o.clone(), t));
                 } else {
-                    index -= c_len;
+                    index -= c_len + 1;
                     i += 1;
                 }
             }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -437,7 +437,7 @@ where
                     }
                 }
             }
-            panic!("Invalid index to set")
+            panic!("Invalid index to set: {} but len was {}", index, self.len())
         }
     }
 

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -232,9 +232,9 @@ where
         self.length -= 1;
         if self.children[child_index].elements.len() >= T {
             // recursively delete index - 1 in predecessor_node
-            let value = self.children[child_index].remove(index);
+            let predecessor = self.children[child_index].remove(index - 1);
             // replace element with that one
-            std::mem::replace(&mut self.elements[child_index], value)
+            std::mem::replace(&mut self.elements[child_index], predecessor)
         } else {
             // predecessor_node.elements.len() < T
             let successor_node = &mut self.children[child_index + 1];

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -52,7 +52,7 @@ where
     /// # Panics
     ///
     /// Panics if `index > len`.
-    pub fn insert(&mut self, mut index: usize, opid: OpId, element: T) {
+    pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
         let old_len = self.len();
         if let Some(root) = self.root_node.as_mut() {
             #[cfg(debug_assertions)]
@@ -69,16 +69,18 @@ where
                 root.children.push(old_root);
                 root.split_child(0);
 
+                assert_eq!(original_len, root.len());
+
                 // after splitting the root has one element and two children, find which child the
                 // index is in
-                let mut i = 0;
-                if root.children[0].len() < index {
-                    i += 1;
-                    index -= root.children[0].len() + 1
-                }
-                assert_eq!(original_len, root.len());
+                let first_child_len = root.children[0].len();
+                let (child, insertion_index) = if first_child_len < index {
+                    (&mut root.children[1], index - (first_child_len + 1))
+                } else {
+                    (&mut root.children[0], index)
+                };
                 root.length += 1;
-                root.children[i].insert_into_non_full_node(index, opid, element)
+                child.insert_into_non_full_node(insertion_index, opid, element)
             } else {
                 root.insert_into_non_full_node(index, opid, element)
             }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -31,7 +31,7 @@ where
         self.len() == 0
     }
 
-    pub fn iter<'a>(&'a self) -> Iter<'a, T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             inner: self,
             index: 0,
@@ -142,10 +142,8 @@ where
                         let num_children = self.children.len();
                         let mut cumulative_len = 0;
                         for c in self.children.iter_mut() {
-                            if cumulative_len + c.len() >= index {
-                                c.insert_non_full(index - cumulative_len, opid, element);
-                                break;
-                            } else if child_index == num_children - 1 {
+                            if cumulative_len + c.len() >= index || child_index == num_children - 1
+                            {
                                 c.insert_non_full(index - cumulative_len, opid, element);
                                 break;
                             } else {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -121,12 +121,20 @@ where
                     if c.elements.len() == 2 * T - 1 {
                         self.split_child(child_index);
 
-                        todo!("find which split child to insert into")
+                        let mut cumulative_len = 0;
+                        for c in self.children.iter_mut() {
+                            cumulative_len += c.len();
+                            if cumulative_len > index {
+                                c.insert_non_full(index - i, opid, element);
+                                break;
+                            }
+                        }
+                    } else {
+                        c.insert_non_full(index - i, opid, element);
                     }
-                    c.insert_non_full(index - i, opid, element);
                     break;
                 } else {
-                    i += c.len()
+                    i += c.len() + 1
                 }
             }
         }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -465,20 +465,21 @@ where
         }
     }
 
-    pub fn get(&self, mut index: usize) -> Option<(OpId, &T)> {
+    pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
         if self.is_leaf() {
             return self.elements.get(index).map(|b| (b.0.clone(), &b.1));
         } else {
+            let mut cumulative_len = 0;
             for (child_index, child) in self.children.iter().enumerate() {
-                match index.cmp(&child.len()) {
+                match (cumulative_len + child.len()).cmp(&index) {
                     Ordering::Less => {
-                        return child.get(index);
+                        cumulative_len += child.len() + 1;
                     }
                     Ordering::Equal => {
                         return self.elements.get(child_index).map(|b| (b.0.clone(), &b.1));
                     }
                     Ordering::Greater => {
-                        index -= child.len() + 1;
+                        return child.get(index - cumulative_len);
                     }
                 }
             }
@@ -486,17 +487,18 @@ where
         None
     }
 
-    pub fn get_mut(&mut self, mut index: usize) -> Option<(OpId, &mut T)> {
+    pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
         if self.is_leaf() {
             return self
                 .elements
                 .get_mut(index)
                 .map(|b| (b.0.clone(), &mut b.1));
         } else {
+            let mut cumulative_len = 0;
             for (child_index, child) in self.children.iter_mut().enumerate() {
-                match index.cmp(&child.len()) {
+                match (cumulative_len + child.len()).cmp(&index) {
                     Ordering::Less => {
-                        return child.get_mut(index);
+                        cumulative_len += child.len() + 1;
                     }
                     Ordering::Equal => {
                         return self
@@ -505,7 +507,7 @@ where
                             .map(|b| (b.0.clone(), &mut b.1));
                     }
                     Ordering::Greater => {
-                        index -= child.len() + 1;
+                        return child.get_mut(index - cumulative_len);
                     }
                 }
             }

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -177,7 +177,6 @@ where
         };
 
         let y = &mut self.children[i];
-        dbg!(&y);
         z.elements = y.elements.split_off(T);
         if !y.is_leaf() {
             z.children = y.children.split_off(T);

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -9,7 +9,10 @@ pub struct SequenceTree<T> {
 
 #[derive(Clone, Debug, PartialEq)]
 enum SequenceTreeNode<T> {
-    Leaf(OpId, T),
+    Leaf {
+        opid: OpId,
+        element: T,
+    },
     Node {
         left: Option<Box<SequenceTreeNode<T>>>,
         right: Option<Box<SequenceTreeNode<T>>>,
@@ -71,14 +74,17 @@ where
 {
     pub fn len(&self) -> usize {
         match self {
-            SequenceTreeNode::Leaf(..) => 1,
+            SequenceTreeNode::Leaf { .. } => 1,
             SequenceTreeNode::Node { len, .. } => *len,
         }
     }
 
     pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
         match self {
-            SequenceTreeNode::Leaf(_old_opid, _old_element) => {
+            SequenceTreeNode::Leaf {
+                opid: _,
+                element: _,
+            } => {
                 let leaf = std::mem::replace(
                     self,
                     SequenceTreeNode::Node {
@@ -88,9 +94,16 @@ where
                     },
                 );
 
-                if let SequenceTreeNode::Leaf(old_opid, old_element) = leaf {
-                    let left = Some(Box::new(SequenceTreeNode::Leaf(old_opid, old_element)));
-                    let right = Some(Box::new(SequenceTreeNode::Leaf(opid, element)));
+                if let SequenceTreeNode::Leaf {
+                    opid: old_opid,
+                    element: old_element,
+                } = leaf
+                {
+                    let left = Some(Box::new(SequenceTreeNode::Leaf {
+                        opid: old_opid,
+                        element: old_element,
+                    }));
+                    let right = Some(Box::new(SequenceTreeNode::Leaf { opid, element }));
                     *self = SequenceTreeNode::Node {
                         left,
                         right,
@@ -107,13 +120,13 @@ where
                     if let Some(right) = right {
                         right.insert(index - left_len, opid, element)
                     } else {
-                        *right = Some(Box::new(SequenceTreeNode::Leaf(opid, element)))
+                        *right = Some(Box::new(SequenceTreeNode::Leaf { opid, element }))
                     }
                 } else {
                     if let Some(left) = left {
                         left.insert(index, opid, element)
                     } else {
-                        *left = Some(Box::new(SequenceTreeNode::Leaf(opid, element)))
+                        *left = Some(Box::new(SequenceTreeNode::Leaf { opid, element }))
                     }
                 }
             }
@@ -122,7 +135,10 @@ where
 
     pub fn remove(&mut self, index: usize) -> T {
         match self {
-            SequenceTreeNode::Leaf(_old_opid, _old_element) => {
+            SequenceTreeNode::Leaf {
+                opid: _,
+                element: _,
+            } => {
                 unreachable!("shouldn't be calling remove on a leaf, just a node")
             }
             SequenceTreeNode::Node { left, right, len } => {
@@ -130,9 +146,15 @@ where
                 *len -= 1;
                 if index > left_len {
                     if let Some(right_child) = right {
-                        if let SequenceTreeNode::Leaf(_opid, _element) = &**right_child {
+                        if let SequenceTreeNode::Leaf {
+                            opid: _,
+                            element: _,
+                        } = &**right_child
+                        {
                             let right_child = std::mem::take(right);
-                            if let SequenceTreeNode::Leaf(_, element) = *right_child.unwrap() {
+                            if let SequenceTreeNode::Leaf { opid: _, element } =
+                                *right_child.unwrap()
+                            {
                                 element
                             } else {
                                 unreachable!("was leaf then wasn't leaf")
@@ -145,9 +167,15 @@ where
                     }
                 } else {
                     if let Some(left_child) = left {
-                        if let SequenceTreeNode::Leaf(_opid, _element) = &**left_child {
+                        if let SequenceTreeNode::Leaf {
+                            opid: _,
+                            element: _,
+                        } = &**left_child
+                        {
                             let left_child = std::mem::take(left);
-                            if let SequenceTreeNode::Leaf(_, element) = *left_child.unwrap() {
+                            if let SequenceTreeNode::Leaf { opid: _, element } =
+                                *left_child.unwrap()
+                            {
                                 element
                             } else {
                                 unreachable!("was leaf then wasn't leaf")
@@ -165,7 +193,10 @@ where
 
     pub fn set(&mut self, index: usize, element: T) -> T {
         match self {
-            SequenceTreeNode::Leaf(_, old_element) => std::mem::replace(old_element, element),
+            SequenceTreeNode::Leaf {
+                opid: _,
+                element: old_element,
+            } => std::mem::replace(old_element, element),
             SequenceTreeNode::Node {
                 left,
                 right,
@@ -191,7 +222,7 @@ where
 
     pub fn get(&self, index: usize) -> Option<(OpId, &T)> {
         match &self {
-            SequenceTreeNode::Leaf(opid, element) => Some((opid.clone(), element)),
+            SequenceTreeNode::Leaf { opid, element } => Some((opid.clone(), element)),
             SequenceTreeNode::Node {
                 left,
                 right,
@@ -209,7 +240,7 @@ where
 
     pub fn get_mut(&mut self, index: usize) -> Option<(OpId, &mut T)> {
         match self {
-            SequenceTreeNode::Leaf(opid, element) => Some((opid.clone(), element)),
+            SequenceTreeNode::Leaf { opid, element } => Some((opid.clone(), element)),
             SequenceTreeNode::Node {
                 left,
                 right,

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -641,7 +641,7 @@ mod tests {
     }
 
     fn arb_indices() -> impl Strategy<Value = Vec<usize>> {
-        proptest::collection::vec(any::<usize>(), 0..100).prop_map(|v| {
+        proptest::collection::vec(any::<usize>(), 0..1000).prop_map(|v| {
             let mut len = 0;
             v.into_iter()
                 .map(|i| {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -237,7 +237,6 @@ where
             if successor_node.elements.len() >= T {
                 // recursively delete index - 1 in predecessor_node
                 let value = successor_node.remove(index);
-                successor_node.length -= 1;
                 // replace element with that one
                 std::mem::replace(&mut self.elements[child_index], value)
             } else {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -147,8 +147,26 @@ where
         todo!()
     }
 
-    pub fn set(&mut self, index: usize, element: T) -> T {
-        todo!()
+    pub fn set(&mut self, mut index: usize, element: T) -> T {
+        let mut i = 0;
+        if self.children.is_empty() {
+            let (_, old_element) = self.elements.get_mut(i).unwrap();
+            std::mem::replace(old_element, element)
+        } else {
+            for c in &mut self.children {
+                let c_len = c.len();
+                if index < c_len {
+                    return c.set(index, element);
+                } else if index == c_len {
+                    let (_, old_element) = self.elements.get_mut(i).unwrap();
+                    return std::mem::replace(old_element, element);
+                } else {
+                    index -= c_len;
+                    i += 1;
+                }
+            }
+            panic!("Invalid index to set")
+        }
     }
 
     pub fn get(&self, mut index: usize) -> Option<(OpId, &T)> {

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use automerge_protocol::{ActorId, OpId};
+
+pub struct SequenceTree<T> {
+    nodes: Vec<SequenceTreeNode<T>>,
+}
+
+pub struct SequenceTreeNode<T> {
+        actor: ActorId,
+        start_counter:usize,
+        start_index: usize,
+        elements: Vec<T>,
+}
+
+impl<T> SequenceTree<T> {
+    pub fn new() -> Self {
+        Self {
+            nodes:Vec::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        todo!()
+    }
+
+    pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
+        // add 1 to length
+        //
+        // go through nodes trying to insert
+
+        for node in nodes {
+            if node.
+        }
+    }
+}
+
+impl<T> SequenceTreeNode<T> {
+    pub fn new() -> Self {
+        Self::Children { nodes: Vec::new() }
+    }
+
+    pub fn insert(&mut self, index: usize, opid: OpId, element: T) {
+        match self {
+            SequenceTreeNode::Items {
+                actor,
+                start_index,
+                elements,
+            } => todo!(),
+            SequenceTreeNode::Children { nodes } => {
+                for node in nodes {
+                    if node
+                }
+            },
+        }
+    }
+}

--- a/automerge-frontend/src/state_tree/sequence_tree.rs
+++ b/automerge-frontend/src/state_tree/sequence_tree.rs
@@ -76,8 +76,21 @@ where
     }
 
     pub fn remove(&mut self, index: usize) -> T {
-        println!("remove {}", index);
-        self.root_node.as_mut().unwrap().remove(index)
+        if let Some(root) = self.root_node.as_mut() {
+            let old = root.remove(index);
+
+            if root.elements.is_empty() {
+                if root.children.is_empty() {
+                    self.root_node = None;
+                } else {
+                    self.root_node = Some(root.children[0].clone());
+                }
+            }
+
+            old
+        } else {
+            panic!("remove from empty tree")
+        }
     }
 
     pub fn set(&mut self, index: usize, element: T) -> T {
@@ -143,8 +156,34 @@ where
         self.elements.insert(i, middle);
     }
 
-    pub fn remove(&mut self, index: usize) -> T {
+    fn remove_from_leaf(&mut self, index: usize) -> T {
+        self.elements.remove(index).1
+    }
+
+    fn remove_from_non_leaf(&mut self, index: usize) -> T {
         todo!()
+    }
+
+    pub fn remove(&mut self, index: usize) -> T {
+        let mut total_index = 0;
+        for (ci, child) in self.children.iter().enumerate() {
+            if total_index + child.len() > index {
+                // in that child
+                todo!("remove in a child")
+            } else if total_index + child.len() == index {
+                // in this node
+                if self.children.is_empty() {
+                    return self.remove_from_leaf(ci);
+                } else {
+                    todo!("delete internal key")
+                }
+            } else {
+                // should be later on in the loop
+                total_index += child.len();
+                continue;
+            }
+        }
+        panic!("index not found to remove")
     }
 
     pub fn set(&mut self, mut index: usize, element: T) -> T {

--- a/perf/src/main.rs
+++ b/perf/src/main.rs
@@ -320,6 +320,7 @@ fn trace(edits: Vec<(u32, u32, Option<String>)>) {
         let (patch, _) = backend.apply_local_change(change).unwrap();
         doc.apply_patch(patch).unwrap();
     }
+    println!("processed all changes in {:?}", loop_start.elapsed());
 
     let save = Instant::now();
     let bytes = backend.save().unwrap();


### PR DESCRIPTION
Taking some inspiration from [joseph's blog article](https://josephg.com/blog/crdts-go-brrr/) as well as seeing very poor performance in the flamegraphs from `im_rc::Vector` I decided to work on a simple btree-like implementation for sequences.

This doesn't do anything fancy like RLE encoding sequences of opids but does give us a very nice speed up and changes the bottleneck.

On my machine the main branch (`3c786b26`) runs the automerge trace (as implemented in the `perf` binary, roughly) in about 45 seconds, while this branch (at time of writing) runs in about 2 seconds.