### PR TITLE
Cleanup actor id api

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -72,7 +72,11 @@ impl Automerge {
     pub(crate) fn get_actor_index(&mut self) -> usize {
         match &mut self.actor {
             Actor::Unused(actor) => {
-                let index = self.ops.m.actors.cache(std::mem::take(actor));
+                let index = self
+                    .ops
+                    .m
+                    .actors
+                    .cache(std::mem::replace(actor, ActorId::from(&[][..])));
                 self.actor = Actor::Cached(index);
                 index
             }

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -24,7 +24,7 @@ const HEAD_STR: &str = "_head";
 // Note that change encoding relies on the Ord implementation for the ActorId being implemented in
 // terms of the lexicographic ordering of the underlying bytes. Be aware of this if you are
 // changing the ActorId implementation in ways which might affect the Ord implementation
-#[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord, Default)]
+#[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
 #[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ActorId(TinyVec<[u8; 16]>);
 
@@ -47,10 +47,6 @@ impl ActorId {
 
     pub fn to_hex_string(&self) -> String {
         hex::encode(&self.0)
-    }
-
-    pub fn op_id_at(&self, seq: u64) -> amp::OpId {
-        amp::OpId(seq, self.clone())
     }
 }
 


### PR DESCRIPTION
Default can be a footgun and confuse users, it was used internally but
that now uses the `from` impls. Also, opidat wasn't used and doesn't
seem to need to be public.