### PR TITLE
Correctly sort actor IDs when encoding changes

### DIFF
--- a/automerge-backend/src/backend.rs
+++ b/automerge-backend/src/backend.rs
@@ -369,6 +369,13 @@ impl Backend {
         Ok(backend)
     }
 
+    pub fn load_without_hash_verification(data: &[u8]) -> Result<Self, AutomergeError> {
+        let changes = Change::load_document_without_hash_verification(data)?;
+        let mut backend = Self::new();
+        backend.load_changes(changes)?;
+        Ok(backend)
+    }
+
     pub fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<amp::ChangeHash> {
         let in_queue: HashSet<_> = self.queue.iter().map(|change| change.hash).collect();
         let mut missing = HashSet::new();

--- a/automerge-backend/src/decoding.rs
+++ b/automerge-backend/src/decoding.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::{borrow::Cow, convert::TryFrom, io, io::Read, str};
+use std::{borrow::Cow, collections::HashSet, convert::TryFrom, io, io::Read, str};
 
 use automerge_protocol as amp;
 use smol_str::SmolStr;
@@ -41,8 +41,11 @@ pub enum Error {
     NoDocChanges,
     #[error("An overflow would have occurred, the data may be corrupt")]
     Overflow,
-    #[error("Calculated heads differed from actual heads")]
-    MismatchedHeads,
+    #[error("Calculated heads differed from actual heads. Calculated: {derived_heads:?} != stated {stated_heads:?}")]
+    MismatchedHeads {
+        derived_heads: HashSet<amp::ChangeHash>,
+        stated_heads: HashSet<amp::ChangeHash>,
+    },
     #[error("Failed to read leb128 number {0}")]
     Leb128(#[from] leb128::read::Error),
     #[error(transparent)]

--- a/automerge-backend/src/expanded_op.rs
+++ b/automerge-backend/src/expanded_op.rs
@@ -44,6 +44,8 @@ impl<'a> Iterator for ExpandedOpIterator<'a> {
                     if count.get() == 1 {
                         InternalOpType::Del
                     } else {
+                        // TODO this error should not cause a panic. Therefore this iterator should
+                        // be fallible
                         assert_eq!(
                             op.pred.len(),
                             1,

--- a/automerge-backend/tests/bad_hashes.rs
+++ b/automerge-backend/tests/bad_hashes.rs
@@ -1,0 +1,36 @@
+use automerge_protocol as amp;
+
+// Reproduces the problem encountered in https://github.com/automerge/automerge-rs/issues/240
+#[test]
+fn mismatched_head_repro_one() {
+    let op_json = serde_json::json!({
+        "ops": [
+            {
+                "action": "del",
+                "obj": "1@1485eebc689d47efbf8b892e81653eb3",
+                "elemId": "3164@0dcdf83d9594477199f80ccd25e87053",
+                "multiOp": 1,
+                "pred": [
+                    "3164@0dcdf83d9594477199f80ccd25e87053"
+                ]
+            },
+        ],
+        "actor": "e63cf5ed1f0a4fb28b2c5bc6793b9272",
+        "hash": "e7fd5c02c8fdd2cdc3071ce898a5839bf36229678af3b940f347da541d147ae2",
+        "seq": 1,
+        "startOp": 3179,
+        "time": 1634146652,
+        "message": null,
+        "deps": [
+            "2603cded00f91e525507fc9e030e77f9253b239d90264ee343753efa99e3fec1"
+        ]
+    });
+
+    let change: amp::Change = serde_json::from_value(op_json).unwrap();
+    let expected_hash: amp::ChangeHash =
+        "4dff4665d658a28bb6dcace8764eb35fa8e48e0a255e70b6b8cbf8e8456e5c50"
+            .parse()
+            .unwrap();
+    let encoded: automerge_backend::Change = change.into();
+    assert_eq!(encoded.hash, expected_hash);
+}

--- a/automerge-cli/Cargo.toml
+++ b/automerge-cli/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0.16"
 combine = "4.5.2"
 maplit = "1.0.2"
 colored_json = "2.1.0"
+tracing-subscriber = "^0.2"
 
 automerge-backend = { path = "../automerge-backend" }
 automerge-frontend = { path = "../automerge-frontend" }

--- a/automerge-cli/src/examine.rs
+++ b/automerge-cli/src/examine.rs
@@ -30,7 +30,7 @@ pub fn examine(
     input
         .read_to_end(&mut buf)
         .map_err(|e| ExamineError::ReadingChanges { source: e })?;
-    let changes = amb::Change::load_document(&buf)
+    let changes = amb::Change::load_document_without_hash_verification(&buf)
         .map_err(|e| ExamineError::ApplyingInitialChanges { source: e })?;
     let uncompressed_changes: Vec<amp::Change> = changes.iter().map(|c| c.decode()).collect();
     if is_tty {

--- a/automerge-cli/src/main.rs
+++ b/automerge-cli/src/main.rs
@@ -142,6 +142,7 @@ fn create_file_or_stdout(maybe_path: Option<PathBuf>) -> Result<Box<dyn std::io:
 }
 
 fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
     let opts = Opts::parse();
     match opts.cmd {
         Command::Export {


### PR DESCRIPTION
The javascript implementation of automerge sorts actor IDs
lexicographically when encoding changes. We were sorting actor IDs in
the order the appear in the change we're encoding. This meant that the
index that we assigned to operations in the encoded change was different
to that which the javascript implementation assigns, resulting in
mismatched head errors as the hashes we created did not match the
javascript implementation.

This change fixes the issue by introducing a `HexActoId` type which we
use to sort actor IDs lexicographically. We make a pass over the
operations in the change before encoding to collect the actor IDs and
sort them. This means we no longer need to pass a mutable `Vec<ActorId>`
to the various encode functions, which cleans things up a little.

Fixes #240