### PR TITLE
Add docs workflow for gh-pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Documentation
+
+jobs:
+  deploy-docs:
+    concurrency: deploy-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Build docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --all-features --no-deps
+
+      - name: Configure root page
+        run: echo '<meta http-equiv="refresh" content="0; url=automerge">' > target/doc/index.html
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc

--- a/automerge-backend-wasm/src/lib.rs
+++ b/automerge-backend-wasm/src/lib.rs
@@ -1,4 +1,5 @@
 //#![feature(set_stdio)]
+#![allow(clippy::unused_unit)]
 
 mod types;
 


### PR DESCRIPTION
Before we release to crates.io and whilst we are developing changes it is useful to be able to visit the built docs. This PR adds the github action to build and push them to the `gh-pages` branch.

@orionz this would need the github pages to be setup under settings, I think you have access to do that if you'd be able to, just needs something like this 
![image](https://user-images.githubusercontent.com/13849792/154352690-3b269b7d-7846-4234-a23b-8bc37d29d12c.png)

An example is available [on my branch](http://jeffas.io/automerge-rs/automerge/)