### PR TITLE
Separate scalars and objects in transaction API

### DIFF
--- a/automerge-cli/src/import.rs
+++ b/automerge-cli/src/import.rs
@@ -31,7 +31,7 @@ fn import_map(
                 doc.set(obj, key, s.as_ref())?;
             }
             serde_json::Value::Array(vec) => {
-                let id = doc.set(obj, key, am::Value::list())?.unwrap();
+                let id = doc.set_object(obj, key, am::ObjType::List)?;
                 import_list(doc, &id, vec)?;
             }
             serde_json::Value::Number(n) => {
@@ -46,7 +46,7 @@ fn import_map(
                 }
             }
             serde_json::Value::Object(map) => {
-                let id = doc.set(obj, key, am::Value::map())?.unwrap();
+                let id = doc.set_object(obj, key, am::ObjType::Map)?;
                 import_map(doc, &id, map)?;
             }
         }
@@ -71,7 +71,7 @@ fn import_list(
                 doc.insert(obj, i, s.as_ref())?;
             }
             serde_json::Value::Array(vec) => {
-                let id = doc.insert(obj, i, am::Value::list())?.unwrap();
+                let id = doc.insert_object(obj, i, am::ObjType::List)?;
                 import_list(doc, &id, vec)?;
             }
             serde_json::Value::Number(n) => {
@@ -86,7 +86,7 @@ fn import_list(
                 }
             }
             serde_json::Value::Object(map) => {
-                let id = doc.insert(obj, i, am::Value::map())?.unwrap();
+                let id = doc.insert_object(obj, i, am::ObjType::Map)?;
                 import_map(doc, &id, map)?;
             }
         }

