### PR TITLE
Correctly sort actor IDs when encoding changes

### DIFF
--- a/automerge/src/encoding.rs
+++ b/automerge/src/encoding.rs
@@ -246,11 +246,7 @@ pub(crate) trait Encodable {
         Ok(buf)
     }
 
-    fn encode_with_actors<R: Write>(
-        &self,
-        buf: &mut R,
-        _actors: &mut Vec<ActorId>,
-    ) -> io::Result<usize> {
+    fn encode_with_actors<R: Write>(&self, buf: &mut R, _actors: &[ActorId]) -> io::Result<usize> {
         self.encode(buf)
     }
 


### PR DESCRIPTION
This is a port of a fix previously merged into `main` in `e72571962b51c2f0726fb534890ef3b4f7c74dfc`

The javascript implementation of automerge sorts actor IDs
lexicographically when encoding changes. We were sorting actor IDs in
the order the appear in the change we're encoding. This meant that the
index that we assigned to operations in the encoded change was different
to that which the javascript implementation assigns, resulting in
mismatched head errors as the hashes we created did not match the
javascript implementation.

This change fixes the issue by sorting actor IDs lexicographically. We
make a pass over the operations in the change before encoding to collect
the actor IDs and sort them. This means we no longer need to pass a
mutable `Vec<ActorId>` to the various encode functions, which cleans
things up a little.