### PR TITLE
automerge::set - don't generate ops for noops

### DIFF
--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -226,7 +226,10 @@ impl Automerge {
         let prop = self.import_prop(prop)?;
         let value = self.import_value(value, datatype)?;
         let opid = self.0.set(obj, prop, value).map_err(to_js_err)?;
-        Ok(self.export(opid))
+        match opid {
+            Some(opid) => Ok(self.export(opid)),
+            None => Ok(JsValue::null()),
+        }
     }
 
     pub fn inc(&mut self, obj: JsValue, prop: JsValue, value: JsValue) -> Result<(), JsValue> {

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -1,0 +1,46 @@
+use automerge::Automerge;
+
+#[test]
+fn no_conflict_on_repeated_assignment() {
+    let mut doc = Automerge::new();
+    doc.set(automerge::ROOT, "foo", 1).unwrap();
+    doc.set(automerge::ROOT, "foo", 2).unwrap();
+    assert_eq!(
+        doc.values(automerge::ROOT, "foo")
+            .unwrap()
+            .into_iter()
+            .map(|e| e.0)
+            .collect::<Vec<automerge::Value>>(),
+        vec![2.into()]
+    );
+}
+
+#[test]
+fn no_change_on_repeated_map_set() {
+    let mut doc = Automerge::new();
+    doc.set(automerge::ROOT, "foo", 1).unwrap();
+    assert!(doc.set(automerge::ROOT, "foo", 1).unwrap().is_none());
+}
+
+#[test]
+fn no_change_on_repeated_list_set() {
+    let mut doc = Automerge::new();
+    let list_id = doc
+        .set(automerge::ROOT, "list", automerge::Value::list())
+        .unwrap()
+        .unwrap();
+    doc.insert(list_id, 0, 1).unwrap();
+    doc.set(list_id, 0, 1).unwrap();
+    assert!(doc.set(list_id, 0, 1).unwrap().is_none());
+}
+
+#[test]
+fn no_change_on_list_insert_followed_by_set_of_same_value() {
+    let mut doc = Automerge::new();
+    let list_id = doc
+        .set(automerge::ROOT, "list", automerge::Value::list())
+        .unwrap()
+        .unwrap();
+    doc.insert(list_id, 0, 1).unwrap();
+    assert!(doc.set(list_id, 0, 1).unwrap().is_none());
+}

--- a/edit-trace/src/main.rs
+++ b/edit-trace/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), AutomergeError> {
     let mut doc = Automerge::new();
 
     let now = Instant::now();
-    let text = doc.set(ROOT, "text", Value::text()).unwrap();
+    let text = doc.set(ROOT, "text", Value::text()).unwrap().unwrap();
     for (i, (pos, del, vals)) in commands.into_iter().enumerate() {
         if i % 1000 == 0 {
             println!("Processed {} edits in {} ms", i, now.elapsed().as_millis());


### PR DESCRIPTION
Repeatedly setting the same value for a particular (obj, key)
combination now no longer generates an operation. To allow this we
modify the return value of `automerge::set` so that it may return an
`Option<OpId>` instead of an `OpId`.