### PR TITLE
Add test for overwriting a map and getting value from old one

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1224,6 +1224,14 @@ mod tests {
         );
 
         // but we can still access the old one if we know the ID!
-        assert_eq!(doc.value(&map1, "b").unwrap(), None);
+        assert_eq!(doc.value(&map1, "b").unwrap().unwrap().0, Value::int(1));
+        // and even set new things in it!
+        let mut tx = doc.transaction();
+
+        // This should panic as we are modifying an old object
+        tx.set(&map1, "c", 3).unwrap();
+        tx.commit();
+
+        assert_eq!(doc.value(&map1, "c").unwrap(), None);
     }
 }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1203,7 +1203,7 @@ mod tests {
     }
 
     #[test]
-    fn overwrite_map() {
+    fn mutate_old_objects() {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
         // create a map
@@ -1227,11 +1227,9 @@ mod tests {
         assert_eq!(doc.value(&map1, "b").unwrap().unwrap().0, Value::int(1));
         // and even set new things in it!
         let mut tx = doc.transaction();
-
-        // This should panic as we are modifying an old object
         tx.set(&map1, "c", 3).unwrap();
         tx.commit();
 
-        assert_eq!(doc.value(&map1, "c").unwrap(), None);
+        assert_eq!(doc.value(&map1, "c").unwrap().unwrap().0, Value::int(3));
     }
 }


### PR DESCRIPTION
This test shows that we can still access an object using its ID, even though it is no longer accessible in the document tree (using the paths). I assume that this is useful for cases such as conflicts but I wonder if there might be a way to make it more footgun-like? 

I'm ok with being able to look at old objects for historical reasons but I think trying to modify them should be an error.

As for how to detect that the object is not in the current document I'm not sure, maybe keep a running set of all the object ids in the document which we can alter as changes are made, or add a modifiable bool to each object?
