### PR TITLE
Expose a non-document-specific opid

### DIFF
--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::fmt::Display;
+use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -149,7 +150,7 @@ impl Automerge {
     }
 
     pub fn keys(&mut self, obj: JsValue, heads: JsValue) -> Result<Array, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let result = if let Some(heads) = get_heads(heads) {
             self.0.keys_at(obj, &heads)
         } else {
@@ -162,7 +163,7 @@ impl Automerge {
     }
 
     pub fn text(&mut self, obj: JsValue, heads: JsValue) -> Result<JsValue, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         if let Some(heads) = get_heads(heads) {
             self.0.text_at(obj, &heads)
         } else {
@@ -179,7 +180,7 @@ impl Automerge {
         delete_count: JsValue,
         text: JsValue,
     ) -> Result<(), JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let start = to_usize(start, "start")?;
         let delete_count = to_usize(delete_count, "deleteCount")?;
         let mut vals = vec![];
@@ -214,7 +215,7 @@ impl Automerge {
         value: JsValue,
         datatype: JsValue,
     ) -> Result<JsValue, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         //let key = self.insert_pos_for_index(&obj, prop)?;
         let index: Result<_, JsValue> = index
             .as_f64()
@@ -235,7 +236,7 @@ impl Automerge {
         value: JsValue,
         datatype: JsValue,
     ) -> Result<JsValue, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let prop = self.import_prop(prop)?;
         let value = self.import_value(value, datatype)?;
         let opid = self.0.set(obj, prop, value).map_err(to_js_err)?;
@@ -246,7 +247,7 @@ impl Automerge {
     }
 
     pub fn inc(&mut self, obj: JsValue, prop: JsValue, value: JsValue) -> Result<(), JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let prop = self.import_prop(prop)?;
         let value: f64 = value
             .as_f64()
@@ -257,7 +258,7 @@ impl Automerge {
     }
 
     pub fn value(&mut self, obj: JsValue, prop: JsValue, heads: JsValue) -> Result<Array, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let result = Array::new();
         let prop = to_prop(prop);
         let heads = get_heads(heads);
@@ -284,7 +285,7 @@ impl Automerge {
     }
 
     pub fn values(&mut self, obj: JsValue, arg: JsValue, heads: JsValue) -> Result<Array, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let result = Array::new();
         let prop = to_prop(arg);
         if let Ok(prop) = prop {
@@ -316,7 +317,7 @@ impl Automerge {
     }
 
     pub fn length(&mut self, obj: JsValue, heads: JsValue) -> Result<JsValue, JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         if let Some(heads) = get_heads(heads) {
             Ok((self.0.length_at(obj, &heads) as f64).into())
         } else {
@@ -325,7 +326,7 @@ impl Automerge {
     }
 
     pub fn del(&mut self, obj: JsValue, prop: JsValue) -> Result<(), JsValue> {
-        let obj = self.import(obj)?;
+        let obj: automerge::ObjId = self.import(obj)?;
         let prop = to_prop(prop)?;
         self.0.del(obj, prop).map_err(to_js_err)?;
         Ok(())
@@ -442,16 +443,18 @@ impl Automerge {
         }
     }
 
-    fn export<E: automerge::Exportable>(&self, val: E) -> JsValue {
-        self.0.export(val).into()
+    fn export<D: std::fmt::Display>(&self, val: D) -> JsValue {
+        val.to_string().into()
     }
 
-    fn import<I: automerge::Importable>(&self, id: JsValue) -> Result<I, JsValue> {
-        let id_str = id
-            .as_string()
-            .ok_or("invalid opid/objid/elemid")
-            .map_err(to_js_err)?;
-        self.0.import(&id_str).map_err(to_js_err)
+    fn import<F: FromStr>(&self, id: JsValue) -> Result<F, JsValue>
+    where
+        F::Err: std::fmt::Display,
+    {
+        id.as_string()
+            .ok_or("invalid opid/objid/elemid")?
+            .parse::<F>()
+            .map_err(to_js_err)
     }
 
     fn import_prop(&mut self, prop: JsValue) -> Result<Prop, JsValue> {

--- a/automerge/src/clock.rs
+++ b/automerge/src/clock.rs
@@ -1,4 +1,4 @@
-use crate::OpId;
+use crate::types::OpId;
 use fxhash::FxBuildHasher;
 use std::cmp;
 use std::collections::HashMap;
@@ -19,8 +19,8 @@ impl Clock {
     }
 
     pub fn covers(&self, id: &OpId) -> bool {
-        if let Some(val) = self.0.get(&id.1) {
-            val >= &id.0
+        if let Some(val) = self.0.get(&id.actor()) {
+            val >= &id.counter()
         } else {
             false
         }
@@ -38,15 +38,15 @@ mod tests {
         clock.include(1, 20);
         clock.include(2, 10);
 
-        assert!(clock.covers(&OpId(10, 1)));
-        assert!(clock.covers(&OpId(20, 1)));
-        assert!(!clock.covers(&OpId(30, 1)));
+        assert!(clock.covers(&OpId::new(10, 1)));
+        assert!(clock.covers(&OpId::new(20, 1)));
+        assert!(!clock.covers(&OpId::new(30, 1)));
 
-        assert!(clock.covers(&OpId(5, 2)));
-        assert!(clock.covers(&OpId(10, 2)));
-        assert!(!clock.covers(&OpId(15, 2)));
+        assert!(clock.covers(&OpId::new(5, 2)));
+        assert!(clock.covers(&OpId::new(10, 2)));
+        assert!(!clock.covers(&OpId::new(15, 2)));
 
-        assert!(!clock.covers(&OpId(1, 3)));
-        assert!(!clock.covers(&OpId(100, 3)));
+        assert!(!clock.covers(&OpId::new(1, 3)));
+        assert!(!clock.covers(&OpId::new(100, 3)));
     }
 }

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -11,8 +11,10 @@ use std::{
     str,
 };
 
-use crate::ROOT;
-use crate::{ActorId, ElemId, Key, ObjId, ObjType, OpId, OpType, ScalarValue};
+use crate::{
+    types::{ElemId, Key, ObjId, OpId},
+    ActorId, ObjType, OpType, ScalarValue,
+};
 
 use crate::legacy as amp;
 use amp::SortedVec;
@@ -686,15 +688,15 @@ impl KeyEncoder {
                 self.ctr.append_null();
                 self.str.append_value(props[i].clone());
             }
-            Key::Seq(ElemId(OpId(0, 0))) => {
+            Key::Seq(ElemId::Head) => {
                 // HEAD
                 self.actor.append_null();
                 self.ctr.append_value(0);
                 self.str.append_null();
             }
-            Key::Seq(ElemId(OpId(ctr, actor))) => {
-                self.actor.append_value(actors[actor]);
-                self.ctr.append_value(ctr);
+            Key::Seq(ElemId::Op(opid)) => {
+                self.actor.append_value(actors[opid.actor()]);
+                self.ctr.append_value(opid.counter());
                 self.str.append_null();
             }
         }
@@ -773,8 +775,8 @@ impl SuccEncoder {
     fn append(&mut self, succ: &[OpId], actors: &[usize]) {
         self.num.append_value(succ.len());
         for s in succ.iter() {
-            self.ctr.append_value(s.0);
-            self.actor.append_value(actors[s.1]);
+            self.ctr.append_value(s.counter());
+            self.actor.append_value(actors[s.actor()]);
         }
     }
 
@@ -845,14 +847,14 @@ impl ObjEncoder {
     }
 
     fn append(&mut self, obj: &ObjId, actors: &[usize]) {
-        match obj.0 {
-            ROOT => {
+        match obj {
+            ObjId::Root => {
                 self.actor.append_null();
                 self.ctr.append_null();
             }
-            OpId(ctr, actor) => {
-                self.actor.append_value(actors[actor]);
-                self.ctr.append_value(ctr);
+            ObjId::Op(opid) => {
+                self.actor.append_value(actors[opid.actor()]);
+                self.ctr.append_value(opid.counter());
             }
         }
     }

--- a/automerge/src/external_types.rs
+++ b/automerge/src/external_types.rs
@@ -1,0 +1,290 @@
+// This module contains types which are intended to be exposed to users of the automerge library
+// rather than being used internally. Internally we use a variety of types (`Key`, `ElemId`, `ObjId`)
+// which are based on the internal `OpId`. `OpId` is designed to be extremely lightweight, it is
+// just a (u64, usize). This means it can be cheaply copied and many of them can fit in a cache
+// line but to achieve this the "actor ID" component of an `OpId` is actually just an index into an
+// internal array of actor IDs. This means that we prefer not to expose `OpId` to API users -
+// `OpId`s would only be usable with the document they were generated for and we would need to
+// either build a bunch of tricky type system magic to ensure that users do not mix up their
+// documents and ops or just document everywhere that `OpId`s are giant footguns and please be
+// careful.
+//
+// What we want to achieve for external OpIds (external meaning "exposed to the user") is the following:
+// - OpIds are just values. You can clone them, store them, use them from one document to another
+//   without thinking about it.
+// - Using OpIds with the mutation APIs of automerge documents is natural and performant
+//
+// The first requirement gives us a straightforward specification for an external `OpId`. It must
+// contain both the counter and the actual bytes of the actor ID - otherwise we would need to
+// include a reference to a document and some kind of lifetime, serialization becomes tricky, etc.
+// etc.
+//
+// The second requirement is more interesting. Frequently within an automerge document you would
+// like to do things like this:
+//
+//     let list_id = doc.set(ObjId::Root, "list", automerge::Value::list()).unwrap().unwrap();
+//     doc.set(&list_id, 0, "first").unwrap()
+//
+// We would like the first argument of `doc.set` to be an `ObjectId` enum, this is so that we
+// can distinguish between setting on the `Root` object ID and setting on some contained object; on
+// the other hand `doc.set` should return an external `OpId` - it may after all not be creating an
+// object. How do we line this types up? The basic principle is that we represent all external
+// types which may contain an external OpId as wrappers which contain a reference to an external
+// OpId, we use `Into<ObjId>` (or `Into<Key>` or `Into<ElemId>` etc.) as the arguments to `doc.set`
+// or similar functions, finally we implement `Into<ObjId> for OpId` by just wrapping the
+// referenced opid.
+//
+// For example, Object ID looks like this:
+//
+//     enum ObjId<'a> {
+//          Root,
+//          Op(Cow<'a, OpId>)
+//     }
+//
+//  Note that we use a `Cow` to contain the OpId, this allows us to create `ObjId<'static>` when
+//  deserializing and it allows us to present an `ObjId::into_owned() -> ObjId<'static>` for
+//  situations where you need to take ownership of the underlying OpId`.
+//
+//  Then we implement `Into<ObjId> for &OpId` like so:
+//
+//      impl<'a> Into<ObjId> for &'a OpId {
+//          fn from(op: &'a OpId) -> ObjId<'a> {
+//              Self::Op(Cow::Borrowed(op))
+//          }
+//      }
+//
+//  Finally the signature of `Automerge::set` looks like this:
+//
+//      fn set<O: Into<ObjId<'_>>(&mut self, objid: O, ...)
+//
+//  Hopefully Rust's niche optimisation means that this has zero overhead compared to just the op
+//  reference directly. But even if not it seems to have negligible impacts on performance.
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+use crate::{legacy, op_tree::OpSetMetadata, types::OpId, ActorId};
+
+const ROOT_STR: &str = "_root";
+const HEAD_STR: &str = "_head";
+
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+pub struct ExternalOpId {
+    counter: u64,
+    actor: ActorId,
+}
+
+impl ExternalOpId {
+    pub(crate) fn from_internal(opid: &OpId, metadata: &OpSetMetadata) -> Option<ExternalOpId> {
+        metadata
+            .actors
+            .get_safe(opid.actor())
+            .map(|actor| ExternalOpId {
+                counter: opid.counter(),
+                actor: actor.clone(),
+            })
+    }
+
+    pub(crate) fn counter(&self) -> u64 {
+        self.counter
+    }
+
+    pub(crate) fn actor(&self) -> &ActorId {
+        &self.actor
+    }
+}
+
+impl From<&legacy::OpId> for ExternalOpId {
+    fn from(l: &legacy::OpId) -> Self {
+        ExternalOpId {
+            counter: l.counter(),
+            actor: l.actor().clone(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+pub enum ExternalObjId<'a> {
+    Root,
+    Op(Cow<'a, ExternalOpId>),
+}
+
+impl<'a> ExternalObjId<'a> {
+    pub fn into_owned(self) -> ExternalObjId<'static> {
+        match self {
+            Self::Root => ExternalObjId::Root,
+            Self::Op(cow) => ExternalObjId::Op(Cow::Owned(cow.into_owned())),
+        }
+    }
+}
+
+impl From<&legacy::ObjectId> for ExternalObjId<'static> {
+    fn from(l: &legacy::ObjectId) -> Self {
+        match l {
+            legacy::ObjectId::Root => ExternalObjId::Root,
+            legacy::ObjectId::Id(opid) => ExternalObjId::Op(Cow::Owned(ExternalOpId::from(opid))),
+        }
+    }
+}
+
+impl From<&legacy::OpId> for ExternalObjId<'static> {
+    fn from(l: &legacy::OpId) -> Self {
+        ExternalObjId::Op(Cow::Owned(ExternalOpId {
+            counter: l.counter(),
+            actor: l.actor().clone(),
+        }))
+    }
+}
+
+impl<'a> From<&'a ExternalOpId> for ExternalObjId<'a> {
+    fn from(op: &'a ExternalOpId) -> Self {
+        ExternalObjId::Op(Cow::Borrowed(op))
+    }
+}
+
+impl From<ExternalOpId> for ExternalObjId<'static> {
+    fn from(op: ExternalOpId) -> Self {
+        ExternalObjId::Op(Cow::Owned(op))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ParseError {
+    #[error("op IDs did not have format <counter: usize>@<hex encoded actor>")]
+    BadFormat,
+    #[error("the counter was not a positive integer")]
+    InvalidCounter,
+    #[error("the actor was not valid hex encoded bytes")]
+    InvalidActor,
+}
+
+impl FromStr for ExternalOpId {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('@');
+        let first_part = parts.next().ok_or(ParseError::BadFormat)?;
+        let second_part = parts.next().ok_or(ParseError::BadFormat)?;
+        let counter: u64 = first_part.parse().map_err(|_| ParseError::InvalidCounter)?;
+        let actor: ActorId = second_part.parse().map_err(|_| ParseError::InvalidActor)?;
+        Ok(ExternalOpId { counter, actor })
+    }
+}
+
+impl FromStr for ExternalObjId<'static> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == ROOT_STR {
+            Ok(ExternalObjId::Root)
+        } else {
+            let op = s.parse::<ExternalOpId>()?;
+            Ok(ExternalObjId::Op(Cow::Owned(op)))
+        }
+    }
+}
+
+impl Display for ExternalOpId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}@{}", self.counter, self.actor)
+    }
+}
+
+impl<'a> Display for ExternalObjId<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Root => write!(f, "{}", ROOT_STR),
+            Self::Op(op) => write!(f, "{}", op),
+        }
+    }
+}
+
+pub enum ExternalElemId<'a> {
+    Head,
+    Op(Cow<'a, ExternalOpId>),
+}
+
+impl<'a> ExternalElemId<'a> {
+    pub fn into_owned(&'a self) -> ExternalElemId<'static> {
+        match self {
+            ExternalElemId::Head => ExternalElemId::Head,
+            ExternalElemId::Op(op) => ExternalElemId::Op(Cow::Owned(op.clone().into_owned())),
+        }
+    }
+}
+
+impl<'a> From<ExternalOpId> for ExternalElemId<'static> {
+    fn from(op: ExternalOpId) -> Self {
+        ExternalElemId::Op(Cow::Owned(op))
+    }
+}
+
+impl<'a> From<&'a ExternalOpId> for ExternalElemId<'a> {
+    fn from(opid: &'a ExternalOpId) -> Self {
+        ExternalElemId::Op(Cow::Borrowed(opid))
+    }
+}
+
+impl<'a> Display for ExternalElemId<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Head => write!(f, "{}", HEAD_STR),
+            Self::Op(op) => write!(f, "{}", op),
+        }
+    }
+}
+
+pub enum ExternalKey<'a> {
+    Map(Cow<'a, str>),
+    Seq(ExternalElemId<'a>),
+}
+
+impl<'a> ExternalKey<'a> {
+    pub fn into_owned(self) -> ExternalKey<'static> {
+        match self {
+            Self::Map(key) => ExternalKey::Map(key.into_owned().into()),
+            Self::Seq(elemid) => ExternalKey::Seq(elemid.into_owned()),
+        }
+    }
+}
+
+impl<'a> From<&'a ExternalOpId> for ExternalKey<'a> {
+    fn from(op: &'a ExternalOpId) -> Self {
+        ExternalKey::Seq(op.into())
+    }
+}
+
+impl From<ExternalOpId> for ExternalKey<'static> {
+    fn from(op: ExternalOpId) -> Self {
+        ExternalKey::Seq(op.into())
+    }
+}
+
+impl<'a> From<&'a str> for ExternalKey<'a> {
+    fn from(s: &'a str) -> Self {
+        ExternalKey::Map(Cow::Borrowed(s))
+    }
+}
+
+impl From<String> for ExternalKey<'static> {
+    fn from(key: String) -> Self {
+        ExternalKey::Map(Cow::Owned(key))
+    }
+}
+
+impl<'a> From<ExternalElemId<'a>> for ExternalKey<'a> {
+    fn from(elemid: ExternalElemId<'a>) -> Self {
+        ExternalKey::Seq(elemid)
+    }
+}
+
+impl<'a> Display for ExternalKey<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Map(k) => write!(f, "{}", k),
+            Self::Seq(op) => write!(f, "{}", op),
+        }
+    }
+}

