### PR TITLE
Unpub ensure_transaction_closed

### DIFF
--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -122,7 +122,7 @@ impl AutoCommit {
         }
     }
 
-    pub fn ensure_transaction_closed(&mut self) {
+    fn ensure_transaction_closed(&mut self) {
         if let Some(tx) = self.transaction.take() {
             self.update_history(export_change(
                 &tx,


### PR DESCRIPTION
This does the same functionality as a commit but without messages or
timestamps and doesn't return the heads. This shouldn't really be a
public API as they should use commit.