### PR TITLE
Add length tests to props tests

### DIFF
--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -289,7 +289,7 @@ pub(crate) fn get_heads(heads: JsValue) -> Option<Vec<ChangeHash>> {
     JS(heads).into()
 }
 
-pub(crate) fn map_to_js(doc: &mut am::Automerge, obj: &ObjId) -> JsValue {
+pub(crate) fn map_to_js(doc: &am::Automerge, obj: &ObjId) -> JsValue {
     let keys = doc.keys(obj);
     let map = Object::new();
     for k in keys {
@@ -312,7 +312,7 @@ pub(crate) fn map_to_js(doc: &mut am::Automerge, obj: &ObjId) -> JsValue {
     map.into()
 }
 
-fn list_to_js(doc: &mut am::Automerge, obj: &ObjId) -> JsValue {
+fn list_to_js(doc: &am::Automerge, obj: &ObjId) -> JsValue {
     let len = doc.length(obj);
     let array = Array::new();
     for i in 0..len {

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -398,8 +398,8 @@ impl Automerge {
     }
 
     #[wasm_bindgen(js_name = toJS)]
-    pub fn to_js(&mut self) -> JsValue {
-        map_to_js(&mut self.0, &ROOT)
+    pub fn to_js(&self) -> JsValue {
+        map_to_js(&self.0, &ROOT)
     }
 
     fn export(&self, val: ObjId) -> JsValue {

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -153,7 +153,8 @@ impl Automerge {
     pub fn rollback(&mut self) -> usize {
         if let Some(tx) = self.transaction.take() {
             let num = tx.operations.len();
-            for op in &tx.operations {
+            // remove in reverse order so sets are removed before makes etc...
+            for op in tx.operations.iter().rev() {
                 for pred_id in &op.pred {
                     // FIXME - use query to make this fast
                     if let Some(p) = self.ops.iter().position(|o| o.id == *pred_id) {

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1253,31 +1253,38 @@ mod tests {
         doc.commit(None, None);
         let heads5 = doc.get_heads();
         assert!(doc.keys_at(&ROOT, &heads1) == vec!["prop1".to_owned()]);
+        assert_eq!(doc.length_at(&ROOT, &heads1), 1);
         assert!(doc.value_at(&ROOT, "prop1", &heads1)?.unwrap().0 == Value::str("val1"));
         assert!(doc.value_at(&ROOT, "prop2", &heads1)? == None);
         assert!(doc.value_at(&ROOT, "prop3", &heads1)? == None);
 
         assert!(doc.keys_at(&ROOT, &heads2) == vec!["prop1".to_owned()]);
+        assert_eq!(doc.length_at(&ROOT, &heads2), 1);
         assert!(doc.value_at(&ROOT, "prop1", &heads2)?.unwrap().0 == Value::str("val2"));
         assert!(doc.value_at(&ROOT, "prop2", &heads2)? == None);
         assert!(doc.value_at(&ROOT, "prop3", &heads2)? == None);
 
         assert!(doc.keys_at(&ROOT, &heads3) == vec!["prop1".to_owned(), "prop2".to_owned()]);
+        assert_eq!(doc.length_at(&ROOT, &heads3), 2);
         assert!(doc.value_at(&ROOT, "prop1", &heads3)?.unwrap().0 == Value::str("val2"));
         assert!(doc.value_at(&ROOT, "prop2", &heads3)?.unwrap().0 == Value::str("val3"));
         assert!(doc.value_at(&ROOT, "prop3", &heads3)? == None);
 
         assert!(doc.keys_at(&ROOT, &heads4) == vec!["prop2".to_owned()]);
+        assert_eq!(doc.length_at(&ROOT, &heads4), 1);
         assert!(doc.value_at(&ROOT, "prop1", &heads4)? == None);
         assert!(doc.value_at(&ROOT, "prop2", &heads4)?.unwrap().0 == Value::str("val3"));
         assert!(doc.value_at(&ROOT, "prop3", &heads4)? == None);
 
         assert!(doc.keys_at(&ROOT, &heads5) == vec!["prop2".to_owned(), "prop3".to_owned()]);
+        assert_eq!(doc.length_at(&ROOT, &heads5), 2);
+        assert_eq!(doc.length(&ROOT), 2);
         assert!(doc.value_at(&ROOT, "prop1", &heads5)? == None);
         assert!(doc.value_at(&ROOT, "prop2", &heads5)?.unwrap().0 == Value::str("val3"));
         assert!(doc.value_at(&ROOT, "prop3", &heads5)?.unwrap().0 == Value::str("val4"));
 
         assert!(doc.keys_at(&ROOT, &[]).is_empty());
+        assert_eq!(doc.length_at(&ROOT, &[]), 0);
         assert!(doc.value_at(&ROOT, "prop1", &[])? == None);
         assert!(doc.value_at(&ROOT, "prop2", &[])? == None);
         assert!(doc.value_at(&ROOT, "prop3", &[])? == None);
@@ -1329,6 +1336,7 @@ mod tests {
         assert!(doc.value_at(&list, 1, &heads5)?.unwrap().0 == Value::int(50));
 
         assert!(doc.length_at(&list, &heads6) == 1);
+        assert!(doc.length(&list) == 1);
         assert!(doc.value_at(&list, 0, &heads6)?.unwrap().0 == Value::int(50));
 
         Ok(())

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -64,11 +64,12 @@ impl<const B: usize> OpSetInternal<B> {
     }
 
     pub fn remove(&mut self, obj: ObjId, index: usize) -> Op {
+        // this happens on rollback - be sure to go back to the old state
         let (_typ, tree) = self.trees.get_mut(&obj).unwrap();
         self.length -= 1;
         let op = tree.remove(index);
-        if tree.is_empty() {
-            self.trees.remove(&obj);
+        if let OpType::Make(_) = &op.action {
+            self.trees.remove(&op.id.into());
         }
         op
     }

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -49,11 +49,6 @@ impl<const B: usize> OpTreeInternal<B> {
         query
     }
 
-    /// Check if the sequence is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     /// Create an iterator through the sequence.
     pub fn iter(&self) -> Iter<'_, B> {
         Iter {

--- a/automerge/src/visualisation.rs
+++ b/automerge/src/visualisation.rs
@@ -43,13 +43,13 @@ impl<'a, const B: usize> GraphVisualisation<'a, B> {
     pub(super) fn construct(
         trees: &'a HashMap<
             crate::types::ObjId,
-            crate::op_tree::OpTreeInternal<B>,
+            (crate::types::ObjType, crate::op_tree::OpTreeInternal<B>),
             BuildHasherDefault<FxHasher>,
         >,
         metadata: &'a crate::op_set::OpSetMetadata,
     ) -> GraphVisualisation<'a, B> {
         let mut nodes = HashMap::new();
-        for (obj_id, tree) in trees {
+        for (obj_id, (_, tree)) in trees {
             if let Some(root_node) = &tree.root_node {
                 let tree_id = Self::construct_nodes(root_node, &mut nodes, metadata);
                 let obj_tree_id = NodeId::default();

--- a/automerge/src/visualisation.rs
+++ b/automerge/src/visualisation.rs
@@ -69,8 +69,8 @@ impl<'a, const B: usize> GraphVisualisation<'a, B> {
             actor_shorthands.insert(actor, format!("actor{}", actor));
         }
         GraphVisualisation {
-            actor_shorthands,
             nodes,
+            actor_shorthands,
         }
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
                 cargo-criterion
                 cargo-fuzz
                 cargo-flamegraph
+                cargo-deny
                 crate2nix
                 wasm-pack
                 pkgconfig


### PR DESCRIPTION
Getting the length of a `Map` object doesn't seem to work.

At some point we'll also want to add a test for a case where an object gets changed from a list to an object and vice-versa to check we get the length of each respective one in history correctly.