### PR TITLE
Optimise saving documents

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -498,7 +498,7 @@ impl Automerge {
 
     pub fn save(&mut self) -> Result<Vec<u8>, AutomergeError> {
         let heads = self.get_heads();
-        let c = self.history.iter().map(|c| c.decode());
+        let c = self.history.iter();
         let ops = self.ops.iter();
         // TODO - can we make encode_document error free
         let bytes = encode_document(heads, c, ops, &self.ops.m.actors, &self.ops.m.props.cache);

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -503,12 +503,11 @@ impl Automerge {
         // TODO - can we make encode_document error free
         let bytes = encode_document(heads, c, ops, &self.ops.m.actors, &self.ops.m.props.cache);
         if bytes.is_ok() {
-            self.saved = self.get_heads().to_vec();
+            self.saved = self.get_heads();
         }
         bytes
     }
 
-    // should this return an empty vec instead of None?
     pub fn save_incremental(&mut self) -> Vec<u8> {
         let changes = self.get_changes(self.saved.as_slice());
         let mut bytes = vec![];
@@ -516,7 +515,7 @@ impl Automerge {
             bytes.extend(c.raw_bytes());
         }
         if !bytes.is_empty() {
-            self.saved = self.get_heads().to_vec()
+            self.saved = self.get_heads()
         }
         bytes
     }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -497,16 +497,11 @@ impl Automerge {
     }
 
     pub fn save(&mut self) -> Result<Vec<u8>, AutomergeError> {
-        // TODO - would be nice if I could pass an iterator instead of a collection here
-        let c: Vec<_> = self.history.iter().map(|c| c.decode()).collect();
-        let ops: Vec<_> = self.ops.iter().cloned().collect();
+        let heads = self.get_heads();
+        let c = self.history.iter().map(|c| c.decode());
+        let ops = self.ops.iter();
         // TODO - can we make encode_document error free
-        let bytes = encode_document(
-            &c,
-            ops.as_slice(),
-            &self.ops.m.actors,
-            &self.ops.m.props.cache,
-        );
+        let bytes = encode_document(heads, c, ops, &self.ops.m.actors, &self.ops.m.props.cache);
         if bytes.is_ok() {
             self.saved = self.get_heads().to_vec();
         }

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -36,10 +36,10 @@ const BLOCK_TYPE_DEFLATE: u8 = 2;
 const CHUNK_START: usize = 8;
 const HASH_RANGE: Range<usize> = 4..8;
 
-pub(crate) fn encode_document<'a>(
+pub(crate) fn encode_document<'a, 'b>(
     heads: Vec<amp::ChangeHash>,
-    changes: impl Iterator<Item = amp::Change>,
-    doc_ops: impl Iterator<Item = &'a Op>,
+    changes: impl Iterator<Item = &'a Change>,
+    doc_ops: impl Iterator<Item = &'b Op>,
     actors_index: &IndexedCache<ActorId>,
     props: &'a [String],
 ) -> Result<Vec<u8>, AutomergeError> {

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -66,8 +66,8 @@ pub(crate) fn encode_document<'a, 'b>(
 
     let (ops_bytes, ops_info) = DocOpEncoder::encode_doc_ops(doc_ops, &actors_map, props);
 
-    bytes.extend(&MAGIC_BYTES);
-    bytes.extend(vec![0, 0, 0, 0]); // we dont know the hash yet so fill in a fake
+    bytes.extend(MAGIC_BYTES);
+    bytes.extend([0, 0, 0, 0]); // we dont know the hash yet so fill in a fake
     bytes.push(BLOCK_TYPE_DOC);
 
     let mut chunk = Vec::new();
@@ -79,7 +79,7 @@ pub(crate) fn encode_document<'a, 'b>(
     }
 
     heads.len().encode(&mut chunk)?;
-    for head in heads.iter().sorted() {
+    for head in heads.iter() {
         chunk.write_all(&head.0).unwrap();
     }
 

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -36,27 +36,14 @@ const BLOCK_TYPE_DEFLATE: u8 = 2;
 const CHUNK_START: usize = 8;
 const HASH_RANGE: Range<usize> = 4..8;
 
-fn get_heads(changes: &[amp::Change]) -> HashSet<amp::ChangeHash> {
-    changes.iter().fold(HashSet::new(), |mut acc, c| {
-        if let Some(h) = c.hash {
-            acc.insert(h);
-        }
-        for dep in &c.deps {
-            acc.remove(dep);
-        }
-        acc
-    })
-}
-
-pub(crate) fn encode_document(
-    changes: &[amp::Change],
-    doc_ops: &[Op],
+pub(crate) fn encode_document<'a>(
+    heads: Vec<amp::ChangeHash>,
+    changes: impl Iterator<Item = amp::Change>,
+    doc_ops: impl Iterator<Item = &'a Op>,
     actors_index: &IndexedCache<ActorId>,
-    props: &[String],
+    props: &'a [String],
 ) -> Result<Vec<u8>, AutomergeError> {
     let mut bytes: Vec<u8> = Vec::new();
-
-    let heads = get_heads(changes);
 
     let actors_map = actors_index.encode_index();
     let actors = actors_index.sorted();

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -905,12 +905,12 @@ pub(crate) struct ChangeEncoder {
 
 impl ChangeEncoder {
     #[instrument(level = "debug", skip(changes, actors))]
-    pub fn encode_changes<'a, 'b, I>(
+    pub fn encode_changes<'a, I>(
         changes: I,
         actors: &'a IndexedCache<ActorId>,
     ) -> (Vec<u8>, Vec<u8>)
     where
-        I: IntoIterator<Item = &'b amp::Change>,
+        I: IntoIterator<Item = amp::Change>,
     {
         let mut e = Self::new();
         e.encode(changes, actors);
@@ -931,9 +931,9 @@ impl ChangeEncoder {
         }
     }
 
-    fn encode<'a, 'b, 'c, I>(&'a mut self, changes: I, actors: &'b IndexedCache<ActorId>)
+    fn encode<I>(&mut self, changes: I, actors: &IndexedCache<ActorId>)
     where
-        I: IntoIterator<Item = &'c amp::Change>,
+        I: IntoIterator<Item = amp::Change>,
     {
         let mut index_by_hash: HashMap<amp::ChangeHash, usize> = HashMap::new();
         for (index, change) in changes.into_iter().enumerate() {
@@ -1010,17 +1010,15 @@ pub(crate) struct DocOpEncoder {
     succ: SuccEncoder,
 }
 
-// FIXME - actors should not be mut here
-
 impl DocOpEncoder {
     #[instrument(level = "debug", skip(ops, actors))]
-    pub(crate) fn encode_doc_ops<'a, I>(
+    pub(crate) fn encode_doc_ops<'a, 'b, 'c, I>(
         ops: I,
         actors: &'a [usize],
-        props: &'a [String],
+        props: &'b [String],
     ) -> (Vec<u8>, Vec<u8>)
     where
-        I: IntoIterator<Item = &'a Op>,
+        I: IntoIterator<Item = &'c Op>,
     {
         let mut e = Self::new();
         e.encode(ops, actors, props);

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -11,7 +11,10 @@ use std::{
     str,
 };
 
-use crate::types::{ActorId, ElemId, Key, ObjId, ObjType, Op, OpId, OpType, ScalarValue};
+use crate::{
+    types::{ActorId, ElemId, Key, ObjId, ObjType, Op, OpId, OpType, ScalarValue},
+    Change,
+};
 
 use crate::legacy as amp;
 use amp::SortedVec;
@@ -905,12 +908,12 @@ pub(crate) struct ChangeEncoder {
 
 impl ChangeEncoder {
     #[instrument(level = "debug", skip(changes, actors))]
-    pub fn encode_changes<'a, I>(
+    pub fn encode_changes<'a, 'b, I>(
         changes: I,
         actors: &'a IndexedCache<ActorId>,
     ) -> (Vec<u8>, Vec<u8>)
     where
-        I: IntoIterator<Item = amp::Change>,
+        I: IntoIterator<Item = &'b Change>,
     {
         let mut e = Self::new();
         e.encode(changes, actors);
@@ -931,23 +934,21 @@ impl ChangeEncoder {
         }
     }
 
-    fn encode<I>(&mut self, changes: I, actors: &IndexedCache<ActorId>)
+    fn encode<'a, I>(&mut self, changes: I, actors: &IndexedCache<ActorId>)
     where
-        I: IntoIterator<Item = amp::Change>,
+        I: IntoIterator<Item = &'a Change>,
     {
         let mut index_by_hash: HashMap<amp::ChangeHash, usize> = HashMap::new();
         for (index, change) in changes.into_iter().enumerate() {
-            if let Some(hash) = change.hash {
-                index_by_hash.insert(hash, index);
-            }
+            index_by_hash.insert(change.hash, index);
             self.actor
-                .append_value(actors.lookup(&change.actor_id).unwrap()); //actors.iter().position(|a| a == &change.actor_id).unwrap());
+                .append_value(actors.lookup(change.actor_id()).unwrap()); //actors.iter().position(|a| a == &change.actor_id).unwrap());
             self.seq.append_value(change.seq);
             // FIXME iterops.count is crazy slow
             self.max_op
-                .append_value(change.start_op + change.operations.len() as u64 - 1);
+                .append_value(change.start_op + change.iter_ops().count() as u64 - 1);
             self.time.append_value(change.time as u64);
-            self.message.append_value(change.message.clone());
+            self.message.append_value(change.message());
             self.deps_num.append_value(change.deps.len());
             for dep in &change.deps {
                 if let Some(dep_index) = index_by_hash.get(dep) {
@@ -961,8 +962,8 @@ impl ChangeEncoder {
                 }
             }
             self.extra_len
-                .append_value(change.extra_bytes.len() << 4 | VALUE_TYPE_BYTES);
-            self.extra_raw.extend(&change.extra_bytes);
+                .append_value(change.extra_bytes().len() << 4 | VALUE_TYPE_BYTES);
+            self.extra_raw.extend(change.extra_bytes());
         }
     }
 


### PR DESCRIPTION
On my machine this takes the save benchmark (saving the edit-trace) from 132ms to 74ms, a rough 44% saving.