--- a/automerge-js/src/proxies.js
+++ b/automerge-js/src/proxies.js
@@ -134,21 +134,21 @@ const MapHandler = {
     }
     switch (datatype) {
       case "list":
-        const list = context.set(objectId, key, [])
+        const list = context.set_object(objectId, key, [])
         const proxyList = listProxy(context, list, [ ... path, key ], readonly );
         for (let i = 0; i < value.length; i++) {
           proxyList[i] = value[i]
         }
         break;
       case "text":
-        const text = context.set(objectId, key, "", "text")
+        const text = context.set_object(objectId, key, "", "text")
         const proxyText = textProxy(context, text, [ ... path, key ], readonly );
         for (let i = 0; i < value.length; i++) {
           proxyText[i] = value.get(i)
         }
         break;
       case "map":
-        const map = context.set(objectId, key, {})
+        const map = context.set_object(objectId, key, {})
         const proxyMap = mapProxy(context, map, [ ... path, key ], readonly );
         for (const key in value) {
           proxyMap[key] = value[key]
@@ -251,9 +251,9 @@ const ListHandler = {
       case "list":
         let list
         if (index >= context.length(objectId)) {
-          list = context.insert(objectId, index, [])
+          list = context.insert_object(objectId, index, [])
         } else {
-          list = context.set(objectId, index, [])
+          list = context.set_object(objectId, index, [])
         }
         const proxyList = listProxy(context, list, [ ... path, index ], readonly);
         proxyList.splice(0,0,...value)
@@ -261,9 +261,9 @@ const ListHandler = {
       case "text":
         let text
         if (index >= context.length(objectId)) {
-          text = context.insert(objectId, index, "", "text")
+          text = context.insert_object(objectId, index, "", "text")
         } else {
-          text = context.set(objectId, index, "", "text")
+          text = context.set_object(objectId, index, "", "text")
         }
         const proxyText = textProxy(context, text, [ ... path, index ], readonly);
         proxyText.splice(0,0,...value)
@@ -271,9 +271,9 @@ const ListHandler = {
       case "map":
         let map
         if (index >= context.length(objectId)) {
-          map = context.insert(objectId, index, {})
+          map = context.insert_object(objectId, index, {})
         } else {
-          map = context.set(objectId, index, {})
+          map = context.set_object(objectId, index, {})
         }
         const proxyMap = mapProxy(context, map, [ ... path, index ], readonly);
         for (const key in value) {
@@ -478,17 +478,17 @@ function listMethods(target) {
       for (let [value,datatype] of values) {
         switch (datatype) {
           case "list":
-            const list = context.insert(objectId, index, [])
+            const list = context.insert_object(objectId, index, [])
             const proxyList = listProxy(context, list, [ ... path, index ], readonly);
             proxyList.splice(0,0,...value)
             break;
           case "text":
-            const text = context.insert(objectId, index, "", "text")
+            const text = context.insert_object(objectId, index, "", "text")
             const proxyText = textProxy(context, text, [ ... path, index ], readonly);
             proxyText.splice(0,0,...value)
             break;
           case "map":
-            const map = context.insert(objectId, index, {})
+            const map = context.insert_object(objectId, index, {})
             const proxyMap = mapProxy(context, map, [ ... path, index ], readonly);
             for (const key in value) {
               proxyMap[key] = value[key]

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -167,8 +167,8 @@ impl Automerge {
         datatype: JsValue,
     ) -> Result<Option<String>, JsValue> {
         let obj = self.import(obj)?;
-        let (value, subvals) =
-            to_objtype(&value, &datatype.as_string()).ok_or(to_js_err("expected object"))?;
+        let (value, subvals) = to_objtype(&value, &datatype.as_string())
+            .ok_or_else(|| to_js_err("expected object"))?;
         let index = self.0.length(&obj);
         let opid = self.0.insert_object(&obj, index, value)?;
         self.subset(&opid, subvals)?;
@@ -186,7 +186,7 @@ impl Automerge {
         let index = index as f64;
         let value = self
             .import_scalar(&value, &datatype.as_string())
-            .ok_or(to_js_err("expected scalar value"))?;
+            .ok_or_else(|| to_js_err("expected scalar value"))?;
         self.0.insert(&obj, index as usize, value)?;
         Ok(())
     }
@@ -200,8 +200,8 @@ impl Automerge {
     ) -> Result<Option<String>, JsValue> {
         let obj = self.import(obj)?;
         let index = index as f64;
-        let (value, subvals) =
-            to_objtype(&value, &datatype.as_string()).ok_or(to_js_err("expected object"))?;
+        let (value, subvals) = to_objtype(&value, &datatype.as_string())
+            .ok_or_else(|| to_js_err("expected object"))?;
         let opid = self.0.insert_object(&obj, index as usize, value)?;
         self.subset(&opid, subvals)?;
         Ok(opid.to_string().into())
@@ -218,7 +218,7 @@ impl Automerge {
         let prop = self.import_prop(prop)?;
         let value = self
             .import_scalar(&value, &datatype.as_string())
-            .ok_or(to_js_err("expected scalar value"))?;
+            .ok_or_else(|| to_js_err("expected scalar value"))?;
         self.0.set(&obj, prop, value)?;
         Ok(())
     }
@@ -232,8 +232,8 @@ impl Automerge {
     ) -> Result<JsValue, JsValue> {
         let obj = self.import(obj)?;
         let prop = self.import_prop(prop)?;
-        let (value, subvals) =
-            to_objtype(&value, &datatype.as_string()).ok_or(to_js_err("expected object"))?;
+        let (value, subvals) = to_objtype(&value, &datatype.as_string())
+            .ok_or_else(|| to_js_err("expected object"))?;
         let opid = self.0.set_object(&obj, prop, value)?;
         self.subset(&opid, subvals)?;
         Ok(opid.to_string().into())

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -129,49 +129,50 @@ impl Automerge {
         start: f64,
         delete_count: f64,
         text: JsValue,
-    ) -> Result<Option<Array>, JsValue> {
+    ) -> Result<(), JsValue> {
         let obj = self.import(obj)?;
         let start = start as usize;
         let delete_count = delete_count as usize;
         let mut vals = vec![];
         if let Some(t) = text.as_string() {
             self.0.splice_text(&obj, start, delete_count, &t)?;
-            Ok(None)
         } else {
             if let Ok(array) = text.dyn_into::<Array>() {
                 for i in array.iter() {
-                    let (value, subvals) = self.import_value(&i, None)?;
-                    if !subvals.is_empty() {
-                        return Err(to_js_err("splice must be shallow"));
-                    }
+                    let value = self
+                        .import_scalar(&i, &None)
+                        .ok_or_else(|| to_js_err("expected scalar"))?;
                     vals.push(value);
                 }
             }
-            let result = self.0.splice(&obj, start, delete_count, vals)?;
-            if result.is_empty() {
-                Ok(None)
-            } else {
-                let result: Array = result
-                    .iter()
-                    .map(|r| JsValue::from(r.to_string()))
-                    .collect();
-                Ok(result.into())
-            }
+            self.0.splice(&obj, start, delete_count, vals)?;
         }
+        Ok(())
     }
 
-    pub fn push(
+    pub fn push(&mut self, obj: JsValue, value: JsValue, datatype: JsValue) -> Result<(), JsValue> {
+        let obj = self.import(obj)?;
+        let value = self
+            .import_scalar(&value, &datatype.as_string())
+            .ok_or_else(|| to_js_err("invalid scalar value"))?;
+        let index = self.0.length(&obj);
+        self.0.insert(&obj, index, value)?;
+        Ok(())
+    }
+
+    pub fn push_object(
         &mut self,
         obj: JsValue,
         value: JsValue,
         datatype: JsValue,
     ) -> Result<Option<String>, JsValue> {
         let obj = self.import(obj)?;
-        let (value, subvals) = self.import_value(&value, datatype.as_string())?;
+        let (value, subvals) =
+            to_objtype(&value, &datatype.as_string()).ok_or(to_js_err("expected object"))?;
         let index = self.0.length(&obj);
-        let opid = self.0.insert(&obj, index, value)?;
+        let opid = self.0.insert_object(&obj, index, value)?;
         self.subset(&opid, subvals)?;
-        Ok(opid.map(|id| id.to_string()))
+        Ok(opid.to_string().into())
     }
 
     pub fn insert(
@@ -180,13 +181,30 @@ impl Automerge {
         index: f64,
         value: JsValue,
         datatype: JsValue,
+    ) -> Result<(), JsValue> {
+        let obj = self.import(obj)?;
+        let index = index as f64;
+        let value = self
+            .import_scalar(&value, &datatype.as_string())
+            .ok_or(to_js_err("expected scalar value"))?;
+        self.0.insert(&obj, index as usize, value)?;
+        Ok(())
+    }
+
+    pub fn insert_object(
+        &mut self,
+        obj: JsValue,
+        index: f64,
+        value: JsValue,
+        datatype: JsValue,
     ) -> Result<Option<String>, JsValue> {
         let obj = self.import(obj)?;
         let index = index as f64;
-        let (value, subvals) = self.import_value(&value, datatype.as_string())?;
-        let opid = self.0.insert(&obj, index as usize, value)?;
+        let (value, subvals) =
+            to_objtype(&value, &datatype.as_string()).ok_or(to_js_err("expected object"))?;
+        let opid = self.0.insert_object(&obj, index as usize, value)?;
         self.subset(&opid, subvals)?;
-        Ok(opid.map(|id| id.to_string()))
+        Ok(opid.to_string().into())
     }
 
     pub fn set(
@@ -195,44 +213,55 @@ impl Automerge {
         prop: JsValue,
         value: JsValue,
         datatype: JsValue,
+    ) -> Result<(), JsValue> {
+        let obj = self.import(obj)?;
+        let prop = self.import_prop(prop)?;
+        let value = self
+            .import_scalar(&value, &datatype.as_string())
+            .ok_or(to_js_err("expected scalar value"))?;
+        self.0.set(&obj, prop, value)?;
+        Ok(())
+    }
+
+    pub fn set_object(
+        &mut self,
+        obj: JsValue,
+        prop: JsValue,
+        value: JsValue,
+        datatype: JsValue,
     ) -> Result<JsValue, JsValue> {
         let obj = self.import(obj)?;
         let prop = self.import_prop(prop)?;
-        let (value, subvals) = self.import_value(&value, datatype.as_string())?;
-        let opid = self.0.set(&obj, prop, value)?;
+        let (value, subvals) =
+            to_objtype(&value, &datatype.as_string()).ok_or(to_js_err("expected object"))?;
+        let opid = self.0.set_object(&obj, prop, value)?;
         self.subset(&opid, subvals)?;
-        Ok(opid.map(|id| id.to_string()).into())
+        Ok(opid.to_string().into())
     }
 
-    fn subset(
-        &mut self,
-        obj: &Option<am::ObjId>,
-        vals: Vec<(am::Prop, JsValue)>,
-    ) -> Result<(), JsValue> {
-        if let Some(id) = obj {
-            for (p, v) in vals {
-                let (value, subvals) = self.import_value(&v, None)?;
-                //let opid = self.0.set(id, p, value)?;
-                let opid = match p {
-                    Prop::Map(s) => self.0.set(id, s, value)?,
-                    Prop::Seq(i) => self.0.insert(id, i, value)?,
-                };
+    fn subset(&mut self, obj: &am::ObjId, vals: Vec<(am::Prop, JsValue)>) -> Result<(), JsValue> {
+        for (p, v) in vals {
+            let (value, subvals) = self.import_value(&v, None)?;
+            //let opid = self.0.set(id, p, value)?;
+            let opid = match (p, value) {
+                (Prop::Map(s), Value::Object(objtype)) => Some(self.0.set_object(obj, s, objtype)?),
+                (Prop::Map(s), Value::Scalar(scalar)) => {
+                    self.0.set(obj, s, scalar)?;
+                    None
+                }
+                (Prop::Seq(i), Value::Object(objtype)) => {
+                    Some(self.0.insert_object(obj, i, objtype)?)
+                }
+                (Prop::Seq(i), Value::Scalar(scalar)) => {
+                    self.0.insert(obj, i, scalar)?;
+                    None
+                }
+            };
+            if let Some(opid) = opid {
                 self.subset(&opid, subvals)?;
             }
         }
         Ok(())
-    }
-
-    pub fn make(&mut self, obj: JsValue, prop: JsValue, value: JsValue) -> Result<String, JsValue> {
-        let obj = self.import(obj)?;
-        let prop = self.import_prop(prop)?;
-        if let Some((value, subvals)) = to_objtype(&value, &None) {
-            let opid = self.0.set(&obj, prop, value)?;
-            self.subset(&opid, subvals)?;
-            Ok(opid.unwrap().to_string())
-        } else {
-            Err(to_js_err("invalid object type"))
-        }
     }
 
     pub fn inc(&mut self, obj: JsValue, prop: JsValue, value: JsValue) -> Result<(), JsValue> {

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -1,7 +1,8 @@
 use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
+use automerge::AutomergeError;
+use automerge::ObjType;
 use automerge::{Automerge, ROOT};
-use automerge::{AutomergeError, Value};
 
 // Based on https://automerge.github.io/docs/quickstart
 fn main() {
@@ -12,9 +13,11 @@ fn main() {
             |tx| {
                 let cards = tx.set(ROOT, "cards", Value::list()).unwrap().unwrap();
                 let card1 = tx.insert(&cards, 0, Value::map())?.unwrap();
+                let cards = tx.make(ROOT, "cards", ObjType::List).unwrap();
+                let card1 = tx.make_insert(&cards, 0, ObjType::Map)?;
                 tx.set(&card1, "title", "Rewrite everything in Clojure")?;
                 tx.set(&card1, "done", false)?;
-                let card2 = tx.insert(&cards, 0, Value::map())?.unwrap();
+                let card2 = tx.make_insert(&cards, 0, ObjType::Map)?;
                 tx.set(&card2, "title", "Rewrite everything in Haskell")?;
                 tx.set(&card2, "done", false)?;
                 Ok((cards, card1))

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -11,13 +11,11 @@ fn main() {
         .transact_with::<_, _, AutomergeError, _>(
             || CommitOptions::default().with_message("Add card".to_owned()),
             |tx| {
-                let cards = tx.set(ROOT, "cards", Value::list()).unwrap().unwrap();
-                let card1 = tx.insert(&cards, 0, Value::map())?.unwrap();
-                let cards = tx.make(ROOT, "cards", ObjType::List).unwrap();
-                let card1 = tx.make_insert(&cards, 0, ObjType::Map)?;
+                let cards = tx.set_object(ROOT, "cards", ObjType::List).unwrap();
+                let card1 = tx.insert_object(&cards, 0, ObjType::Map)?;
                 tx.set(&card1, "title", "Rewrite everything in Clojure")?;
                 tx.set(&card1, "done", false)?;
-                let card2 = tx.make_insert(&cards, 0, ObjType::Map)?;
+                let card2 = tx.insert_object(&cards, 0, ObjType::Map)?;
                 tx.set(&card2, "title", "Rewrite everything in Haskell")?;
                 tx.set(&card2, "done", false)?;
                 Ok((cards, card1))

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -248,12 +248,12 @@ impl AutoCommit {
     /// ```
     /// # use automerge::transaction::CommitOptions;
     /// # use automerge::transaction::Transactable;
-    /// # use automerge::Value;
     /// # use automerge::ROOT;
     /// # use automerge::AutoCommit;
+    /// # use automerge::ObjType;
     /// # use std::time::SystemTime;
     /// let mut doc = AutoCommit::new();
-    /// doc.set(ROOT, "todos", Value::list()).unwrap();
+    /// doc.make(ROOT, "todos", ObjType::List).unwrap();
     /// let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as
     /// i64;
     /// doc.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -253,7 +253,7 @@ impl AutoCommit {
     /// # use automerge::ObjType;
     /// # use std::time::SystemTime;
     /// let mut doc = AutoCommit::new();
-    /// doc.make(ROOT, "todos", ObjType::List).unwrap();
+    /// doc.set_object(&ROOT, "todos", ObjType::List).unwrap();
     /// let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as
     /// i64;
     /// doc.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
@@ -332,7 +332,7 @@ impl Transactable for AutoCommit {
         tx.set(&mut self.doc, obj.as_ref(), prop, value)
     }
 
-    fn make<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+    fn set_object<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
         &mut self,
         obj: O,
         prop: P,
@@ -340,7 +340,7 @@ impl Transactable for AutoCommit {
     ) -> Result<ExId, AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
-        tx.make(&mut self.doc, obj.as_ref(), prop, value)
+        tx.set_object(&mut self.doc, obj.as_ref(), prop, value)
     }
 
     fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
@@ -354,7 +354,7 @@ impl Transactable for AutoCommit {
         tx.insert(&mut self.doc, obj.as_ref(), index, value)
     }
 
-    fn make_insert<V: Into<ObjType>>(
+    fn insert_object<V: Into<ObjType>>(
         &mut self,
         obj: &ExId,
         index: usize,
@@ -362,7 +362,7 @@ impl Transactable for AutoCommit {
     ) -> Result<ExId, AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
-        tx.make_insert(&mut self.doc, obj, index, value)
+        tx.insert_object(&mut self.doc, obj, index, value)
     }
 
     fn inc<O: AsRef<ExId>, P: Into<Prop>>(

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -5,7 +5,7 @@ use crate::{
     change::export_change, transaction::TransactionInner, ActorId, Automerge, AutomergeError,
     Change, ChangeHash, Prop, Value,
 };
-use crate::{Keys, KeysAt, SyncMessage, SyncState};
+use crate::{Keys, KeysAt, ObjType, ScalarValue, SyncMessage, SyncState};
 
 /// An automerge document that automatically manages transactions.
 #[derive(Debug, Clone)]
@@ -321,15 +321,26 @@ impl Transactable for AutoCommit {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<Value>>(
+    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         prop: P,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
         tx.set(&mut self.doc, obj.as_ref(), prop, value)
+    }
+
+    fn make<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+        &mut self,
+        obj: O,
+        prop: P,
+        value: V,
+    ) -> Result<ExId, AutomergeError> {
+        self.ensure_transaction_open();
+        let tx = self.transaction.as_mut().unwrap();
+        tx.make(&mut self.doc, obj.as_ref(), prop, value)
     }
 
     fn insert<O: AsRef<ExId>, V: Into<Value>>(

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -332,11 +332,11 @@ impl Transactable for AutoCommit {
         tx.set(&mut self.doc, obj.as_ref(), prop, value)
     }
 
-    fn set_object<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+    fn set_object<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
-        value: V,
+        value: ObjType,
     ) -> Result<ExId, AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
@@ -354,11 +354,11 @@ impl Transactable for AutoCommit {
         tx.insert(&mut self.doc, obj.as_ref(), index, value)
     }
 
-    fn insert_object<V: Into<ObjType>>(
+    fn insert_object(
         &mut self,
         obj: &ExId,
         index: usize,
-        value: V,
+        value: ObjType,
     ) -> Result<ExId, AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -393,8 +393,8 @@ impl Transactable for AutoCommit {
         obj: O,
         pos: usize,
         del: usize,
-        vals: Vec<Value>,
-    ) -> Result<Vec<ExId>, AutomergeError> {
+        vals: Vec<ScalarValue>,
+    ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
         tx.splice(&mut self.doc, obj.as_ref(), pos, del, vals)

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -343,15 +343,26 @@ impl Transactable for AutoCommit {
         tx.make(&mut self.doc, obj.as_ref(), prop, value)
     }
 
-    fn insert<O: AsRef<ExId>, V: Into<Value>>(
+    fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         index: usize,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
         tx.insert(&mut self.doc, obj.as_ref(), index, value)
+    }
+
+    fn make_insert<V: Into<ObjType>>(
+        &mut self,
+        obj: &ExId,
+        index: usize,
+        value: V,
+    ) -> Result<ExId, AutomergeError> {
+        self.ensure_transaction_open();
+        let tx = self.transaction.as_mut().unwrap();
+        tx.make_insert(&mut self.doc, obj, index, value)
     }
 
     fn inc<O: AsRef<ExId>, P: Into<Prop>>(

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1221,10 +1221,10 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
         // create a map
-        let map1 = tx.set(&ROOT, "a", Value::map()).unwrap().unwrap();
+        let map1 = tx.set_object(ROOT, "a", ObjType::Map).unwrap();
         tx.set(&map1, "b", 1).unwrap();
         // overwrite the first map with a new one
-        let map2 = tx.set(&ROOT, "a", Value::map()).unwrap().unwrap();
+        let map2 = tx.set_object(ROOT, "a", ObjType::Map).unwrap();
         tx.set(&map2, "c", 2).unwrap();
         tx.commit();
 

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -885,11 +885,11 @@ mod tests {
 
         assert_eq!(tx.pending_ops(), 1);
 
-        let map = tx.make(ROOT, "b", ObjType::Map)?;
+        let map = tx.set_object(ROOT, "b", ObjType::Map)?;
         // object already exists at b but setting a map again overwrites it so we get an opid.
         tx.set(map, "a", 2)?;
 
-        tx.make(ROOT, "b", ObjType::Map)?;
+        tx.set_object(ROOT, "b", ObjType::Map)?;
 
         assert_eq!(tx.pending_ops(), 4);
         let map = tx.value(ROOT, "b").unwrap().unwrap().1;
@@ -904,7 +904,7 @@ mod tests {
         let mut doc = Automerge::new();
         doc.set_actor(ActorId::random());
         let mut tx = doc.transaction();
-        let list_id = tx.make(ROOT, "items", ObjType::List)?;
+        let list_id = tx.set_object(ROOT, "items", ObjType::List)?;
         tx.set(ROOT, "zzz", "zzzval")?;
         assert!(tx.value(ROOT, "items")?.unwrap().1 == list_id);
         tx.insert(&list_id, 0, "a")?;
@@ -995,7 +995,7 @@ mod tests {
     fn test_save_text() -> Result<(), AutomergeError> {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        let text = tx.make(ROOT, "text", ObjType::Text)?;
+        let text = tx.set_object(ROOT, "text", ObjType::Text)?;
         tx.commit();
         let heads1 = doc.get_heads();
         let mut tx = doc.transaction();
@@ -1095,7 +1095,7 @@ mod tests {
         doc.set_actor("aaaa".try_into().unwrap());
 
         let mut tx = doc.transaction();
-        let list = tx.make(ROOT, "list", ObjType::List)?;
+        let list = tx.set_object(ROOT, "list", ObjType::List)?;
         tx.commit();
         let heads1 = doc.get_heads();
 

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -138,19 +138,30 @@ impl TransactionInner {
         self.operations.push(op);
     }
 
-    pub fn insert<V: Into<Value>>(
+    pub fn insert<V: Into<ScalarValue>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
         index: usize,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         let obj = doc.exid_to_obj(obj)?;
-        if let Some(id) = self.do_insert(doc, obj, index, value)? {
-            Ok(Some(doc.id_to_exid(id)))
-        } else {
-            Ok(None)
-        }
+        self.do_insert(doc, obj, index, Value::Scalar(value.into()))?;
+        Ok(())
+    }
+
+    pub fn make_insert<V: Into<ObjType>>(
+        &mut self,
+        doc: &mut Automerge,
+        obj: &ExId,
+        index: usize,
+        value: V,
+    ) -> Result<ExId, AutomergeError> {
+        let obj = doc.exid_to_obj(obj)?;
+        let id = self
+            .do_insert(doc, obj, index, Value::Object(value.into()))?
+            .unwrap();
+        Ok(doc.id_to_exid(id))
     }
 
     fn do_insert<V: Into<Value>>(

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -358,7 +358,7 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
 
-        let a = tx.set(ROOT, "a", Value::map()).unwrap().unwrap();
+        let a = tx.make(ROOT, "a", ObjType::Map).unwrap();
         tx.set(&a, "b", 1).unwrap();
         assert!(tx.value(&a, "b").unwrap().is_some());
     }

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -327,23 +327,19 @@ impl TransactionInner {
         obj: &ExId,
         mut pos: usize,
         del: usize,
-        vals: Vec<Value>,
-    ) -> Result<Vec<ExId>, AutomergeError> {
+        vals: Vec<ScalarValue>,
+    ) -> Result<(), AutomergeError> {
         let obj = doc.exid_to_obj(obj)?;
         for _ in 0..del {
             // del()
             self.local_op(doc, obj, pos.into(), OpType::Del)?;
         }
-        let mut results = Vec::new();
         for v in vals {
             // insert()
-            let id = self.do_insert(doc, obj, pos, v)?;
-            if let Some(id) = id {
-                results.push(doc.id_to_exid(id));
-            }
+            self.do_insert(doc, obj, pos, v)?;
             pos += 1;
         }
-        Ok(results)
+        Ok(())
     }
 }
 

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -107,7 +107,7 @@ impl TransactionInner {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    pub fn make<P: Into<Prop>, V: Into<ObjType>>(
+    pub fn set_object<P: Into<Prop>, V: Into<ObjType>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
@@ -150,7 +150,7 @@ impl TransactionInner {
         Ok(())
     }
 
-    pub fn make_insert<V: Into<ObjType>>(
+    pub fn insert_object<V: Into<ObjType>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
@@ -358,7 +358,7 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
 
-        let a = tx.make(ROOT, "a", ObjType::Map).unwrap();
+        let a = tx.set_object(ROOT, "a", ObjType::Map).unwrap();
         tx.set(&a, "b", 1).unwrap();
         assert!(tx.value(&a, "b").unwrap().is_some());
     }

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -109,16 +109,28 @@ impl<'a> Transactable for Transaction<'a> {
             .make(self.doc, obj.as_ref(), prop, value)
     }
 
-    fn insert<O: AsRef<ExId>, V: Into<Value>>(
+    fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         index: usize,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         self.inner
             .as_mut()
             .unwrap()
             .insert(self.doc, obj.as_ref(), index, value)
+    }
+
+    fn make_insert<V: Into<ObjType>>(
+        &mut self,
+        obj: &ExId,
+        index: usize,
+        value: V,
+    ) -> Result<ExId, AutomergeError> {
+        self.inner
+            .as_mut()
+            .unwrap()
+            .make_insert(self.doc, obj, index, value)
     }
 
     fn inc<O: AsRef<ExId>, P: Into<Prop>>(

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -163,8 +163,8 @@ impl<'a> Transactable for Transaction<'a> {
         obj: O,
         pos: usize,
         del: usize,
-        vals: Vec<Value>,
-    ) -> Result<Vec<ExId>, AutomergeError> {
+        vals: Vec<ScalarValue>,
+    ) -> Result<(), AutomergeError> {
         self.inner
             .as_mut()
             .unwrap()

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -97,11 +97,11 @@ impl<'a> Transactable for Transaction<'a> {
             .set(self.doc, obj.as_ref(), prop, value)
     }
 
-    fn set_object<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+    fn set_object<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
-        value: V,
+        value: ObjType,
     ) -> Result<ExId, AutomergeError> {
         self.inner
             .as_mut()
@@ -121,11 +121,11 @@ impl<'a> Transactable for Transaction<'a> {
             .insert(self.doc, obj.as_ref(), index, value)
     }
 
-    fn insert_object<V: Into<ObjType>>(
+    fn insert_object(
         &mut self,
         obj: &ExId,
         index: usize,
-        value: V,
+        value: ObjType,
     ) -> Result<ExId, AutomergeError> {
         self.inner
             .as_mut()

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -47,7 +47,7 @@ impl<'a> Transaction<'a> {
     /// # use std::time::SystemTime;
     /// let mut doc = Automerge::new();
     /// let mut tx = doc.transaction();
-    /// tx.make(ROOT, "todos", ObjType::List).unwrap();
+    /// tx.set_object(ROOT, "todos", ObjType::List).unwrap();
     /// let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as
     /// i64;
     /// tx.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
@@ -97,7 +97,7 @@ impl<'a> Transactable for Transaction<'a> {
             .set(self.doc, obj.as_ref(), prop, value)
     }
 
-    fn make<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+    fn set_object<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
         &mut self,
         obj: O,
         prop: P,
@@ -106,7 +106,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.inner
             .as_mut()
             .unwrap()
-            .make(self.doc, obj.as_ref(), prop, value)
+            .set_object(self.doc, obj.as_ref(), prop, value)
     }
 
     fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
@@ -121,7 +121,7 @@ impl<'a> Transactable for Transaction<'a> {
             .insert(self.doc, obj.as_ref(), index, value)
     }
 
-    fn make_insert<V: Into<ObjType>>(
+    fn insert_object<V: Into<ObjType>>(
         &mut self,
         obj: &ExId,
         index: usize,
@@ -130,7 +130,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.inner
             .as_mut()
             .unwrap()
-            .make_insert(self.doc, obj, index, value)
+            .insert_object(self.doc, obj, index, value)
     }
 
     fn inc<O: AsRef<ExId>, P: Into<Prop>>(

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -41,13 +41,13 @@ impl<'a> Transaction<'a> {
     /// ```
     /// # use automerge::transaction::CommitOptions;
     /// # use automerge::transaction::Transactable;
-    /// # use automerge::Value;
     /// # use automerge::ROOT;
     /// # use automerge::Automerge;
+    /// # use automerge::ObjType;
     /// # use std::time::SystemTime;
     /// let mut doc = Automerge::new();
     /// let mut tx = doc.transaction();
-    /// tx.set(ROOT, "todos", Value::list()).unwrap();
+    /// tx.make(ROOT, "todos", ObjType::List).unwrap();
     /// let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as
     /// i64;
     /// tx.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -1,5 +1,5 @@
 use crate::exid::ExId;
-use crate::{Automerge, ChangeHash, KeysAt, Prop, Value};
+use crate::{Automerge, ChangeHash, KeysAt, ObjType, Prop, ScalarValue, Value};
 use crate::{AutomergeError, Keys};
 
 use super::{CommitOptions, Transactable, TransactionInner};
@@ -85,16 +85,28 @@ impl<'a> Transactable for Transaction<'a> {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<Value>>(
+    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         prop: P,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         self.inner
             .as_mut()
             .unwrap()
             .set(self.doc, obj.as_ref(), prop, value)
+    }
+
+    fn make<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+        &mut self,
+        obj: O,
+        prop: P,
+        value: V,
+    ) -> Result<ExId, AutomergeError> {
+        self.inner
+            .as_mut()
+            .unwrap()
+            .make(self.doc, obj.as_ref(), prop, value)
     }
 
     fn insert<O: AsRef<ExId>, V: Into<Value>>(

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -48,12 +48,20 @@ pub trait Transactable {
     ) -> Result<ExId, AutomergeError>;
 
     /// Insert a value into a list at the given index.
-    fn insert<O: AsRef<ExId>, V: Into<Value>>(
+    fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         index: usize,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError>;
+    ) -> Result<(), AutomergeError>;
+
+    /// Insert a value into a list at the given index.
+    fn make_insert<V: Into<ObjType>>(
+        &mut self,
+        obj: &ExId,
+        index: usize,
+        value: V,
+    ) -> Result<ExId, AutomergeError>;
 
     /// Increment the counter at the prop in the object by `value`.
     fn inc<O: AsRef<ExId>, P: Into<Prop>>(

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -1,5 +1,5 @@
 use crate::exid::ExId;
-use crate::{AutomergeError, ChangeHash, Keys, KeysAt, Prop, Value};
+use crate::{AutomergeError, ChangeHash, Keys, KeysAt, ObjType, Prop, ScalarValue, Value};
 use unicode_segmentation::UnicodeSegmentation;
 
 /// A way of mutating a document within a single change.
@@ -20,12 +20,32 @@ pub trait Transactable {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<Value>>(
+    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         prop: P,
         value: V,
-    ) -> Result<Option<ExId>, AutomergeError>;
+    ) -> Result<(), AutomergeError>;
+
+    /// Set the value of property `P` to value `V` in object `obj`.
+    ///
+    /// # Returns
+    ///
+    /// The opid of the operation which was created, or None if this operation doesn't change the
+    /// document
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if
+    /// - The object does not exist
+    /// - The key is the wrong type for the object
+    /// - The key does not exist in the object
+    fn make<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+        &mut self,
+        obj: O,
+        prop: P,
+        value: V,
+    ) -> Result<ExId, AutomergeError>;
 
     /// Insert a value into a list at the given index.
     fn insert<O: AsRef<ExId>, V: Into<Value>>(

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -54,7 +54,7 @@ pub trait Transactable {
         &mut self,
         obj: &ExId,
         index: usize,
-        value: V,
+        object: V,
     ) -> Result<ExId, AutomergeError>;
 
     /// Increment the counter at the prop in the object by `value`.

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -40,7 +40,7 @@ pub trait Transactable {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn make<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+    fn set_object<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
         &mut self,
         obj: O,
         prop: P,
@@ -56,7 +56,7 @@ pub trait Transactable {
     ) -> Result<(), AutomergeError>;
 
     /// Insert a value into a list at the given index.
-    fn make_insert<V: Into<ObjType>>(
+    fn insert_object<V: Into<ObjType>>(
         &mut self,
         obj: &ExId,
         index: usize,

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -9,11 +9,6 @@ pub trait Transactable {
 
     /// Set the value of property `P` to value `V` in object `obj`.
     ///
-    /// # Returns
-    ///
-    /// The opid of the operation which was created, or None if this operation doesn't change the
-    /// document
-    ///
     /// # Errors
     ///
     /// This will return an error if
@@ -27,12 +22,11 @@ pub trait Transactable {
         value: V,
     ) -> Result<(), AutomergeError>;
 
-    /// Set the value of property `P` to value `V` in object `obj`.
+    /// Set the value of property `P` to the new object `V` in object `obj`.
     ///
     /// # Returns
     ///
-    /// The opid of the operation which was created, or None if this operation doesn't change the
-    /// document
+    /// The id of the object which was created.
     ///
     /// # Errors
     ///
@@ -44,7 +38,7 @@ pub trait Transactable {
         &mut self,
         obj: O,
         prop: P,
-        value: V,
+        object: V,
     ) -> Result<ExId, AutomergeError>;
 
     /// Insert a value into a list at the given index.
@@ -55,7 +49,7 @@ pub trait Transactable {
         value: V,
     ) -> Result<(), AutomergeError>;
 
-    /// Insert a value into a list at the given index.
+    /// Insert an object into a list at the given index.
     fn insert_object<V: Into<ObjType>>(
         &mut self,
         obj: &ExId,
@@ -75,15 +69,13 @@ pub trait Transactable {
     fn del<O: AsRef<ExId>, P: Into<Prop>>(&mut self, obj: O, prop: P)
         -> Result<(), AutomergeError>;
 
-    /// Splice new elements into the given sequence. Returns a vector of the OpIds used to insert
-    /// the new elements.
     fn splice<O: AsRef<ExId>>(
         &mut self,
         obj: O,
         pos: usize,
         del: usize,
-        vals: Vec<Value>,
-    ) -> Result<Vec<ExId>, AutomergeError>;
+        vals: Vec<ScalarValue>,
+    ) -> Result<(), AutomergeError>;
 
     /// Like [`Self::splice`] but for text.
     fn splice_text<O: AsRef<ExId>>(
@@ -92,7 +84,7 @@ pub trait Transactable {
         pos: usize,
         del: usize,
         text: &str,
-    ) -> Result<Vec<ExId>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         let mut vals = vec![];
         for c in text.to_owned().graphemes(true) {
             vals.push(c.into());

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -34,11 +34,11 @@ pub trait Transactable {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set_object<O: AsRef<ExId>, P: Into<Prop>, V: Into<ObjType>>(
+    fn set_object<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
-        object: V,
+        object: ObjType,
     ) -> Result<ExId, AutomergeError>;
 
     /// Insert a value into a list at the given index.
@@ -50,11 +50,11 @@ pub trait Transactable {
     ) -> Result<(), AutomergeError>;
 
     /// Insert an object into a list at the given index.
-    fn insert_object<V: Into<ObjType>>(
+    fn insert_object(
         &mut self,
         obj: &ExId,
         index: usize,
-        object: V,
+        object: ObjType,
     ) -> Result<ExId, AutomergeError>;
 
     /// Increment the counter at the prop in the object by `value`.

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -160,6 +160,18 @@ pub enum OpType {
     Set(ScalarValue),
 }
 
+impl From<ObjType> for OpType {
+    fn from(v: ObjType) -> Self {
+        OpType::Make(v)
+    }
+}
+
+impl From<ScalarValue> for OpType {
+    fn from(v: ScalarValue) -> Self {
+        OpType::Set(v)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum Export {
     Id(OpId),

--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -447,6 +447,12 @@ impl From<bool> for ScalarValue {
     }
 }
 
+impl From<()> for ScalarValue {
+    fn from(_: ()) -> Self {
+        ScalarValue::Null
+    }
+}
+
 impl From<char> for ScalarValue {
     fn from(c: char) -> Self {
         ScalarValue::Str(SmolStr::new(c.to_string()))

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -297,16 +297,10 @@ fn concurrently_assigned_nested_maps_should_not_merge() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    let doc1_map_id = doc1
-        .set(&automerge::ROOT, "config", automerge::Value::map())
-        .unwrap()
-        .unwrap();
+    let doc1_map_id = doc1.make(&automerge::ROOT, "config", ObjType::Map).unwrap();
     doc1.set(&doc1_map_id, "background", "blue").unwrap();
 
-    let doc2_map_id = doc2
-        .set(&automerge::ROOT, "config", automerge::Value::map())
-        .unwrap()
-        .unwrap();
+    let doc2_map_id = doc2.make(&automerge::ROOT, "config", ObjType::Map).unwrap();
     doc2.set(&doc2_map_id, "logo_url", "logo.png").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
@@ -333,10 +327,7 @@ fn concurrent_insertions_at_different_list_positions() {
     let mut doc2 = new_doc_with_actor(actor2);
     assert!(doc1.get_actor() < doc2.get_actor());
 
-    let list_id = doc1
-        .set(&automerge::ROOT, "list", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list_id = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
 
     doc1.insert(&list_id, 0, "one").unwrap();
     doc1.insert(&list_id, 1, "three").unwrap();
@@ -368,10 +359,7 @@ fn concurrent_insertions_at_same_list_position() {
     let mut doc2 = new_doc_with_actor(actor2);
     assert!(doc1.get_actor() < doc2.get_actor());
 
-    let list_id = doc1
-        .set(&automerge::ROOT, "birds", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
     doc1.insert(&list_id, 0, "parakeet").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
@@ -424,10 +412,7 @@ fn concurrent_assignment_and_deletion_of_a_map_entry() {
 fn concurrent_assignment_and_deletion_of_list_entry() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1
-        .set(&automerge::ROOT, "birds", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
     doc1.insert(&list_id, 0, "blackbird").unwrap();
     doc1.insert(&list_id, 1, "thrush").unwrap();
     doc1.insert(&list_id, 2, "goldfinch").unwrap();
@@ -474,10 +459,7 @@ fn concurrent_assignment_and_deletion_of_list_entry() {
 fn insertion_after_a_deleted_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1
-        .set(&automerge::ROOT, "birds", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
 
     doc1.insert(&list_id, 0, "blackbird").unwrap();
     doc1.insert(&list_id, 1, "thrush").unwrap();
@@ -518,10 +500,7 @@ fn insertion_after_a_deleted_list_element() {
 fn concurrent_deletion_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1
-        .set(&automerge::ROOT, "birds", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
 
     doc1.insert(&list_id, 0, "albatross").unwrap();
     doc1.insert(&list_id, 1, "buzzard").unwrap();
@@ -563,20 +542,13 @@ fn concurrent_updates_at_different_levels() {
     let mut doc2 = new_doc();
 
     let animals = doc1
-        .set(&automerge::ROOT, "animals", automerge::Value::map())
-        .unwrap()
+        .make(&automerge::ROOT, "animals", ObjType::Map)
         .unwrap();
-    let birds = doc1
-        .set(&animals, "birds", automerge::Value::map())
-        .unwrap()
-        .unwrap();
+    let birds = doc1.make(&animals, "birds", ObjType::Map).unwrap();
     doc1.set(&birds, "pink", "flamingo").unwrap();
     doc1.set(&birds, "black", "starling").unwrap();
 
-    let mammals = doc1
-        .set(&animals, "mammals", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let mammals = doc1.make(&animals, "mammals", ObjType::List).unwrap();
     doc1.insert(&mammals, 0, "badger").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
@@ -614,14 +586,8 @@ fn concurrent_updates_of_concurrently_deleted_objects() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    let birds = doc1
-        .set(&automerge::ROOT, "birds", automerge::Value::map())
-        .unwrap()
-        .unwrap();
-    let blackbird = doc1
-        .set(&birds, "blackbird", automerge::Value::map())
-        .unwrap()
-        .unwrap();
+    let birds = doc1.make(&automerge::ROOT, "birds", ObjType::Map).unwrap();
+    let blackbird = doc1.make(&birds, "blackbird", ObjType::Map).unwrap();
     doc1.set(&blackbird, "feathers", "black").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
@@ -649,8 +615,7 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
     let mut doc2 = new_doc_with_actor(actor2);
 
     let wisdom = doc1
-        .set(&automerge::ROOT, "wisdom", automerge::Value::list())
-        .unwrap()
+        .make(&automerge::ROOT, "wisdom", ObjType::List)
         .unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -710,10 +675,7 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_greater_actor_id(
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
 
-    let list = doc1
-        .set(&automerge::ROOT, "list", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
     doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -736,10 +698,7 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_lesser_actor_id()
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
 
-    let list = doc1
-        .set(&automerge::ROOT, "list", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
     doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -760,10 +719,7 @@ fn insertion_consistent_with_causality() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    let list = doc1
-        .set(&automerge::ROOT, "list", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let list = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
     doc1.insert(&list, 0, "four").unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc2.insert(&list, 0, "three").unwrap();
@@ -796,15 +752,9 @@ fn save_and_restore_empty() {
 #[test]
 fn save_restore_complex() {
     let mut doc1 = new_doc();
-    let todos = doc1
-        .set(&automerge::ROOT, "todos", automerge::Value::list())
-        .unwrap()
-        .unwrap();
+    let todos = doc1.make(&automerge::ROOT, "todos", ObjType::List).unwrap();
 
-    let first_todo = doc1
-        .insert(&todos, 0, automerge::Value::map())
-        .unwrap()
-        .unwrap();
+    let first_todo = doc1.make_insert(&todos, 0, ObjType::Map).unwrap();
     doc1.set(&first_todo, "title", "water plants").unwrap();
     doc1.set(&first_todo, "done", false).unwrap();
 

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -44,7 +44,9 @@ fn repeated_map_assignment_which_resolves_conflict_not_ignored() {
 fn repeated_list_assignment_which_resolves_conflict_not_ignored() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
     doc1.insert(&list_id, 0, 123).unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc2.set(&list_id, 0, 456).unwrap();
@@ -66,7 +68,9 @@ fn repeated_list_assignment_which_resolves_conflict_not_ignored() {
 #[test]
 fn list_deletion() {
     let mut doc = new_doc();
-    let list_id = doc.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list_id = doc
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
     doc.insert(&list_id, 0, 123).unwrap();
     doc.insert(&list_id, 1, 456).unwrap();
     doc.insert(&list_id, 2, 789).unwrap();
@@ -183,7 +187,9 @@ fn concurrent_updates_of_same_field() {
 fn concurrent_updates_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .unwrap();
     doc1.insert(&list_id, 0, "finch").unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc1.set(&list_id, 0, "greenfinch").unwrap();
@@ -210,8 +216,10 @@ fn assignment_conflicts_of_different_types() {
     let mut doc2 = new_doc();
     let mut doc3 = new_doc();
     doc1.set(&automerge::ROOT, "field", "string").unwrap();
-    doc2.make(&automerge::ROOT, "field", ObjType::List).unwrap();
-    doc3.make(&automerge::ROOT, "field", ObjType::Map).unwrap();
+    doc2.set_object(&automerge::ROOT, "field", ObjType::List)
+        .unwrap();
+    doc3.set_object(&automerge::ROOT, "field", ObjType::Map)
+        .unwrap();
     doc1.merge(&mut doc2).unwrap();
     doc1.merge(&mut doc3).unwrap();
 
@@ -232,7 +240,9 @@ fn changes_within_conflicting_map_field() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     doc1.set(&automerge::ROOT, "field", "string").unwrap();
-    let map_id = doc2.make(&automerge::ROOT, "field", ObjType::Map).unwrap();
+    let map_id = doc2
+        .set_object(&automerge::ROOT, "field", ObjType::Map)
+        .unwrap();
     doc2.set(&map_id, "innerKey", 42).unwrap();
     doc1.merge(&mut doc2).unwrap();
 
@@ -256,15 +266,17 @@ fn changes_within_conflicting_list_element() {
     let (actor1, actor2) = sorted_actors();
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
-    let list_id = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
     doc1.insert(&list_id, 0, "hello").unwrap();
     doc2.merge(&mut doc1).unwrap();
 
-    let map_in_doc1 = doc1.make(&list_id, 0, ObjType::Map).unwrap();
+    let map_in_doc1 = doc1.set_object(&list_id, 0, ObjType::Map).unwrap();
     doc1.set(&map_in_doc1, "map1", true).unwrap();
     doc1.set(&map_in_doc1, "key", 1).unwrap();
 
-    let map_in_doc2 = doc2.make(&list_id, 0, ObjType::Map).unwrap();
+    let map_in_doc2 = doc2.set_object(&list_id, 0, ObjType::Map).unwrap();
     doc1.merge(&mut doc2).unwrap();
     doc2.set(&map_in_doc2, "map2", true).unwrap();
     doc2.set(&map_in_doc2, "key", 2).unwrap();
@@ -297,10 +309,14 @@ fn concurrently_assigned_nested_maps_should_not_merge() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    let doc1_map_id = doc1.make(&automerge::ROOT, "config", ObjType::Map).unwrap();
+    let doc1_map_id = doc1
+        .set_object(&automerge::ROOT, "config", ObjType::Map)
+        .unwrap();
     doc1.set(&doc1_map_id, "background", "blue").unwrap();
 
-    let doc2_map_id = doc2.make(&automerge::ROOT, "config", ObjType::Map).unwrap();
+    let doc2_map_id = doc2
+        .set_object(&automerge::ROOT, "config", ObjType::Map)
+        .unwrap();
     doc2.set(&doc2_map_id, "logo_url", "logo.png").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
@@ -327,7 +343,9 @@ fn concurrent_insertions_at_different_list_positions() {
     let mut doc2 = new_doc_with_actor(actor2);
     assert!(doc1.get_actor() < doc2.get_actor());
 
-    let list_id = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
 
     doc1.insert(&list_id, 0, "one").unwrap();
     doc1.insert(&list_id, 1, "three").unwrap();
@@ -359,7 +377,9 @@ fn concurrent_insertions_at_same_list_position() {
     let mut doc2 = new_doc_with_actor(actor2);
     assert!(doc1.get_actor() < doc2.get_actor());
 
-    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .unwrap();
     doc1.insert(&list_id, 0, "parakeet").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
@@ -412,7 +432,9 @@ fn concurrent_assignment_and_deletion_of_a_map_entry() {
 fn concurrent_assignment_and_deletion_of_list_entry() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .unwrap();
     doc1.insert(&list_id, 0, "blackbird").unwrap();
     doc1.insert(&list_id, 1, "thrush").unwrap();
     doc1.insert(&list_id, 2, "goldfinch").unwrap();
@@ -459,7 +481,9 @@ fn concurrent_assignment_and_deletion_of_list_entry() {
 fn insertion_after_a_deleted_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .unwrap();
 
     doc1.insert(&list_id, 0, "blackbird").unwrap();
     doc1.insert(&list_id, 1, "thrush").unwrap();
@@ -500,7 +524,9 @@ fn insertion_after_a_deleted_list_element() {
 fn concurrent_deletion_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    let list_id = doc1.make(&automerge::ROOT, "birds", ObjType::List).unwrap();
+    let list_id = doc1
+        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .unwrap();
 
     doc1.insert(&list_id, 0, "albatross").unwrap();
     doc1.insert(&list_id, 1, "buzzard").unwrap();
@@ -542,13 +568,13 @@ fn concurrent_updates_at_different_levels() {
     let mut doc2 = new_doc();
 
     let animals = doc1
-        .make(&automerge::ROOT, "animals", ObjType::Map)
+        .set_object(&automerge::ROOT, "animals", ObjType::Map)
         .unwrap();
-    let birds = doc1.make(&animals, "birds", ObjType::Map).unwrap();
+    let birds = doc1.set_object(&animals, "birds", ObjType::Map).unwrap();
     doc1.set(&birds, "pink", "flamingo").unwrap();
     doc1.set(&birds, "black", "starling").unwrap();
 
-    let mammals = doc1.make(&animals, "mammals", ObjType::List).unwrap();
+    let mammals = doc1.set_object(&animals, "mammals", ObjType::List).unwrap();
     doc1.insert(&mammals, 0, "badger").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
@@ -586,8 +612,10 @@ fn concurrent_updates_of_concurrently_deleted_objects() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    let birds = doc1.make(&automerge::ROOT, "birds", ObjType::Map).unwrap();
-    let blackbird = doc1.make(&birds, "blackbird", ObjType::Map).unwrap();
+    let birds = doc1
+        .set_object(&automerge::ROOT, "birds", ObjType::Map)
+        .unwrap();
+    let blackbird = doc1.set_object(&birds, "blackbird", ObjType::Map).unwrap();
     doc1.set(&blackbird, "feathers", "black").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
@@ -615,7 +643,7 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
     let mut doc2 = new_doc_with_actor(actor2);
 
     let wisdom = doc1
-        .make(&automerge::ROOT, "wisdom", ObjType::List)
+        .set_object(&automerge::ROOT, "wisdom", ObjType::List)
         .unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -675,7 +703,9 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_greater_actor_id(
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
 
-    let list = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list = doc1
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
     doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -698,7 +728,9 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_lesser_actor_id()
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
 
-    let list = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list = doc1
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
     doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -719,7 +751,9 @@ fn insertion_consistent_with_causality() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    let list = doc1.make(&automerge::ROOT, "list", ObjType::List).unwrap();
+    let list = doc1
+        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .unwrap();
     doc1.insert(&list, 0, "four").unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc2.insert(&list, 0, "three").unwrap();
@@ -752,9 +786,11 @@ fn save_and_restore_empty() {
 #[test]
 fn save_restore_complex() {
     let mut doc1 = new_doc();
-    let todos = doc1.make(&automerge::ROOT, "todos", ObjType::List).unwrap();
+    let todos = doc1
+        .set_object(&automerge::ROOT, "todos", ObjType::List)
+        .unwrap();
 
-    let first_todo = doc1.make_insert(&todos, 0, ObjType::Map).unwrap();
+    let first_todo = doc1.insert_object(&todos, 0, ObjType::Map).unwrap();
     doc1.set(&first_todo, "title", "water plants").unwrap();
     doc1.set(&first_todo, "done", false).unwrap();
 
@@ -794,7 +830,7 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     let mut doc1 = new_doc_with_actor(actor1);
 
-    let list = doc1.make(ROOT, "list", ObjType::List)?;
+    let list = doc1.set_object(ROOT, "list", ObjType::List)?;
     doc1.insert(&list, 0, "a")?;
     doc1.insert(&list, 1, "b")?;
     doc1.insert(&list, 2, "c")?;

--- a/edit-trace/benches/main.rs
+++ b/edit-trace/benches/main.rs
@@ -1,11 +1,11 @@
-use automerge::{transaction::Transactable, AutoCommit, Automerge, Value, ROOT};
+use automerge::{transaction::Transactable, AutoCommit, Automerge, ObjType, ScalarValue, ROOT};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::fs;
 
-fn replay_trace_tx(commands: Vec<(usize, usize, Vec<Value>)>) -> Automerge {
+fn replay_trace_tx(commands: Vec<(usize, usize, Vec<ScalarValue>)>) -> Automerge {
     let mut doc = Automerge::new();
     let mut tx = doc.transaction();
-    let text = tx.set(ROOT, "text", Value::text()).unwrap().unwrap();
+    let text = tx.set_object(ROOT, "text", ObjType::Text).unwrap();
     for (pos, del, vals) in commands {
         tx.splice(&text, pos, del, vals).unwrap();
     }
@@ -13,9 +13,9 @@ fn replay_trace_tx(commands: Vec<(usize, usize, Vec<Value>)>) -> Automerge {
     doc
 }
 
-fn replay_trace_autotx(commands: Vec<(usize, usize, Vec<Value>)>) -> AutoCommit {
+fn replay_trace_autotx(commands: Vec<(usize, usize, Vec<ScalarValue>)>) -> AutoCommit {
     let mut doc = AutoCommit::new();
-    let text = doc.set(ROOT, "text", Value::text()).unwrap().unwrap();
+    let text = doc.set_object(ROOT, "text", ObjType::Text).unwrap();
     for (pos, del, vals) in commands {
         doc.splice(&text, pos, del, vals).unwrap();
     }
@@ -49,7 +49,7 @@ fn bench(c: &mut Criterion) {
         let mut vals = vec![];
         for j in 2..edits[i].len() {
             let v = edits[i][j].as_str().unwrap();
-            vals.push(Value::str(v));
+            vals.push(ScalarValue::Str(v.into()));
         }
         commands.push((pos, del, vals));
     }

--- a/edit-trace/src/main.rs
+++ b/edit-trace/src/main.rs
@@ -1,4 +1,5 @@
-use automerge::{transaction::Transactable, Automerge, AutomergeError, Value, ROOT};
+use automerge::{transaction::Transactable, Automerge, AutomergeError, ROOT};
+use automerge::{ObjType, ScalarValue};
 use std::fs;
 use std::time::Instant;
 
@@ -12,7 +13,7 @@ fn main() -> Result<(), AutomergeError> {
         let mut vals = vec![];
         for j in 2..edits[i].len() {
             let v = edits[i][j].as_str().unwrap();
-            vals.push(Value::str(v));
+            vals.push(ScalarValue::Str(v.into()));
         }
         commands.push((pos, del, vals));
     }
@@ -20,7 +21,7 @@ fn main() -> Result<(), AutomergeError> {
 
     let now = Instant::now();
     let mut tx = doc.transaction();
-    let text = tx.set(ROOT, "text", Value::text()).unwrap().unwrap();
+    let text = tx.set_object(ROOT, "text", ObjType::Text).unwrap();
     for (i, (pos, del, vals)) in commands.into_iter().enumerate() {
         if i % 1000 == 0 {
             println!("Processed {} edits in {} ms", i, now.elapsed().as_millis());


### PR DESCRIPTION
This introduces a separation between the creation of objects and scalars in the API. This makes it safer to use the object id that gets returned when creating an object, as it will always be returned, and nothing will be returned for using a scalar.