### PR TITLE
Always have an actor on the document

### DIFF
--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -50,7 +50,7 @@ impl Automerge {
         let mut automerge = Automerge(self.0.clone());
         if let Some(s) = actor {
             let actor = automerge::ActorId::from(hex::decode(s).map_err(to_js_err)?.to_vec());
-            automerge.0.set_actor(actor)
+            automerge.0.set_actor(actor);
         }
         Ok(automerge)
     }
@@ -60,7 +60,7 @@ impl Automerge {
         let mut automerge = Automerge(self.0.fork());
         if let Some(s) = actor {
             let actor = automerge::ActorId::from(hex::decode(s).map_err(to_js_err)?.to_vec());
-            automerge.0.set_actor(actor)
+            automerge.0.set_actor(actor);
         }
         Ok(automerge)
     }
@@ -538,7 +538,7 @@ pub fn load(data: Uint8Array, actor: Option<String>) -> Result<Automerge, JsValu
     let mut automerge = am::AutoCommit::load(&data).map_err(to_js_err)?;
     if let Some(s) = actor {
         let actor = automerge::ActorId::from(hex::decode(s).map_err(to_js_err)?.to_vec());
-        automerge.set_actor(actor)
+        automerge.set_actor(actor);
     }
     Ok(Automerge(automerge))
 }

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -44,13 +44,6 @@ impl AutoCommit {
         self.doc.get_actor()
     }
 
-    pub fn new_with_actor_id(actor: ActorId) -> Self {
-        Self {
-            doc: Automerge::new_with_actor_id(actor),
-            transaction: None,
-        }
-    }
-
     fn ensure_transaction_open(&mut self) {
         if self.transaction.is_none() {
             let actor = self.doc.actor;

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -46,7 +46,7 @@ impl AutoCommit {
 
     fn ensure_transaction_open(&mut self) {
         if self.transaction.is_none() {
-            let actor = self.doc.actor;
+            let actor = self.doc.get_actor_index();
 
             let seq = self.doc.states.entry(actor).or_default().len() as u64 + 1;
             let mut deps = self.doc.get_heads();

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -35,9 +35,16 @@ impl AutoCommit {
         &self.doc
     }
 
-    pub fn set_actor(&mut self, actor: ActorId) {
+    pub fn with_actor(mut self, actor: ActorId) -> Self {
         self.ensure_transaction_closed();
-        self.doc.set_actor(actor)
+        self.doc.set_actor(actor);
+        self
+    }
+
+    pub fn set_actor(&mut self, actor: ActorId) -> &mut Self {
+        self.ensure_transaction_closed();
+        self.doc.set_actor(actor);
+        self
     }
 
     pub fn get_actor(&self) -> &ActorId {

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -40,12 +40,8 @@ impl AutoCommit {
         self.doc.set_actor(actor)
     }
 
-    pub fn get_actor(&mut self) -> ActorId {
+    pub fn get_actor(&self) -> &ActorId {
         self.doc.get_actor()
-    }
-
-    pub fn maybe_get_actor(&self) -> Option<ActorId> {
-        self.doc.maybe_get_actor()
     }
 
     pub fn new_with_actor_id(actor: ActorId) -> Self {
@@ -57,7 +53,7 @@ impl AutoCommit {
 
     fn ensure_transaction_open(&mut self) {
         if self.transaction.is_none() {
-            let actor = self.doc.get_actor_index();
+            let actor = self.doc.actor;
 
             let seq = self.doc.states.entry(actor).or_default().len() as u64 + 1;
             let mut deps = self.doc.get_heads();

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -61,22 +61,6 @@ impl Automerge {
         &self.ops.m.actors[self.actor]
     }
 
-    pub fn new_with_actor_id(actor: ActorId) -> Self {
-        let mut am = Automerge {
-            queue: vec![],
-            history: vec![],
-            history_index: HashMap::new(),
-            states: HashMap::new(),
-            ops: Default::default(),
-            deps: Default::default(),
-            saved: Default::default(),
-            actor: 0,
-            max_op: 0,
-        };
-        am.actor = am.ops.m.actors.cache(actor);
-        am
-    }
-
     /// Start a transaction.
     pub fn transaction(&mut self) -> Transaction {
         let actor = self.actor;

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -52,8 +52,14 @@ impl Automerge {
         }
     }
 
-    pub fn set_actor(&mut self, actor: ActorId) {
+    pub fn with_actor(mut self, actor: ActorId) -> Self {
         self.actor = Actor::Unused(actor);
+        self
+    }
+
+    pub fn set_actor(&mut self, actor: ActorId) -> &mut Self {
+        self.actor = Actor::Unused(actor);
+        self
     }
 
     pub fn get_actor(&self) -> &ActorId {

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -24,7 +24,7 @@ const HEAD_STR: &str = "_head";
 // Note that change encoding relies on the Ord implementation for the ActorId being implemented in
 // terms of the lexicographic ordering of the underlying bytes. Be aware of this if you are
 // changing the ActorId implementation in ways which might affect the Ord implementation
-#[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord, Default)]
 #[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ActorId(TinyVec<[u8; 16]>);
 

--- a/automerge/tests/helpers/mod.rs
+++ b/automerge/tests/helpers/mod.rs
@@ -7,11 +7,15 @@ use std::{
 use serde::ser::{SerializeMap, SerializeSeq};
 
 pub fn new_doc() -> automerge::AutoCommit {
-    automerge::AutoCommit::new_with_actor_id(automerge::ActorId::random())
+    let mut d = automerge::AutoCommit::new();
+    d.set_actor(automerge::ActorId::random());
+    d
 }
 
 pub fn new_doc_with_actor(actor: automerge::ActorId) -> automerge::AutoCommit {
-    automerge::AutoCommit::new_with_actor_id(actor)
+    let mut d = automerge::AutoCommit::new();
+    d.set_actor(actor);
+    d
 }
 
 /// Returns two actor IDs, the first considered to  be ordered before the second

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -384,7 +384,7 @@ fn concurrent_insertions_at_different_list_positions() {
     let (actor1, actor2) = sorted_actors();
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
-    assert!(doc1.maybe_get_actor().unwrap() < doc2.maybe_get_actor().unwrap());
+    assert!(doc1.get_actor() < doc2.get_actor());
 
     let list_id = doc1
         .set(&automerge::ROOT, "list", automerge::Value::list())
@@ -419,7 +419,7 @@ fn concurrent_insertions_at_same_list_position() {
     let (actor1, actor2) = sorted_actors();
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
-    assert!(doc1.maybe_get_actor().unwrap() < doc2.maybe_get_actor().unwrap());
+    assert!(doc1.get_actor() < doc2.get_actor());
 
     let list_id = doc1
         .set(&automerge::ROOT, "birds", automerge::Value::list())


### PR DESCRIPTION
This helps to clean up the Rust API where getting the actor required `&mut self`.