--- a/automerge/src/indexed_cache.rs
+++ b/automerge/src/indexed_cache.rs
@@ -43,6 +43,11 @@ where
         &self.cache[index]
     }
 
+    // Todo replace all uses of `get` with this
+    pub fn get_safe(&self, index: usize) -> Option<&T> {
+        self.cache.get(index)
+    }
+
     pub fn sorted(&self) -> IndexedCache<T> {
         let mut sorted = Self::new();
         self.cache.iter().sorted().cloned().for_each(|item| {

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -1,9 +1,16 @@
 use crate::op_tree::OpTreeInternal;
 use crate::query::TreeQuery;
-use crate::{ActorId, IndexedCache, Key, ObjId, Op, OpId};
+use crate::{
+    external_types::{ExternalElemId, ExternalKey, ExternalObjId, ExternalOpId},
+    types::{ElemId, Key, ObjId, OpId},
+    ActorId, IndexedCache, Op,
+};
 use fxhash::FxBuildHasher;
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fmt::Debug;
+use std::rc::Rc;
 
 pub(crate) type OpSet = OpSetInternal<16>;
 
@@ -12,7 +19,7 @@ pub(crate) struct OpSetInternal<const B: usize> {
     trees: HashMap<ObjId, OpTreeInternal<B>, FxBuildHasher>,
     objs: Vec<ObjId>,
     length: usize,
-    pub m: OpSetMetadata,
+    pub m: Rc<RefCell<OpSetMetadata>>,
 }
 
 impl<const B: usize> OpSetInternal<B> {
@@ -21,10 +28,11 @@ impl<const B: usize> OpSetInternal<B> {
             trees: Default::default(),
             objs: Default::default(),
             length: 0,
-            m: OpSetMetadata {
+            m: Rc::new(RefCell::new(OpSetMetadata {
                 actors: IndexedCache::new(),
                 props: IndexedCache::new(),
-            },
+                last_objid: None,
+            })),
         }
     }
 
@@ -41,7 +49,7 @@ impl<const B: usize> OpSetInternal<B> {
         Q: TreeQuery<B>,
     {
         if let Some(tree) = self.trees.get(&obj) {
-            tree.search(query, &self.m)
+            tree.search(query, &*self.m.borrow())
         } else {
             query
         }
@@ -83,7 +91,7 @@ impl<const B: usize> OpSetInternal<B> {
             .entry(element.obj)
             .or_insert_with(|| {
                 let pos = objs
-                    .binary_search_by(|probe| m.lamport_cmp(probe.0, element.obj.0))
+                    .binary_search_by(|probe| m.borrow().lamport_cmp(probe, &element.obj))
                     .unwrap_err();
                 objs.insert(pos, element.obj);
                 Default::default()
@@ -95,7 +103,8 @@ impl<const B: usize> OpSetInternal<B> {
     #[cfg(feature = "optree-visualisation")]
     pub fn visualise(&self) -> String {
         let mut out = Vec::new();
-        let graph = super::visualisation::GraphVisualisation::construct(&self.trees, &self.m);
+        let meta_ref = self.m.borrow();
+        let graph = super::visualisation::GraphVisualisation::construct(&self.trees, &meta_ref);
         dot::render(&graph, &mut out).unwrap();
         String::from_utf8_lossy(&out[..]).to_string()
     }
@@ -148,10 +157,13 @@ impl<'a, const B: usize> Iterator for Iter<'a, B> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct OpSetMetadata {
     pub actors: IndexedCache<ActorId>,
     pub props: IndexedCache<String>,
+    // For the common case of many consecutive operations on the same object we cache the last
+    // object we looked up
+    last_objid: Option<(ExternalOpId, OpId)>,
 }
 
 impl OpSetMetadata {
@@ -162,14 +174,102 @@ impl OpSetMetadata {
         }
     }
 
-    pub fn lamport_cmp(&self, left: OpId, right: OpId) -> Ordering {
-        match (left, right) {
-            (OpId(0, _), OpId(0, _)) => Ordering::Equal,
-            (OpId(0, _), OpId(_, _)) => Ordering::Less,
-            (OpId(_, _), OpId(0, _)) => Ordering::Greater,
-            // FIXME - this one seems backwards to me - why - is values() returning in the wrong order?
-            (OpId(a, x), OpId(b, y)) if a == b => self.actors[y].cmp(&self.actors[x]),
-            (OpId(a, _), OpId(b, _)) => a.cmp(&b),
+    pub fn lamport_cmp<S: SuccinctLamport>(&self, left: S, right: S) -> Ordering {
+        S::cmp(self, left, right)
+    }
+
+    pub fn import_opid(&mut self, ext_opid: &ExternalOpId) -> OpId {
+        let actor = self.actors.cache(ext_opid.actor().clone());
+        let opid = OpId::new(ext_opid.counter(), actor);
+        self.last_objid = Some((ext_opid.clone(), opid));
+        opid
+    }
+
+    pub(crate) fn export_opid(&self, opid: &OpId) -> Option<ExternalOpId> {
+        ExternalOpId::from_internal(opid, self)
+    }
+
+    pub(crate) fn export_objid(&self, objid: &ObjId) -> Option<ExternalObjId<'static>> {
+        match objid {
+            ObjId::Root => Some(ExternalObjId::Root),
+            ObjId::Op(op) => self
+                .export_opid(op)
+                .map(|obj| ExternalObjId::from(obj).into_owned()),
         }
+    }
+
+    pub(crate) fn import_objid<'a, A: Into<ExternalObjId<'a>>>(&mut self, ext_objid: A) -> ObjId {
+        match ext_objid.into() {
+            ExternalObjId::Root => ObjId::Root,
+            ExternalObjId::Op(external_op) => {
+                if let Some((last_ext, last_int)) = &self.last_objid {
+                    if last_ext == external_op.as_ref() {
+                        return ObjId::from(*last_int);
+                    }
+                }
+                let op = self.import_opid(&external_op);
+                self.last_objid = Some((external_op.into_owned(), op));
+                ObjId::Op(op)
+            }
+        }
+    }
+
+    pub(crate) fn export_elemid(&self, elemid: &ElemId) -> Option<ExternalElemId<'static>> {
+        match elemid {
+            ElemId::Head => Some(ExternalElemId::Head),
+            ElemId::Op(op) => self
+                .export_opid(op)
+                .map(|o| ExternalElemId::from(o).into_owned()),
+        }
+    }
+
+    pub(crate) fn export_key(&self, key: &Key) -> Option<ExternalKey<'static>> {
+        match key {
+            Key::Map(key_index) => self
+                .map_key(*key_index)
+                .map(|s| ExternalKey::Map(s.clone().into())),
+            Key::Seq(elemid) => self.export_elemid(elemid).map(|e| e.into()),
+        }
+    }
+
+    pub(crate) fn map_key(&self, key_index: usize) -> Option<&String> {
+        self.props.get_safe(key_index)
+    }
+}
+
+/// Lamport timestamps which don't contain their actor ID directly and therefore need access to
+/// some metadata to compare their actor ID parts
+pub(crate) trait SuccinctLamport {
+    fn cmp(m: &OpSetMetadata, left: Self, right: Self) -> Ordering;
+}
+
+impl SuccinctLamport for OpId {
+    fn cmp(m: &OpSetMetadata, left: Self, right: Self) -> Ordering {
+        match (left.counter(), right.counter()) {
+            (0, 0) => Ordering::Equal,
+            (0, _) => Ordering::Less,
+            (_, 0) => Ordering::Greater,
+            (a, b) if a == b => m.actors[right.actor()].cmp(&m.actors[left.actor()]),
+            (a, b) => a.cmp(&b),
+        }
+    }
+}
+
+impl SuccinctLamport for ObjId {
+    fn cmp(m: &OpSetMetadata, left: Self, right: Self) -> Ordering {
+        match (left, right) {
+            (ObjId::Root, ObjId::Root) => Ordering::Equal,
+            (ObjId::Root, ObjId::Op(_)) => Ordering::Less,
+            (ObjId::Op(_), ObjId::Root) => Ordering::Greater,
+            (ObjId::Op(left_op), ObjId::Op(right_op)) => {
+                <OpId as SuccinctLamport>::cmp(m, left_op, right_op)
+            }
+        }
+    }
+}
+
+impl SuccinctLamport for &ObjId {
+    fn cmp(m: &OpSetMetadata, left: Self, right: Self) -> Ordering {
+        <ObjId as SuccinctLamport>::cmp(m, *left, *right)
     }
 }

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -6,7 +6,7 @@ use std::{
 
 pub(crate) use crate::op_set::OpSetMetadata;
 use crate::query::{Index, QueryResult, TreeQuery};
-use crate::{Op, OpId};
+use crate::types::{Op, OpId};
 use std::collections::HashSet;
 
 #[allow(dead_code)]
@@ -628,12 +628,12 @@ struct CounterData {
 #[cfg(test)]
 mod tests {
     use crate::legacy as amp;
-    use crate::{Op, OpId};
+    use crate::types::{Op, OpId};
 
     use super::*;
 
     fn op(n: usize) -> Op {
-        let zero = OpId(0, 0);
+        let zero = OpId::new(0, 0);
         Op {
             change: n,
             id: zero,

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -1,5 +1,9 @@
 use crate::op_tree::{OpSetMetadata, OpTreeNode};
-use crate::{Clock, ElemId, Op, OpId, OpType, ScalarValue};
+use crate::{
+    types::ElemId,
+    types::{OpId, OpType},
+    Clock, Op, ScalarValue,
+};
 use fxhash::FxBuildHasher;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};

--- a/automerge/src/query/insert.rs
+++ b/automerge/src/query/insert.rs
@@ -1,6 +1,7 @@
 use crate::op_tree::OpTreeNode;
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::{AutomergeError, ElemId, Key, Op, HEAD};
+use crate::types::{ElemId, Key};
+use crate::{AutomergeError, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -27,9 +28,9 @@ impl<const B: usize> InsertNth<B> {
 
     pub fn key(&self) -> Result<Key, AutomergeError> {
         if self.target == 0 {
-            Ok(HEAD.into())
+            Ok(ElemId::Head.into())
         } else if self.seen == self.target && self.last_insert.is_some() {
-            Ok(Key::Seq(self.last_insert.unwrap()))
+            Ok(self.last_insert.unwrap().into())
         } else {
             Err(AutomergeError::InvalidIndex(self.target))
         }

--- a/automerge/src/query/keys.rs
+++ b/automerge/src/query/keys.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::OpTreeNode;
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::Key;
+use crate::types::Key;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/keys_at.rs
+++ b/automerge/src/query/keys_at.rs
@@ -1,5 +1,5 @@
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::{Clock, Key, Op};
+use crate::{types::Key, Clock, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/len.rs
+++ b/automerge/src/query/len.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::OpTreeNode;
 use crate::query::{QueryResult, TreeQuery};
-use crate::ObjId;
+use crate::types::ObjId;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/len_at.rs
+++ b/automerge/src/query/len_at.rs
@@ -1,5 +1,5 @@
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::{Clock, ElemId, Op};
+use crate::{types::ElemId, Clock, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/list_vals.rs
+++ b/automerge/src/query/list_vals.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::{OpSetMetadata, OpTreeNode};
 use crate::query::{binary_search_by, is_visible, visible_op, QueryResult, TreeQuery};
-use crate::{ElemId, ObjId, Op};
+use crate::{types::ElemId, types::ObjId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -26,7 +26,7 @@ impl<const B: usize> TreeQuery<B> for ListVals {
         child: &OpTreeNode<B>,
         m: &OpSetMetadata,
     ) -> QueryResult {
-        let start = binary_search_by(child, |op| m.lamport_cmp(op.obj.0, self.obj.0));
+        let start = binary_search_by(child, |op| m.lamport_cmp(op.obj, self.obj));
         let mut counters = Default::default();
         for pos in start..child.len() {
             let op = child.get(pos).unwrap();

--- a/automerge/src/query/list_vals_at.rs
+++ b/automerge/src/query/list_vals_at.rs
@@ -1,5 +1,5 @@
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::{Clock, ElemId, Op};
+use crate::{types::ElemId, Clock, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/nth.rs
+++ b/automerge/src/query/nth.rs
@@ -1,6 +1,9 @@
 use crate::op_tree::OpTreeNode;
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::{AutomergeError, ElemId, Key, Op};
+use crate::{
+    types::{ElemId, Key},
+    AutomergeError, Op,
+};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/nth_at.rs
+++ b/automerge/src/query/nth_at.rs
@@ -1,5 +1,5 @@
 use crate::query::{QueryResult, TreeQuery, VisWindow};
-use crate::{Clock, ElemId, Op};
+use crate::{types::ElemId, Clock, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/prop.rs
+++ b/automerge/src/query/prop.rs
@@ -1,6 +1,9 @@
 use crate::op_tree::{OpSetMetadata, OpTreeNode};
 use crate::query::{binary_search_by, is_visible, visible_op, QueryResult, TreeQuery};
-use crate::{Key, ObjId, Op};
+use crate::{
+    types::{Key, ObjId},
+    Op,
+};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -31,7 +34,7 @@ impl<const B: usize> TreeQuery<B> for Prop {
         m: &OpSetMetadata,
     ) -> QueryResult {
         let start = binary_search_by(child, |op| {
-            m.lamport_cmp(op.obj.0, self.obj.0)
+            m.lamport_cmp(op.obj, self.obj)
                 .then_with(|| m.key_cmp(&op.key, &self.key))
         });
         let mut counters = Default::default();

--- a/automerge/src/query/prop_at.rs
+++ b/automerge/src/query/prop_at.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::{OpSetMetadata, OpTreeNode};
 use crate::query::{binary_search_by, QueryResult, TreeQuery, VisWindow};
-use crate::{Clock, Key, Op};
+use crate::{types::Key, Clock, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/query/seek_op.rs
+++ b/automerge/src/query/seek_op.rs
@@ -1,6 +1,7 @@
 use crate::op_tree::{OpSetMetadata, OpTreeNode};
 use crate::query::{binary_search_by, QueryResult, TreeQuery};
-use crate::{Key, Op, HEAD};
+use crate::types::{ElemId, Key};
+use crate::Op;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 
@@ -56,7 +57,7 @@ impl<const B: usize> TreeQuery<B> for SeekOp<B> {
             return QueryResult::Decend;
         }
         match self.op.key {
-            Key::Seq(e) if e == HEAD => {
+            Key::Seq(ElemId::Head) => {
                 while self.pos < child.len() {
                     let op = child.get(self.pos).unwrap();
                     if self.op.overwrites(op) {
@@ -69,8 +70,8 @@ impl<const B: usize> TreeQuery<B> for SeekOp<B> {
                 }
                 QueryResult::Finish
             }
-            Key::Seq(e) => {
-                if self.found || child.index.ops.contains(&e.0) {
+            Key::Seq(ElemId::Op(op)) => {
+                if self.found || child.index.ops.contains(&op) {
                     QueryResult::Decend
                 } else {
                     self.pos += child.len();

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -9,11 +9,8 @@ use std::fmt;
 use std::str::FromStr;
 use tinyvec::{ArrayVec, TinyVec};
 
-pub(crate) const HEAD: ElemId = ElemId(OpId(0, 0));
-pub const ROOT: OpId = OpId(0, 0);
-
-const ROOT_STR: &str = "_root";
-const HEAD_STR: &str = "_head";
+//const ROOT_STR: &str = "_root";
+//const HEAD_STR: &str = "_head";
 
 /// An actor id is a sequence of bytes. By default we use a uuid which can be nicely stack
 /// allocated.
@@ -160,128 +157,33 @@ pub enum OpType {
     Set(ScalarValue),
 }
 
-#[derive(Debug)]
-pub enum Export {
-    Id(OpId),
-    Special(String),
-    Prop(usize),
-}
-
-pub trait Exportable {
-    fn export(&self) -> Export;
-}
-
-pub trait Importable {
-    fn wrap(id: OpId) -> Self;
-    fn from(s: &str) -> Option<Self>
-    where
-        Self: std::marker::Sized;
-}
-
 impl OpId {
+    pub(crate) fn new(counter: u64, actor: usize) -> OpId {
+        OpId(counter, actor)
+    }
+
     #[inline]
     pub fn counter(&self) -> u64 {
         self.0
     }
     #[inline]
-    pub fn actor(&self) -> usize {
+    pub(crate) fn actor(&self) -> usize {
         self.1
-    }
-}
-
-impl Exportable for ObjId {
-    fn export(&self) -> Export {
-        if self.0 == ROOT {
-            Export::Special(ROOT_STR.to_owned())
-        } else {
-            Export::Id(self.0)
-        }
-    }
-}
-
-impl Exportable for &ObjId {
-    fn export(&self) -> Export {
-        if self.0 == ROOT {
-            Export::Special(ROOT_STR.to_owned())
-        } else {
-            Export::Id(self.0)
-        }
-    }
-}
-
-impl Exportable for ElemId {
-    fn export(&self) -> Export {
-        if self == &HEAD {
-            Export::Special(HEAD_STR.to_owned())
-        } else {
-            Export::Id(self.0)
-        }
-    }
-}
-
-impl Exportable for OpId {
-    fn export(&self) -> Export {
-        Export::Id(*self)
-    }
-}
-
-impl Exportable for Key {
-    fn export(&self) -> Export {
-        match self {
-            Key::Map(p) => Export::Prop(*p),
-            Key::Seq(e) => e.export(),
-        }
-    }
-}
-
-impl Importable for ObjId {
-    fn wrap(id: OpId) -> Self {
-        ObjId(id)
-    }
-    fn from(s: &str) -> Option<Self> {
-        if s == ROOT_STR {
-            Some(ROOT.into())
-        } else {
-            None
-        }
-    }
-}
-
-impl Importable for OpId {
-    fn wrap(id: OpId) -> Self {
-        id
-    }
-    fn from(s: &str) -> Option<Self> {
-        if s == ROOT_STR {
-            Some(ROOT)
-        } else {
-            None
-        }
-    }
-}
-
-impl Importable for ElemId {
-    fn wrap(id: OpId) -> Self {
-        ElemId(id)
-    }
-    fn from(s: &str) -> Option<Self> {
-        if s == HEAD_STR {
-            Some(HEAD)
-        } else {
-            None
-        }
     }
 }
 
 impl From<OpId> for ObjId {
     fn from(o: OpId) -> Self {
-        ObjId(o)
+        match (o.counter(), o.actor()) {
+            (0, 0) => ObjId::Root,
+            (_, _) => ObjId::Op(o),
+        }
     }
 }
 
 impl From<OpId> for ElemId {
     fn from(o: OpId) -> Self {
-        ElemId(o)
+        ElemId::Op(o)
     }
 }
 
@@ -317,7 +219,7 @@ impl From<f64> for Prop {
 
 impl From<OpId> for Key {
     fn from(id: OpId) -> Self {
-        Key::Seq(ElemId(id))
+        Key::Seq(ElemId::Op(id))
     }
 }
 
@@ -352,13 +254,37 @@ impl Key {
 }
 
 #[derive(Debug, Clone, PartialOrd, Ord, Eq, PartialEq, Copy, Hash, Default)]
-pub struct OpId(pub u64, pub usize);
+pub(crate) struct OpId(u64, usize);
 
-#[derive(Debug, Clone, Copy, PartialOrd, Eq, PartialEq, Ord, Hash, Default)]
-pub(crate) struct ObjId(pub OpId);
+#[derive(Debug, Clone, Copy, PartialOrd, Eq, PartialEq, Ord, Hash)]
+pub(crate) enum ObjId {
+    Root,
+    Op(OpId),
+}
 
-#[derive(Debug, Clone, Copy, PartialOrd, Eq, PartialEq, Ord, Hash, Default)]
-pub(crate) struct ElemId(pub OpId);
+impl Default for ObjId {
+    fn default() -> Self {
+        Self::Root
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialOrd, Eq, PartialEq, Ord, Hash)]
+pub(crate) enum ElemId {
+    Head,
+    Op(OpId),
+}
+
+impl Default for ElemId {
+    fn default() -> Self {
+        ElemId::Head
+    }
+}
+
+impl From<&OpId> for ElemId {
+    fn from(op: &OpId) -> Self {
+        ElemId::Op(*op)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Op {
@@ -383,7 +309,7 @@ impl Op {
 
     pub fn elemid(&self) -> Option<ElemId> {
         if self.insert {
-            Some(ElemId(self.id))
+            Some(ElemId::Op(self.id))
         } else {
             self.key.elemid()
         }

--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{error, ObjType, Op, OpId, OpType};
+use crate::{error, types::OpId, ObjType, Op, OpType};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::convert::TryFrom;

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -1,16 +1,16 @@
-use automerge::Automerge;
+use automerge::{Automerge, ObjId};
 
 mod helpers;
 #[allow(unused_imports)]
 use helpers::{
     mk_counter, new_doc, new_doc_with_actor, pretty_print, realize, realize_obj, sorted_actors,
-    translate_obj_id, OpIdExt, RealizedObject,
+    RealizedObject,
 };
 #[test]
 fn no_conflict_on_repeated_assignment() {
     let mut doc = Automerge::new();
-    doc.set(automerge::ROOT, "foo", 1).unwrap();
-    let op = doc.set(automerge::ROOT, "foo", 2).unwrap().unwrap();
+    doc.set(ObjId::Root, "foo", 1).unwrap();
+    let op = doc.set(ObjId::Root, "foo", 2).unwrap().unwrap();
     assert_doc!(
         &doc,
         map! {
@@ -22,19 +22,19 @@ fn no_conflict_on_repeated_assignment() {
 #[test]
 fn no_change_on_repeated_map_set() {
     let mut doc = new_doc();
-    doc.set(automerge::ROOT, "foo", 1).unwrap();
-    assert!(doc.set(automerge::ROOT, "foo", 1).unwrap().is_none());
+    doc.set(ObjId::Root, "foo", 1).unwrap();
+    assert!(doc.set(ObjId::Root, "foo", 1).unwrap().is_none());
 }
 
 #[test]
 fn no_change_on_repeated_list_set() {
     let mut doc = new_doc();
     let list_id = doc
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    doc.insert(list_id, 0, 1).unwrap();
-    doc.set(list_id, 0, 1).unwrap();
+    doc.insert(&list_id, 0, 1).unwrap();
+    doc.set(&list_id, 0, 1).unwrap();
     assert!(doc.set(list_id, 0, 1).unwrap().is_none());
 }
 
@@ -42,25 +42,25 @@ fn no_change_on_repeated_list_set() {
 fn no_change_on_list_insert_followed_by_set_of_same_value() {
     let mut doc = new_doc();
     let list_id = doc
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    doc.insert(list_id, 0, 1).unwrap();
-    assert!(doc.set(list_id, 0, 1).unwrap().is_none());
+    doc.insert(&list_id, 0, 1).unwrap();
+    assert!(doc.set(&list_id, 0, 1).unwrap().is_none());
 }
 
 #[test]
 fn repeated_map_assignment_which_resolves_conflict_not_ignored() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(automerge::ROOT, "field", 123).unwrap();
+    doc1.set(ObjId::Root, "field", 123).unwrap();
     doc2.merge(&mut doc1);
-    doc2.set(automerge::ROOT, "field", 456).unwrap();
-    doc1.set(automerge::ROOT, "field", 789).unwrap();
+    doc2.set(ObjId::Root, "field", 456).unwrap();
+    doc1.set(ObjId::Root, "field", 789).unwrap();
     doc1.merge(&mut doc2);
-    assert_eq!(doc1.values(automerge::ROOT, "field").unwrap().len(), 2);
+    assert_eq!(doc1.values(ObjId::Root, "field").unwrap().len(), 2);
 
-    let op = doc1.set(automerge::ROOT, "field", 123).unwrap().unwrap();
+    let op = doc1.set(ObjId::Root, "field", 123).unwrap().unwrap();
     assert_doc!(
         &doc1,
         map! {
@@ -76,15 +76,14 @@ fn repeated_list_assignment_which_resolves_conflict_not_ignored() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    doc1.insert(list_id, 0, 123).unwrap();
+    doc1.insert(&list_id, 0, 123).unwrap();
     doc2.merge(&mut doc1);
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
-    doc2.set(list_id_in_doc2, 0, 456).unwrap().unwrap();
+    doc2.set(&list_id, 0, 456).unwrap().unwrap();
     doc1.merge(&mut doc2);
-    let doc1_op = doc1.set(list_id, 0, 789).unwrap().unwrap();
+    let doc1_op = doc1.set(&list_id, 0, 789).unwrap().unwrap();
 
     assert_doc!(
         &doc1,
@@ -102,13 +101,13 @@ fn repeated_list_assignment_which_resolves_conflict_not_ignored() {
 fn list_deletion() {
     let mut doc = new_doc();
     let list_id = doc
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let op1 = doc.insert(list_id, 0, 123).unwrap();
-    doc.insert(list_id, 1, 456).unwrap();
-    let op3 = doc.insert(list_id, 2, 789).unwrap();
-    doc.del(list_id, 1).unwrap();
+    let op1 = doc.insert(&list_id, 0, 123).unwrap();
+    doc.insert(&list_id, 1, 456).unwrap();
+    let op3 = doc.insert(&list_id.clone(), 2, 789).unwrap();
+    doc.del(&list_id, 1).unwrap();
     assert_doc!(
         &doc,
         map! {
@@ -124,28 +123,25 @@ fn list_deletion() {
 fn merge_concurrent_map_prop_updates() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let op1 = doc1.set(automerge::ROOT, "foo", "bar").unwrap().unwrap();
-    let hello = doc2
-        .set(automerge::ROOT, "hello", "world")
-        .unwrap()
-        .unwrap();
+    let op1 = doc1.set(ObjId::Root, "foo", "bar").unwrap().unwrap();
+    let hello = doc2.set(ObjId::Root, "hello", "world").unwrap().unwrap();
     doc1.merge(&mut doc2);
     assert_eq!(
-        doc1.value(automerge::ROOT, "foo").unwrap().unwrap().0,
+        doc1.value(ObjId::Root, "foo").unwrap().unwrap().0,
         "bar".into()
     );
     assert_doc!(
         &doc1,
         map! {
             "foo" => { op1 => "bar" },
-            "hello" => { hello.translate(&doc2) => "world" },
+            "hello" => { hello => "world" },
         }
     );
     doc2.merge(&mut doc1);
     assert_doc!(
         &doc2,
         map! {
-            "foo" => { op1.translate(&doc1) => "bar" },
+            "foo" => { op1 => "bar" },
             "hello" => { hello => "world" },
         }
     );
@@ -157,12 +153,12 @@ fn add_concurrent_increments_of_same_property() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let counter_id = doc1
-        .set(automerge::ROOT, "counter", mk_counter(0))
+        .set(ObjId::Root, "counter", mk_counter(0))
         .unwrap()
         .unwrap();
     doc2.merge(&mut doc1);
-    doc1.inc(automerge::ROOT, "counter", 1).unwrap();
-    doc2.inc(automerge::ROOT, "counter", 2).unwrap();
+    doc1.inc(ObjId::Root, "counter", 1).unwrap();
+    doc2.inc(ObjId::Root, "counter", 2).unwrap();
     doc1.merge(&mut doc2);
     assert_doc!(
         &doc1,
@@ -181,17 +177,17 @@ fn add_increments_only_to_preceeded_values() {
 
     // create a counter in doc1
     let doc1_counter_id = doc1
-        .set(automerge::ROOT, "counter", mk_counter(0))
+        .set(ObjId::Root, "counter", mk_counter(0))
         .unwrap()
         .unwrap();
-    doc1.inc(automerge::ROOT, "counter", 1).unwrap();
+    doc1.inc(ObjId::Root, "counter", 1).unwrap();
 
     // create a counter in doc2
     let doc2_counter_id = doc2
-        .set(automerge::ROOT, "counter", mk_counter(0))
+        .set(ObjId::Root, "counter", mk_counter(0))
         .unwrap()
         .unwrap();
-    doc2.inc(automerge::ROOT, "counter", 3).unwrap();
+    doc2.inc(ObjId::Root, "counter", 3).unwrap();
 
     // The two values should be conflicting rather than added
     doc1.merge(&mut doc2);
@@ -200,8 +196,8 @@ fn add_increments_only_to_preceeded_values() {
         &doc1,
         map! {
             "counter" => {
-                doc1_counter_id.native() => mk_counter(1),
-                doc2_counter_id.translate(&doc2) => mk_counter(3),
+                doc1_counter_id => mk_counter(1),
+                doc2_counter_id => mk_counter(3),
             }
         }
     );
@@ -211,8 +207,8 @@ fn add_increments_only_to_preceeded_values() {
 fn concurrent_updates_of_same_field() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let set_one_opid = doc1.set(automerge::ROOT, "field", "one").unwrap().unwrap();
-    let set_two_opid = doc2.set(automerge::ROOT, "field", "two").unwrap().unwrap();
+    let set_one_opid = doc1.set(ObjId::Root, "field", "one").unwrap().unwrap();
+    let set_two_opid = doc2.set(ObjId::Root, "field", "two").unwrap().unwrap();
 
     doc1.merge(&mut doc2);
 
@@ -220,8 +216,8 @@ fn concurrent_updates_of_same_field() {
         &doc1,
         map! {
             "field" => {
-                set_one_opid.native() => "one",
-                set_two_opid.translate(&doc2) => "two",
+                set_one_opid => "one",
+                set_two_opid => "two",
             }
         }
     );
@@ -232,14 +228,13 @@ fn concurrent_updates_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set(automerge::ROOT, "birds", automerge::Value::list())
+        .set(ObjId::Root, "birds", automerge::Value::list())
         .unwrap()
         .unwrap();
-    doc1.insert(list_id, 0, "finch").unwrap();
+    doc1.insert(list_id.clone(), 0, "finch").unwrap();
     doc2.merge(&mut doc1);
-    let set_one_op = doc1.set(list_id, 0, "greenfinch").unwrap().unwrap();
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
-    let set_op_two = doc2.set(list_id_in_doc2, 0, "goldfinch").unwrap().unwrap();
+    let set_one_op = doc1.set(&list_id, 0, "greenfinch").unwrap().unwrap();
+    let set_op_two = doc2.set(&list_id, 0, "goldfinch").unwrap().unwrap();
 
     doc1.merge(&mut doc2);
 
@@ -248,8 +243,8 @@ fn concurrent_updates_of_same_list_element() {
         map! {
             "birds" => {
                 list_id => list![{
-                    set_one_op.native() => "greenfinch",
-                    set_op_two.translate(&doc2) => "goldfinch",
+                    set_one_op => "greenfinch",
+                    set_op_two => "goldfinch",
                 }]
             }
         }
@@ -261,16 +256,13 @@ fn assignment_conflicts_of_different_types() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let mut doc3 = new_doc();
-    let op_one = doc1
-        .set(automerge::ROOT, "field", "string")
-        .unwrap()
-        .unwrap();
+    let op_one = doc1.set(ObjId::Root, "field", "string").unwrap().unwrap();
     let op_two = doc2
-        .set(automerge::ROOT, "field", automerge::Value::list())
+        .set(ObjId::Root, "field", automerge::Value::list())
         .unwrap()
         .unwrap();
     let op_three = doc3
-        .set(automerge::ROOT, "field", automerge::Value::map())
+        .set(ObjId::Root, "field", automerge::Value::map())
         .unwrap()
         .unwrap();
 
@@ -281,9 +273,9 @@ fn assignment_conflicts_of_different_types() {
         &doc1,
         map! {
             "field" => {
-                op_one.native() => "string",
-                op_two.translate(&doc2) => list!{},
-                op_three.translate(&doc3) => map!{},
+                op_one => "string",
+                op_two => list!{},
+                op_three => map!{},
             }
         }
     );
@@ -293,25 +285,22 @@ fn assignment_conflicts_of_different_types() {
 fn changes_within_conflicting_map_field() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let op_one = doc1
-        .set(automerge::ROOT, "field", "string")
-        .unwrap()
-        .unwrap();
+    let op_one = doc1.set(ObjId::Root, "field", "string").unwrap().unwrap();
     let map_id = doc2
-        .set(automerge::ROOT, "field", automerge::Value::map())
+        .set(ObjId::Root, "field", automerge::Value::map())
         .unwrap()
         .unwrap();
-    let set_in_doc2 = doc2.set(map_id, "innerKey", 42).unwrap().unwrap();
+    let set_in_doc2 = doc2.set(&map_id, "innerKey", 42).unwrap().unwrap();
     doc1.merge(&mut doc2);
 
     assert_doc!(
         &doc1,
         map! {
             "field" => {
-                op_one.native() => "string",
-                map_id.translate(&doc2) => map!{
+                op_one => "string",
+                map_id => map!{
                     "innerKey" => {
-                        set_in_doc2.translate(&doc2) => 42,
+                        set_in_doc2 => 42,
                     }
                 }
             }
@@ -325,27 +314,26 @@ fn changes_within_conflicting_list_element() {
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
     let list_id = doc1
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    doc1.insert(list_id, 0, "hello").unwrap();
+    doc1.insert(&list_id, 0, "hello").unwrap();
     doc2.merge(&mut doc1);
 
     let map_in_doc1 = doc1
-        .set(list_id, 0, automerge::Value::map())
+        .set(&list_id, 0, automerge::Value::map())
         .unwrap()
         .unwrap();
-    let set_map1 = doc1.set(map_in_doc1, "map1", true).unwrap().unwrap();
-    let set_key1 = doc1.set(map_in_doc1, "key", 1).unwrap().unwrap();
+    let set_map1 = doc1.set(&map_in_doc1, "map1", true).unwrap().unwrap();
+    let set_key1 = doc1.set(&map_in_doc1, "key", 1).unwrap().unwrap();
 
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
     let map_in_doc2 = doc2
-        .set(list_id_in_doc2, 0, automerge::Value::map())
+        .set(&list_id, 0, automerge::Value::map())
         .unwrap()
         .unwrap();
     doc1.merge(&mut doc2);
-    let set_map2 = doc2.set(map_in_doc2, "map2", true).unwrap().unwrap();
-    let set_key2 = doc2.set(map_in_doc2, "key", 2).unwrap().unwrap();
+    let set_map2 = doc2.set(&map_in_doc2, "map2", true).unwrap().unwrap();
+    let set_key2 = doc2.set(&map_in_doc2, "key", 2).unwrap().unwrap();
 
     doc1.merge(&mut doc2);
 
@@ -355,13 +343,13 @@ fn changes_within_conflicting_list_element() {
             "list" => {
                 list_id => list![
                     {
-                        map_in_doc2.translate(&doc2) => map!{
-                            "map2" => { set_map2.translate(&doc2) => true },
-                            "key" => { set_key2.translate(&doc2) => 2 },
+                        map_in_doc2 => map!{
+                            "map2" => { set_map2 => true },
+                            "key" => { set_key2 => 2 },
                         },
-                        map_in_doc1.native() => map!{
-                            "key" => { set_key1.native() => 1 },
-                            "map1" => { set_map1.native() => true },
+                        map_in_doc1 => map!{
+                            "key" => { set_key1 => 1 },
+                            "map1" => { set_map1 => true },
                         }
                     }
                 ]
@@ -376,20 +364,20 @@ fn concurrently_assigned_nested_maps_should_not_merge() {
     let mut doc2 = new_doc();
 
     let doc1_map_id = doc1
-        .set(automerge::ROOT, "config", automerge::Value::map())
+        .set(ObjId::Root, "config", automerge::Value::map())
         .unwrap()
         .unwrap();
     let doc1_field = doc1
-        .set(doc1_map_id, "background", "blue")
+        .set(doc1_map_id.clone(), "background", "blue")
         .unwrap()
         .unwrap();
 
     let doc2_map_id = doc2
-        .set(automerge::ROOT, "config", automerge::Value::map())
+        .set(ObjId::Root, "config", automerge::Value::map())
         .unwrap()
         .unwrap();
     let doc2_field = doc2
-        .set(doc2_map_id, "logo_url", "logo.png")
+        .set(doc2_map_id.clone(), "logo_url", "logo.png")
         .unwrap()
         .unwrap();
 
@@ -399,11 +387,11 @@ fn concurrently_assigned_nested_maps_should_not_merge() {
         &doc1,
         map! {
             "config" => {
-                doc1_map_id.native() => map!{
-                    "background" => {doc1_field.native() => "blue"}
+                doc1_map_id => map!{
+                    "background" => {doc1_field => "blue"}
                 },
-                doc2_map_id.translate(&doc2) => map!{
-                    "logo_url" => {doc2_field.translate(&doc2) => "logo.png"}
+                doc2_map_id => map!{
+                    "logo_url" => {doc2_field => "logo.png"}
                 }
             }
         }
@@ -418,16 +406,15 @@ fn concurrent_insertions_at_different_list_positions() {
     assert!(doc1.maybe_get_actor().unwrap() < doc2.maybe_get_actor().unwrap());
 
     let list_id = doc1
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
 
-    let one = doc1.insert(list_id, 0, "one").unwrap();
-    let three = doc1.insert(list_id, 1, "three").unwrap();
+    let one = doc1.insert(&list_id, 0, "one").unwrap();
+    let three = doc1.insert(&list_id, 1, "three").unwrap();
     doc2.merge(&mut doc1);
-    let two = doc1.splice(list_id, 1, 0, vec!["two".into()]).unwrap()[0];
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
-    let four = doc2.insert(list_id_in_doc2, 2, "four").unwrap();
+    let two = doc1.splice(&list_id, 1, 0, vec!["two".into()]).unwrap()[0].clone();
+    let four = doc2.insert(&list_id, 2, "four").unwrap();
 
     doc1.merge(&mut doc2);
 
@@ -436,10 +423,10 @@ fn concurrent_insertions_at_different_list_positions() {
         map! {
             "list" => {
                 list_id => list![
-                    {one.native() => "one"},
-                    {two.native() => "two"},
-                    {three.native() => "three"},
-                    {four.translate(&doc2) => "four"},
+                    {one => "one"},
+                    {two => "two"},
+                    {three => "three"},
+                    {four => "four"},
                 ]
             }
         }
@@ -454,15 +441,14 @@ fn concurrent_insertions_at_same_list_position() {
     assert!(doc1.maybe_get_actor().unwrap() < doc2.maybe_get_actor().unwrap());
 
     let list_id = doc1
-        .set(automerge::ROOT, "birds", automerge::Value::list())
+        .set(ObjId::Root, "birds", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let parakeet = doc1.insert(list_id, 0, "parakeet").unwrap();
+    let parakeet = doc1.insert(&list_id, 0, "parakeet").unwrap();
 
     doc2.merge(&mut doc1);
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
-    let starling = doc1.insert(list_id, 1, "starling").unwrap();
-    let chaffinch = doc2.insert(list_id_in_doc2, 1, "chaffinch").unwrap();
+    let starling = doc1.insert(&list_id, 1, "starling").unwrap();
+    let chaffinch = doc2.insert(&list_id, 1, "chaffinch").unwrap();
     doc1.merge(&mut doc2);
 
     assert_doc!(
@@ -471,13 +457,13 @@ fn concurrent_insertions_at_same_list_position() {
             "birds" => {
                 list_id => list![
                     {
-                        parakeet.native() => "parakeet",
+                        parakeet => "parakeet",
                     },
                     {
-                        starling.native() => "starling",
+                        starling => "starling",
                     },
                     {
-                        chaffinch.translate(&doc2) => "chaffinch",
+                        chaffinch => "chaffinch",
                     },
                 ]
             },
@@ -489,11 +475,11 @@ fn concurrent_insertions_at_same_list_position() {
 fn concurrent_assignment_and_deletion_of_a_map_entry() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(automerge::ROOT, "bestBird", "robin").unwrap();
+    doc1.set(ObjId::Root, "bestBird", "robin").unwrap();
     doc2.merge(&mut doc1);
-    doc1.del(automerge::ROOT, "bestBird").unwrap();
+    doc1.del(ObjId::Root, "bestBird").unwrap();
     let set_two = doc2
-        .set(automerge::ROOT, "bestBird", "magpie")
+        .set(ObjId::Root, "bestBird", "magpie")
         .unwrap()
         .unwrap();
 
@@ -503,7 +489,7 @@ fn concurrent_assignment_and_deletion_of_a_map_entry() {
         &doc1,
         map! {
             "bestBird" => {
-                set_two.translate(&doc2) => "magpie",
+                set_two => "magpie",
             }
         }
     );
@@ -514,25 +500,24 @@ fn concurrent_assignment_and_deletion_of_list_entry() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set(automerge::ROOT, "birds", automerge::Value::list())
+        .set(ObjId::Root, "birds", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let blackbird = doc1.insert(list_id, 0, "blackbird").unwrap();
-    doc1.insert(list_id, 1, "thrush").unwrap();
-    let goldfinch = doc1.insert(list_id, 2, "goldfinch").unwrap();
+    let blackbird = doc1.insert(&list_id, 0, "blackbird").unwrap();
+    doc1.insert(&list_id, 1, "thrush").unwrap();
+    let goldfinch = doc1.insert(&list_id, 2, "goldfinch").unwrap();
     doc2.merge(&mut doc1);
 
-    let starling = doc1.set(list_id, 1, "starling").unwrap().unwrap();
+    let starling = doc1.set(&list_id, 1, "starling").unwrap().unwrap();
 
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
-    doc2.del(list_id_in_doc2, 1).unwrap();
+    doc2.del(&list_id, 1).unwrap();
 
     assert_doc!(
         &doc2,
         map! {
-            "birds" => {list_id.translate(&doc1) => list![
-                { blackbird.translate(&doc1) => "blackbird"},
-                { goldfinch.translate(&doc1) => "goldfinch"},
+            "birds" => {list_id => list![
+                { blackbird => "blackbird"},
+                { goldfinch => "goldfinch"},
             ]}
         }
     );
@@ -540,7 +525,7 @@ fn concurrent_assignment_and_deletion_of_list_entry() {
     assert_doc!(
         &doc1,
         map! {
-            "birds" => {list_id => list![
+            "birds" => {list_id.clone() => list![
                 { blackbird => "blackbird" },
                 { starling => "starling" },
                 { goldfinch => "goldfinch" },
@@ -567,22 +552,22 @@ fn insertion_after_a_deleted_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set(automerge::ROOT, "birds", automerge::Value::list())
+        .set(ObjId::Root, "birds", automerge::Value::list())
         .unwrap()
         .unwrap();
 
-    let blackbird = doc1.insert(list_id, 0, "blackbird").unwrap();
-    doc1.insert(list_id, 1, "thrush").unwrap();
-    doc1.insert(list_id, 2, "goldfinch").unwrap();
+    let blackbird = doc1.insert(list_id.clone(), 0, "blackbird").unwrap();
+    doc1.insert(&list_id, 1, "thrush").unwrap();
+    doc1.insert(&list_id, 2, "goldfinch").unwrap();
 
     doc2.merge(&mut doc1);
 
-    doc1.splice(list_id, 1, 2, Vec::new()).unwrap();
+    doc1.splice(&list_id, 1, 2, Vec::new()).unwrap();
 
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
     let starling = doc2
-        .splice(list_id_in_doc2, 2, 0, vec!["starling".into()])
-        .unwrap()[0];
+        .splice(&list_id, 2, 0, vec!["starling".into()])
+        .unwrap()[0]
+        .clone();
 
     doc1.merge(&mut doc2);
 
@@ -590,8 +575,8 @@ fn insertion_after_a_deleted_list_element() {
         &doc1,
         map! {
             "birds" => {list_id => list![
-                { blackbird.native() => "blackbird" },
-                { starling.translate(&doc2) => "starling" }
+                { blackbird => "blackbird" },
+                { starling => "starling" }
             ]}
         }
     );
@@ -600,9 +585,9 @@ fn insertion_after_a_deleted_list_element() {
     assert_doc!(
         &doc2,
         map! {
-            "birds" => {list_id.translate(&doc1) => list![
-                { blackbird.translate(&doc1) => "blackbird" },
-                { starling.native() => "starling" }
+            "birds" => {list_id => list![
+                { blackbird => "blackbird" },
+                { starling => "starling" }
             ]}
         }
     );
@@ -613,20 +598,19 @@ fn concurrent_deletion_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set(automerge::ROOT, "birds", automerge::Value::list())
+        .set(ObjId::Root, "birds", automerge::Value::list())
         .unwrap()
         .unwrap();
 
-    let albatross = doc1.insert(list_id, 0, "albatross").unwrap();
-    doc1.insert(list_id, 1, "buzzard").unwrap();
-    let cormorant = doc1.insert(list_id, 2, "cormorant").unwrap();
+    let albatross = doc1.insert(list_id.clone(), 0, "albatross").unwrap();
+    doc1.insert(&list_id, 1, "buzzard").unwrap();
+    let cormorant = doc1.insert(&list_id, 2, "cormorant").unwrap();
 
     doc2.merge(&mut doc1);
 
-    doc1.del(list_id, 1).unwrap();
+    doc1.del(&list_id, 1).unwrap();
 
-    let list_id_in_doc2 = translate_obj_id(&doc1, &doc2, list_id);
-    doc2.del(list_id_in_doc2, 1).unwrap();
+    doc2.del(&list_id, 1).unwrap();
 
     doc1.merge(&mut doc2);
 
@@ -644,9 +628,9 @@ fn concurrent_deletion_of_same_list_element() {
     assert_doc!(
         &doc2,
         map! {
-            "birds" => {list_id.translate(&doc1) => list![
-                { albatross.translate(&doc1) => "albatross" },
-                { cormorant.translate(&doc1) => "cormorant" }
+            "birds" => {list_id => list![
+                { albatross => "albatross" },
+                { cormorant => "cormorant" }
             ]}
         }
     );
@@ -658,33 +642,32 @@ fn concurrent_updates_at_different_levels() {
     let mut doc2 = new_doc();
 
     let animals = doc1
-        .set(automerge::ROOT, "animals", automerge::Value::map())
+        .set(ObjId::Root, "animals", automerge::Value::map())
         .unwrap()
         .unwrap();
     let birds = doc1
-        .set(animals, "birds", automerge::Value::map())
+        .set(&animals, "birds", automerge::Value::map())
         .unwrap()
         .unwrap();
-    doc1.set(birds, "pink", "flamingo").unwrap().unwrap();
-    doc1.set(birds, "black", "starling").unwrap().unwrap();
+    doc1.set(&birds, "pink", "flamingo").unwrap().unwrap();
+    doc1.set(&birds, "black", "starling").unwrap().unwrap();
 
     let mammals = doc1
-        .set(animals, "mammals", automerge::Value::list())
+        .set(&animals, "mammals", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let badger = doc1.insert(mammals, 0, "badger").unwrap();
+    let badger = doc1.insert(&mammals, 0, "badger").unwrap();
 
     doc2.merge(&mut doc1);
 
-    doc1.set(birds, "brown", "sparrow").unwrap().unwrap();
+    doc1.set(&birds, "brown", "sparrow").unwrap().unwrap();
 
-    let animals_in_doc2 = translate_obj_id(&doc1, &doc2, animals);
-    doc2.del(animals_in_doc2, "birds").unwrap();
+    doc2.del(&animals, "birds").unwrap();
     doc1.merge(&mut doc2);
 
     assert_obj!(
         &doc1,
-        automerge::ROOT,
+        ObjId::Root,
         "animals",
         map! {
             "mammals" => {
@@ -695,11 +678,11 @@ fn concurrent_updates_at_different_levels() {
 
     assert_obj!(
         &doc2,
-        automerge::ROOT,
+        ObjId::Root,
         "animals",
         map! {
             "mammals" => {
-                mammals.translate(&doc1) => list![{ badger.translate(&doc1) => "badger" }],
+                mammals => list![{ badger => "badger" }],
             }
         }
     );
@@ -711,21 +694,20 @@ fn concurrent_updates_of_concurrently_deleted_objects() {
     let mut doc2 = new_doc();
 
     let birds = doc1
-        .set(automerge::ROOT, "birds", automerge::Value::map())
+        .set(ObjId::Root, "birds", automerge::Value::map())
         .unwrap()
         .unwrap();
     let blackbird = doc1
-        .set(birds, "blackbird", automerge::Value::map())
+        .set(&birds, "blackbird", automerge::Value::map())
         .unwrap()
         .unwrap();
-    doc1.set(blackbird, "feathers", "black").unwrap().unwrap();
+    doc1.set(&blackbird, "feathers", "black").unwrap().unwrap();
 
     doc2.merge(&mut doc1);
 
-    doc1.del(birds, "blackbird").unwrap();
+    doc1.del(&birds, "blackbird").unwrap();
 
-    translate_obj_id(&doc1, &doc2, blackbird);
-    doc2.set(blackbird, "beak", "orange").unwrap();
+    doc2.set(&blackbird, "beak", "orange").unwrap();
 
     doc1.merge(&mut doc2);
 
@@ -746,14 +728,14 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
     let mut doc2 = new_doc_with_actor(actor2);
 
     let wisdom = doc1
-        .set(automerge::ROOT, "wisdom", automerge::Value::list())
+        .set(ObjId::Root, "wisdom", automerge::Value::list())
         .unwrap()
         .unwrap();
     doc2.merge(&mut doc1);
 
     let doc1elems = doc1
         .splice(
-            wisdom,
+            &wisdom,
             0,
             0,
             vec![
@@ -766,10 +748,9 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
         )
         .unwrap();
 
-    let wisdom_in_doc2 = translate_obj_id(&doc1, &doc2, wisdom);
     let doc2elems = doc2
         .splice(
-            wisdom_in_doc2,
+            &wisdom,
             0,
             0,
             vec![
@@ -788,16 +769,16 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
         &doc1,
         map! {
             "wisdom" => {wisdom => list![
-                {doc1elems[0].native() => "to"},
-                {doc1elems[1].native() => "be"},
-                {doc1elems[2].native() => "is"},
-                {doc1elems[3].native() => "to"},
-                {doc1elems[4].native() => "do"},
-                {doc2elems[0].translate(&doc2) => "to"},
-                {doc2elems[1].translate(&doc2) => "do"},
-                {doc2elems[2].translate(&doc2) => "is"},
-                {doc2elems[3].translate(&doc2) => "to"},
-                {doc2elems[4].translate(&doc2) => "be"},
+                {doc1elems[0] => "to"},
+                {doc1elems[1] => "be"},
+                {doc1elems[2] => "is"},
+                {doc1elems[3] => "to"},
+                {doc1elems[4] => "do"},
+                {doc2elems[0] => "to"},
+                {doc2elems[1] => "do"},
+                {doc2elems[2] => "is"},
+                {doc2elems[3] => "to"},
+                {doc2elems[4] => "be"},
             ]}
         }
     );
@@ -811,20 +792,19 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_greater_actor_id(
     let mut doc2 = new_doc_with_actor(actor2);
 
     let list = doc1
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let two = doc1.insert(list, 0, "two").unwrap();
+    let two = doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1);
 
-    let list_in_doc2 = translate_obj_id(&doc1, &doc2, list);
-    let one = doc2.insert(list_in_doc2, 0, "one").unwrap();
+    let one = doc2.insert(&list, 0, "one").unwrap();
     assert_doc!(
         &doc2,
         map! {
-            "list" => { list.translate(&doc1) => list![
-                { one.native() => "one" },
-                { two.translate(&doc1) => "two" },
+            "list" => { list => list![
+                { one => "one" },
+                { two => "two" },
             ]}
         }
     );
@@ -838,20 +818,19 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_lesser_actor_id()
     let mut doc2 = new_doc_with_actor(actor2);
 
     let list = doc1
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let two = doc1.insert(list, 0, "two").unwrap();
+    let two = doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1);
 
-    let list_in_doc2 = translate_obj_id(&doc1, &doc2, list);
-    let one = doc2.insert(list_in_doc2, 0, "one").unwrap();
+    let one = doc2.insert(&list, 0, "one").unwrap();
     assert_doc!(
         &doc2,
         map! {
-            "list" => { list.translate(&doc1) => list![
-                { one.native() => "one" },
-                { two.translate(&doc1) => "two" },
+            "list" => { list => list![
+                { one => "one" },
+                { two => "two" },
             ]}
         }
     );
@@ -863,29 +842,69 @@ fn insertion_consistent_with_causality() {
     let mut doc2 = new_doc();
 
     let list = doc1
-        .set(automerge::ROOT, "list", automerge::Value::list())
+        .set(ObjId::Root, "list", automerge::Value::list())
         .unwrap()
         .unwrap();
-    let four = doc1.insert(list, 0, "four").unwrap();
+    let four = doc1.insert(&list, 0, "four").unwrap();
     doc2.merge(&mut doc1);
-    let list_in_doc2 = translate_obj_id(&doc1, &doc2, list);
-    let three = doc2.insert(list_in_doc2, 0, "three").unwrap();
+    let three = doc2.insert(&list, 0, "three").unwrap();
     doc1.merge(&mut doc2);
-    let two = doc1.insert(list, 0, "two").unwrap();
+    let two = doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1);
-    let one = doc2.insert(list_in_doc2, 0, "one").unwrap();
+    let one = doc2.insert(&list, 0, "one").unwrap();
 
     assert_doc!(
         &doc2,
         map! {
-            "list" => {list.translate(&doc1) => list![
-                {one.native() => "one"},
-                {two.translate(&doc1) => "two"},
-                {three.native() => "three" },
-                {four.translate(&doc1) => "four"},
+            "list" => {list => list![
+                {one => "one"},
+                {two => "two"},
+                {three => "three" },
+                {four => "four"},
             ]}
         }
     );
+}
+
+#[test]
+fn should_handle_arbitrary_depth_nesting() {
+    let mut doc1 = new_doc();
+    let a = doc1
+        .set(ObjId::Root, "a", automerge::Value::map())
+        .unwrap()
+        .unwrap();
+    let b = doc1.set(&a, "b", automerge::Value::map()).unwrap().unwrap();
+    let c = doc1.set(&b, "c", automerge::Value::map()).unwrap().unwrap();
+    let d = doc1.set(&c, "d", automerge::Value::map()).unwrap().unwrap();
+    let e = doc1.set(&d, "e", automerge::Value::map()).unwrap().unwrap();
+    let f = doc1.set(&e, "f", automerge::Value::map()).unwrap().unwrap();
+    let g = doc1.set(&f, "g", automerge::Value::map()).unwrap().unwrap();
+    let h = doc1.set(&g, "h", "h").unwrap().unwrap();
+    let j = doc1.set(&f, "i", "j").unwrap().unwrap();
+
+    assert_doc!(
+        &doc1,
+        map! {
+            "a" => {a => map!{
+                "b" => {b => map!{
+                    "c" => {c => map!{
+                        "d" => {d => map!{
+                            "e" => {e => map!{
+                                "f" => {f => map!{
+                                    "g" => {g => map!{
+                                        "h" => {h => "h"}
+                                    }},
+                                    "i" => {j => "j"},
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }
+    );
+
+    Automerge::load(&doc1.save().unwrap()).unwrap();
 }
 
 #[test]
@@ -900,26 +919,30 @@ fn save_and_restore_empty() {
 fn save_restore_complex() {
     let mut doc1 = new_doc();
     let todos = doc1
-        .set(automerge::ROOT, "todos", automerge::Value::list())
+        .set(ObjId::Root, "todos", automerge::Value::list())
         .unwrap()
         .unwrap();
 
-    let first_todo = doc1.insert(todos, 0, automerge::Value::map()).unwrap();
-    doc1.set(first_todo, "title", "water plants")
+    let first_todo = doc1
+        .insert(todos.clone(), 0, automerge::Value::map())
+        .unwrap();
+    doc1.set(&first_todo, "title", "water plants")
         .unwrap()
         .unwrap();
-    let first_done = doc1.set(first_todo, "done", false).unwrap().unwrap();
+    let first_done = doc1
+        .set(first_todo.clone(), "done", false)
+        .unwrap()
+        .unwrap();
 
     let mut doc2 = new_doc();
     doc2.merge(&mut doc1);
-    let first_todo_in_doc2 = translate_obj_id(&doc1, &doc2, first_todo);
     let weed_title = doc2
-        .set(first_todo_in_doc2, "title", "weed plants")
+        .set(first_todo.clone(), "title", "weed plants")
         .unwrap()
         .unwrap();
 
     let kill_title = doc1
-        .set(first_todo, "title", "kill plants")
+        .set(&first_todo, "title", "kill plants")
         .unwrap()
         .unwrap();
     doc1.merge(&mut doc2);
@@ -929,13 +952,13 @@ fn save_restore_complex() {
     assert_doc!(
         &reloaded,
         map! {
-            "todos" => {todos.translate(&doc1) => list![
-                {first_todo.translate(&doc1) => map!{
+            "todos" => {todos => list![
+                {first_todo => map!{
                     "title" => {
-                        weed_title.translate(&doc2) => "weed plants",
-                        kill_title.translate(&doc1) => "kill plants",
+                        weed_title => "weed plants",
+                        kill_title => "kill plants",
                     },
-                    "done" => {first_done.translate(&doc1) => false},
+                    "done" => {first_done => false},
                 }}
             ]}
         }

--- a/edit-trace/Cargo.toml
+++ b/edit-trace/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "edit-trace"
+bench = false
 
 [dependencies]
 automerge = { path = "../automerge" }

--- a/edit-trace/benches/main.rs
+++ b/edit-trace/benches/main.rs
@@ -1,13 +1,16 @@
-use automerge::{Automerge, Value, ROOT};
+use automerge::{Automerge, ObjId, Value};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::fs;
 
 fn replay_trace(commands: Vec<(usize, usize, Vec<Value>)>) -> Automerge {
     let mut doc = Automerge::new();
 
-    let text = doc.set(ROOT, "text", Value::text()).unwrap().unwrap();
+    let text = doc
+        .set(ObjId::Root, "text", Value::text())
+        .unwrap()
+        .unwrap();
     for (pos, del, vals) in commands {
-        doc.splice(text, pos, del, vals).unwrap();
+        doc.splice(&text, pos, del, vals).unwrap();
     }
     doc.commit(None, None);
     doc

--- a/edit-trace/src/main.rs
+++ b/edit-trace/src/main.rs
@@ -1,4 +1,4 @@
-use automerge::{Automerge, AutomergeError, Value, ROOT};
+use automerge::{Automerge, AutomergeError, ObjId, Value};
 use std::fs;
 use std::time::Instant;
 
@@ -19,12 +19,15 @@ fn main() -> Result<(), AutomergeError> {
     let mut doc = Automerge::new();
 
     let now = Instant::now();
-    let text = doc.set(ROOT, "text", Value::text()).unwrap().unwrap();
+    let text = doc
+        .set(ObjId::Root, "text", Value::text())
+        .unwrap()
+        .unwrap();
     for (i, (pos, del, vals)) in commands.into_iter().enumerate() {
         if i % 1000 == 0 {
             println!("Processed {} edits in {} ms", i, now.elapsed().as_millis());
         }
-        doc.splice(text, pos, del, vals)?;
+        doc.splice(&text, pos, del, vals)?;
     }
     let _ = doc.save();
     println!("Done in {} ms", now.elapsed().as_millis());


### PR DESCRIPTION
# Errrrgonomics

The current API contains a footgun: OpIds which are generated by different documents cannot be used interchangeably. This PR attempts to fix this by introducing some "external" types, which are intended to be exposed to users of the API in the place of the current OpId based types. We also change the representation of object IDs and element IDs to be enums with a `Root` and `Head` branch respectively, which is more idiomatic in Rust and thus hopefully more readable.

A detailed description of the design of the external types is documented in the comments at the top of `automerge/src/external_types.rs`. The short story is that we expose an `ExternalOpId` type which contains the counter and the actual bytes of the OpId, whilst all derivative types which may contain an OpId (e.g. ElemIds, or ObjectIds, or Keys) just contain a refereence to an `ExternalOpid`. 

This PR just contains the work necessary to expose the external types and line up the types on the external API. Once this change is in it will probably make sense to split `automerge::Automerge` into a facade which just performs the work of translating opids and an `Inner` type which actually performas the logic of interacting with the OpSet.

You can already see examples of how much this cleans up the API if you look at the tests. 

## Interior Mutability

The biggest change which is required here is that `OpSet::m: OpSetMetadata` has  become an `Rc<RefCell<OpSetMetadata>>`. This is because now that we are using external opids we must import these opids into the metadata even for "read only" operations - otherwise we have no basis for comparing query operations with internal operations. This does expose us to the risk of violating the contract of `borrow` calls on `Refcell`. For now we rely on tests to catch these situations (and they did several times in the writing of this code) but once the split into Facade and Inner I spoke about above is complete then we could move the `OpSetMetadata` to be held by the facade and passed in by reference to the `OpSet`. This would allow us to easily reason about when mutable borrows are active as they would only be active in the scope of functions in the facade.

## Performance Impact

The benchmarks for save and load are unchanged. The replay benchmark is affected, on my machine it is anywhere from 5-15% slower. The majority of this additional time seems to be spent allocating and pushing into the vector of operations IDs which are returned by the `splice` call. This may be to do with external OpIds being unable to benefit from cache locality of some kind due to being larger? I don't know. Regardless I don't think this is too important. We're still talking about 380ms to _replay_ the entire document and if we want to recoup that performance we can add an option to `splice` to not return the OpIds and thus skip all the tedious allocating and copying. In my opinion this is not worth it until we have actual examples of users who would be impacted by this.
