### PR TITLE
Add test and doc update for setting scalarvalues

### DIFF
--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -289,7 +289,7 @@ pub(crate) fn get_heads(heads: JsValue) -> Option<Vec<ChangeHash>> {
     JS(heads).into()
 }
 
-pub(crate) fn map_to_js(doc: &mut am::Automerge, obj: &ObjId) -> JsValue {
+pub(crate) fn map_to_js(doc: &am::Automerge, obj: &ObjId) -> JsValue {
     let keys = doc.keys(obj);
     let map = Object::new();
     for k in keys {
@@ -312,7 +312,7 @@ pub(crate) fn map_to_js(doc: &mut am::Automerge, obj: &ObjId) -> JsValue {
     map.into()
 }
 
-fn list_to_js(doc: &mut am::Automerge, obj: &ObjId) -> JsValue {
+fn list_to_js(doc: &am::Automerge, obj: &ObjId) -> JsValue {
     let len = doc.length(obj);
     let array = Array::new();
     for i in 0..len {

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -398,8 +398,8 @@ impl Automerge {
     }
 
     #[wasm_bindgen(js_name = toJS)]
-    pub fn to_js(&mut self) -> JsValue {
-        map_to_js(&mut self.0, &ROOT)
+    pub fn to_js(&self) -> JsValue {
+        map_to_js(&self.0, &ROOT)
     }
 
     fn export(&self, val: ObjId) -> JsValue {

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -253,7 +253,7 @@ impl Automerge {
     /// # Returns
     ///
     /// The opid of the operation which was created, or None if this operation doesn't change the
-    /// document
+    /// document or create a new object.
     ///
     /// # Errors
     ///
@@ -1132,6 +1132,20 @@ mod tests {
         doc.set(&ROOT, "hello", "world")?;
         assert!(doc.pending_ops() == 1);
         doc.value(&ROOT, "hello")?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_set() -> Result<(), AutomergeError> {
+        let mut doc = Automerge::new();
+        // setting a scalar value shouldn't return an opid as no object was created.
+        assert!(doc.set(&ROOT, "a", 1)?.is_none());
+        // setting the same value shouldn't return an opid as there is no change.
+        assert!(doc.set(&ROOT, "a", 1)?.is_none());
+
+        assert!(doc.set(&ROOT, "b", Value::map())?.is_some());
+        // object already exists at b but setting a map again overwrites it so we get an opid.
+        assert!(doc.set(&ROOT, "b", Value::map())?.is_some());
         Ok(())
     }
 

--- a/automerge/src/visualisation.rs
+++ b/automerge/src/visualisation.rs
@@ -69,8 +69,8 @@ impl<'a, const B: usize> GraphVisualisation<'a, B> {
             actor_shorthands.insert(actor, format!("actor{}", actor));
         }
         GraphVisualisation {
-            actor_shorthands,
             nodes,
+            actor_shorthands,
         }
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
                 cargo-criterion
                 cargo-fuzz
                 cargo-flamegraph
+                cargo-deny
                 crate2nix
                 wasm-pack
                 pkgconfig


### PR DESCRIPTION
The docs for set mention the return of an opid only when the document changes, which I would have expected a scalarvalue set to do. This adds the caveat that it is also required to create a new object in the document.

I think the docs on this could be clearer, maybe also mentioning that setting an object overwrites the old one (if it existed) thus returning an opid.