### PR TITLE
Lamport compare was backward on Actor's and so was value resolution

### DIFF
--- a/automerge-js/test/legacy_tests.js
+++ b/automerge-js/test/legacy_tests.js
@@ -613,6 +613,29 @@ describe('Automerge', () => {
         assert.strictEqual(s1.japaneseFood.length, 3)
       })
 
+      it('concurrent edits insert in reverse actorid order if counters equal', () => {
+        s1 = Automerge.init('aaaa')
+        s2 = Automerge.init('bbbb')
+        s1 = Automerge.change(s1, doc => doc.list = [])
+        s2 = Automerge.merge(s2, s1)
+        s1 = Automerge.change(s1, doc => doc.list.splice(0, 0, "2@aaaa"))
+        s2 = Automerge.change(s2, doc => doc.list.splice(0, 0, "2@bbbb"))
+        s2 = Automerge.merge(s2, s1)
+        assert.deepStrictEqual(Automerge.toJS(s2).list, ["2@bbbb", "2@aaaa"])
+      })
+
+      it('concurrent edits insert in reverse counter order if different', () => {
+        s1 = Automerge.init('aaaa')
+        s2 = Automerge.init('bbbb')
+        s1 = Automerge.change(s1, doc => doc.list = [])
+        s2 = Automerge.merge(s2, s1)
+        s1 = Automerge.change(s1, doc => doc.list.splice(0, 0, "2@aaaa"))
+          s2 = Automerge.change(s2, doc => doc.foo = "2@bbbb")
+          s2 = Automerge.change(s2, doc => doc.list.splice(0, 0, "3@bbbb"))
+          s2 = Automerge.merge(s2, s1)
+          assert.deepStrictEqual(s2.list, ["3@bbbb", "2@aaaa"])
+      })
+
       it('should treat out-by-one assignment as insertion', () => {
         s1 = Automerge.change(s1, doc => doc.japaneseFood = ['udon'])
         s1 = Automerge.change(s1, doc => doc.japaneseFood[1] = 'sushi')

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unused_unit)]
 use automerge as am;
 use automerge::{Change, ObjId, Prop, Value, ROOT};
 use js_sys::{Array, Object, Uint8Array};

--- a/automerge-wasm/test/test.js
+++ b/automerge-wasm/test/test.js
@@ -303,14 +303,15 @@ describe('Automerge', () => {
       doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values("_root", "cnt")
       assert.deepEqual(result,[
-        ['counter',10,'2@cccc'],
+        ['int',20,'2@aaaa'],
         ['counter',0,'2@bbbb'],
-        ['int',20,'2@aaaa']
+        ['counter',10,'2@cccc'],
       ])
       doc1.inc("_root", "cnt", 5)
       result = doc1.values("_root", "cnt")
       assert.deepEqual(result, [
-        [ 'counter', 15, '2@cccc' ], [ 'counter', 5, '2@bbbb' ]
+        [ 'counter', 5, '2@bbbb' ],
+        [ 'counter', 15, '2@cccc' ],
       ])
 
       let save1 = doc1.save()
@@ -335,14 +336,15 @@ describe('Automerge', () => {
       doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values(seq, 0)
       assert.deepEqual(result,[
-        ['counter',10,'3@cccc'],
+        ['int',20,'3@aaaa'],
         ['counter',0,'3@bbbb'],
-        ['int',20,'3@aaaa']
+        ['counter',10,'3@cccc'],
       ])
       doc1.inc(seq, 0, 5)
       result = doc1.values(seq, 0)
       assert.deepEqual(result, [
-        [ 'counter', 15, '3@cccc' ], [ 'counter', 5, '3@bbbb' ]
+        [ 'counter', 5, '3@bbbb' ],
+        [ 'counter', 15, '3@cccc' ],
       ])
 
       let save = doc1.save()

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -745,7 +745,7 @@ impl Automerge {
             &self.ops.m.props.cache,
         );
         if bytes.is_ok() {
-            self.saved = self.get_heads().iter().copied().collect();
+            self.saved = self.get_heads().to_vec();
         }
         bytes
     }
@@ -759,7 +759,7 @@ impl Automerge {
             bytes.extend(c.raw_bytes());
         }
         if !bytes.is_empty() {
-            self.saved = self._get_heads().iter().copied().collect();
+            self.saved = self._get_heads().to_vec()
         }
         bytes
     }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -455,7 +455,7 @@ impl Automerge {
         obj: &ExId,
         prop: P,
     ) -> Result<Option<(Value, ExId)>, AutomergeError> {
-        Ok(self.values(obj, prop.into())?.first().cloned())
+        Ok(self.values(obj, prop.into())?.last().cloned())
     }
 
     pub fn value_at<P: Into<Prop>>(
@@ -464,7 +464,7 @@ impl Automerge {
         prop: P,
         heads: &[ChangeHash],
     ) -> Result<Option<(Value, ExId)>, AutomergeError> {
-        Ok(self.values_at(obj, prop, heads)?.first().cloned())
+        Ok(self.values_at(obj, prop, heads)?.last().cloned())
     }
 
     pub fn values<P: Into<Prop>>(

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -260,7 +260,7 @@ impl<'a> Iterator for ChangeIterator<'a> {
         let max_op = self.max_op.next()??;
         let time = self.time.next()?? as i64;
         let message = self.message.next()?;
-        let extra_bytes = self.extra.next().unwrap_or_else(Vec::new);
+        let extra_bytes = self.extra.next().unwrap_or_default();
         Some(DocChange {
             actor,
             seq,

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -173,8 +173,7 @@ impl OpSetMetadata {
             (OpId(0, _), OpId(0, _)) => Ordering::Equal,
             (OpId(0, _), OpId(_, _)) => Ordering::Less,
             (OpId(_, _), OpId(0, _)) => Ordering::Greater,
-            // FIXME - this one seems backwards to me - why - is values() returning in the wrong order?
-            (OpId(a, x), OpId(b, y)) if a == b => self.actors[y].cmp(&self.actors[x]),
+            (OpId(a, x), OpId(b, y)) if a == b => self.actors[x].cmp(&self.actors[y]),
             (OpId(a, _), OpId(b, _)) => a.cmp(&b),
         }
     }

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -440,10 +440,10 @@ fn concurrent_insertions_at_same_list_position() {
                         "parakeet",
                     },
                     {
-                        "starling",
+                        "chaffinch",
                     },
                     {
-                        "chaffinch",
+                        "starling",
                     },
                 ]
             },
@@ -741,15 +741,15 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
         map! {
             "wisdom" => {list![
                 {"to"},
-                {"be"},
-                {"is"},
-                {"to"},
-                {"do"},
-                {"to"},
                 {"do"},
                 {"is"},
                 {"to"},
                 {"be"},
+                {"to"},
+                {"be"},
+                {"is"},
+                {"to"},
+                {"do"},
             ]}
         }
     );
@@ -890,9 +890,9 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
     let mut v = vec![ActorId::random(), ActorId::random(), ActorId::random()];
     v.sort();
     println!("{:?}", v);
-    let actor1 = v[2].clone();
+    let actor1 = v[0].clone();
     let actor2 = v[1].clone();
-    let actor3 = v[0].clone();
+    let actor3 = v[2].clone();
 
     let mut doc1 = new_doc_with_actor(actor1);
 


### PR DESCRIPTION
Found a pretty surprising bug.  Lamport compare was being resolved in reverse order and so was conflict resolution... canceling each other out in all of the available tests.  Fixed both and added tests that would have caught this.  Going to make a PR to add these tests to automerge mainline as well.