### PR TITLE
Fix rolling back a transaction with a new actor

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -83,7 +83,7 @@ impl Automerge {
     /// Start a transaction.
     pub fn transaction(&mut self) -> Transaction {
         let actor = self.get_actor_index();
-        let seq = self.states.entry(actor).or_default().len() as u64 + 1;
+        let seq = self.states.get(&actor).map_or(0, |v| v.len()) as u64 + 1;
         let mut deps = self.get_heads();
         if seq > 1 {
             let last_hash = self.get_hash(actor, seq - 1).unwrap();

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1188,4 +1188,17 @@ mod tests {
         let keys = doc.keys(&ROOT);
         assert_eq!(keys.collect::<Vec<_>>(), vec!["a", "b", "c", "d"]);
     }
+
+    #[test]
+    fn rolling_back_transaction_has_no_effect() {
+        let mut doc = Automerge::new();
+        let old_states = doc.states.clone();
+        let bytes = doc.save().unwrap();
+        let tx = doc.transaction();
+        tx.rollback();
+        let new_states = doc.states.clone();
+        assert_eq!(old_states, new_states);
+        let new_bytes = doc.save().unwrap();
+        assert_eq!(bytes, new_bytes);
+    }
 }

--- a/automerge/src/indexed_cache.rs
+++ b/automerge/src/indexed_cache.rs
@@ -43,6 +43,19 @@ where
         &self.cache[index]
     }
 
+    /// Remove the last inserted entry into this cache.
+    /// This is safe to do as it does not require reshuffling other entries.
+    ///
+    /// # Panics
+    ///
+    /// Panics on an empty cache.
+    pub fn remove_last(&mut self) -> T {
+        let last = self.cache.len() - 1;
+        let t = self.cache.remove(last);
+        self.lookup.remove(&t);
+        t
+    }
+
     pub fn sorted(&self) -> IndexedCache<T> {
         let mut sorted = Self::new();
         self.cache.iter().sorted().cloned().for_each(|item| {

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -1,3 +1,4 @@
+use crate::automerge::Actor;
 use crate::exid::ExId;
 use crate::query::{self, OpIdSearch};
 use crate::types::{Key, ObjId, OpId};
@@ -46,6 +47,12 @@ impl TransactionInner {
     /// Undo the operations added in this transaction, returning the number of cancelled
     /// operations.
     pub fn rollback(self, doc: &mut Automerge) -> usize {
+        // remove the actor from the cache so that it doesn't end up in the saved document
+        if doc.states.get(&self.actor).is_none() {
+            let actor = doc.ops.m.actors.remove_last();
+            doc.actor = Actor::Unused(actor);
+        }
+
         let num = self.operations.len();
         // remove in reverse order so sets are removed before makes etc...
         for op in self.operations.iter().rev() {


### PR DESCRIPTION
This fixes the case where a new actor would start to make a change (with a transaction) and then roll it back.

Previously it would leave the actor in the actors cache, meaning that they get written into the document (but not read again).

This handles undoing the changes on rollback properly.