### PR TITLE
Add failing test for decoding a conflicted merge

### DIFF
--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -538,6 +538,31 @@ describe('Automerge', () => {
       assert.deepStrictEqual(doc.save(), doc2.save())
     })
 
+    it('should handle merging text conflicts then saving & loading', () => {
+      let A = create()
+      let At = A.make('_root', 'text', TEXT)
+      A.splice(At, 0, 0, Array.from('hello'))
+
+      let B = A.clone()
+      let Bt = B.value('_root', 'text')
+      if (!Bt || Bt[0] !== 'text') return assert.fail()
+      let obj = Bt[1]
+      B.splice(obj, 4, 1, '')
+      B.splice(obj, 4, 0, '!')
+      B.splice(obj, 5, 0, ' ')
+      B.splice(obj, 6, 0, Array.from('world'))
+
+      A.applyChanges(B.getChanges(A.getHeads()))
+
+      let binary = A.save()
+
+      let C = loadDoc(binary)
+
+      assert.deepEqual(C.value('_root', 'text'), ['text', 'hello world'])
+
+
+    })
+
   })
   describe('sync', () => {
     it('should send a sync message implying no local data', () => {


### PR DESCRIPTION
```
  1) Automerge
       basics
         should handle merging text conflicts then saving & loading:
     Error: there was a decoding problem
      at /Users/okdistribute/dev/upwelling/api/automerge-rs/automerge-wasm/dev/index.js:1560:15
      at logError (/Users/okdistribute/dev/upwelling/api/automerge-rs/automerge-wasm/dev/index.js:427:18)
      at module.exports.__wbg_new_55259b13834a484c (/Users/okdistribute/dev/upwelling/api/automerge-rs/automerge-wasm/dev/index.js:1559:65)
      at js_sys::Error::new::hbdf90002c6b69763 (wasm://wasm/01c8115e:0:4645140)
      at automerge_wasm::interop::to_js_err::h69077334a2afb4da (wasm://wasm/01c8115e:0:3258952)
      at core::ops::function::FnOnce::call_once::h4d2ed61124df3442 (wasm://wasm/01c8115e:0:4487290)
      at core::result::Result<T,E>::map_err::h95c6f87840744bc3 (wasm://wasm/01c8115e:0:2945210)
      at automerge_wasm::load::h0603d928f2e5a59f (wasm://wasm/01c8115e:0:1522527)
      at loadDoc (wasm://wasm/01c8115e:0:3317722)
      at module.exports.loadDoc (/Users/okdistribute/dev/upwelling/api/automerge-rs/automerge-wasm/dev/index.js:243:14)
      at Context.<anonymous> (/Users/okdistribute/dev/upwelling/api/automerge-rs/automerge-wasm/test/test.ts:566:22)
      at callFn (/Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runnable.js:366:21)
      at Test.Runnable.run (/Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runnable.js:354:5)
      at Runner.runTest (/Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runner.js:681:10)
      at /Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runner.js:804:12
      at next (/Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runner.js:596:14)
      at /Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runner.js:606:7
      at next (/Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runner.js:489:14)
      at Immediate._onImmediate (/Users/okdistribute/dev/upwelling/api/node_modules/mocha/lib/runner.js:574:5)
      at processImmediate (internal/timers.js:461:21)
```