### PR TITLE
Run the js tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,11 @@
 name: ci
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+    - experiment
+  pull_request:
+    branches:
+    - experiment
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -52,6 +58,15 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}
+
+  js_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: run tests
+        run: ./scripts/ci/js_tests
 
   linux:
     runs-on: ubuntu-latest

--- a/automerge-js/package.json
+++ b/automerge-js/package.json
@@ -10,7 +10,7 @@
     "mocha": "^9.1.1"
   },
   "dependencies": {
-    "automerge-wasm": "file:../automerge-wasm",
+    "automerge-wasm": "file:../automerge-wasm/dev",
     "fast-sha256": "^1.3.0",
     "pako": "^2.0.4",
     "uuid": "^8.3"

--- a/scripts/ci/js_tests
+++ b/scripts/ci/js_tests
@@ -1,0 +1,18 @@
+THIS_SCRIPT=$(dirname "$0");
+WASM_PROJECT=$THIS_SCRIPT/../../automerge-wasm;
+JS_PROJECT=$THIS_SCRIPT/../../automerge-js;
+
+yarn --cwd $WASM_PROJECT install;
+# This will take care of running wasm-pack
+yarn --cwd $WASM_PROJECT build;
+# If the dependencies are already installed we delete automerge-wasm. This makes
+# this script usable for iterative development.
+if [ -d $JS_PROJECT/node_modules/automerge-wasm ]; then
+    rm -rf $JS_PROJECT/node_modules/automerge-wasm
+fi
+# --check-files forces yarn to check if the local dep has changed
+yarn --cwd $JS_PROJECT install --check-files;
+yarn --cwd $JS_PROJECT test;
+
+
+

--- a/scripts/ci/run
+++ b/scripts/ci/run
@@ -6,3 +6,4 @@ set -eou pipefail
 ./scripts/ci/build-test
 ./scripts/ci/docs
 ./scripts/ci/advisory
+./scripts/ci/js_tests


### PR DESCRIPTION
We add a script for running the js tests in `scripts/ci/js_tests`. This
script can also be run locally. We move the `automerge-js` package to
below the `automerge-wasm` crate as it is specifically testing the wasm
interface. We also add an action to the github actions workflow for CI
to run the js tests.