### PR TITLE
Clean up sync api

### DIFF
--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -226,7 +226,7 @@ impl From<&[am::SyncHave]> for AR {
                     .map(|h| JsValue::from_str(&hex::encode(&h.0)))
                     .collect();
                 // FIXME - the clone and the unwrap here shouldnt be needed - look at into_bytes()
-                let bloom = Uint8Array::from(have.bloom.clone().into_bytes().unwrap().as_slice());
+                let bloom = Uint8Array::from(have.bloom.to_bytes().as_slice());
                 let obj: JsValue = Object::new().into();
                 // we can unwrap here b/c we created the object and know its not frozen
                 Reflect::set(&obj, &"lastSync".into(), &last_sync.into()).unwrap();

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -437,7 +437,7 @@ impl Automerge {
     #[wasm_bindgen(js_name = generateSyncMessage)]
     pub fn generate_sync_message(&mut self, state: &mut SyncState) -> Result<JsValue, JsValue> {
         if let Some(message) = self.0.generate_sync_message(&mut state.0) {
-            Ok(Uint8Array::from(message.encode().map_err(to_js_err)?.as_slice()).into())
+            Ok(Uint8Array::from(message.encode().as_slice()).into())
         } else {
             Ok(JsValue::null())
         }
@@ -588,7 +588,6 @@ pub fn encode_sync_message(message: JsValue) -> Result<Uint8Array, JsValue> {
             changes,
         }
         .encode()
-        .unwrap()
         .as_slice(),
     ))
 }
@@ -612,9 +611,7 @@ pub fn decode_sync_message(msg: Uint8Array) -> Result<JsValue, JsValue> {
 #[wasm_bindgen(js_name = encodeSyncState)]
 pub fn encode_sync_state(state: SyncState) -> Result<Uint8Array, JsValue> {
     let state = state.0;
-    Ok(Uint8Array::from(
-        state.encode().map_err(to_js_err)?.as_slice(),
-    ))
+    Ok(Uint8Array::from(state.encode().as_slice()))
 }
 
 #[wasm_bindgen(js_name = decodeSyncState)]

--- a/automerge/src/encoding.rs
+++ b/automerge/src/encoding.rs
@@ -251,6 +251,10 @@ pub(crate) trait Encodable {
     }
 
     fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize>;
+
+    fn encode_vec(&self, buf: &mut Vec<u8>) -> usize {
+        self.encode(buf).unwrap()
+    }
 }
 
 impl Encodable for SmolStr {

--- a/automerge/src/sync/bloom.rs
+++ b/automerge/src/sync/bloom.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{decoding, decoding::Decoder, encoding, encoding::Encodable, ChangeHash};
+use crate::{decoding, decoding::Decoder, encoding::Encodable, ChangeHash};
 
 // These constants correspond to a 1% false positive rate. The values can be changed without
 // breaking compatibility of the network protocol, since the parameters used for a particular
@@ -17,19 +17,15 @@ pub struct BloomFilter {
 }
 
 impl BloomFilter {
-    // FIXME - we can avoid a result here - why do we need to consume the bloom filter?  requires
-    // me to clone in places I shouldn't need to
-    pub fn into_bytes(self) -> Result<Vec<u8>, encoding::Error> {
-        if self.num_entries == 0 {
-            Ok(Vec::new())
-        } else {
-            let mut buf = Vec::new();
-            self.num_entries.encode(&mut buf)?;
-            self.num_bits_per_entry.encode(&mut buf)?;
-            self.num_probes.encode(&mut buf)?;
-            buf.extend(self.bits);
-            Ok(buf)
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        if self.num_entries != 0 {
+            self.num_entries.encode_vec(&mut buf);
+            self.num_bits_per_entry.encode_vec(&mut buf);
+            self.num_probes.encode_vec(&mut buf);
+            buf.extend(&self.bits);
         }
+        buf
     }
 
     fn get_probes(&self, hash: &ChangeHash) -> Vec<u32> {

--- a/automerge/src/sync/state.rs
+++ b/automerge/src/sync/state.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashSet};
 
 use super::{decode_hashes, encode_hashes};
-use crate::{decoding, decoding::Decoder, encoding, BloomFilter, ChangeHash};
+use crate::{decoding, decoding::Decoder, BloomFilter, ChangeHash};
 
 const SYNC_STATE_TYPE: u8 = 0x43; // first byte of an encoded sync state, for identification
 
@@ -26,10 +26,10 @@ impl SyncState {
         Default::default()
     }
 
-    pub fn encode(&self) -> Result<Vec<u8>, encoding::Error> {
+    pub fn encode(&self) -> Vec<u8> {
         let mut buf = vec![SYNC_STATE_TYPE];
-        encode_hashes(&mut buf, &self.shared_heads)?;
-        Ok(buf)
+        encode_hashes(&mut buf, &self.shared_heads);
+        buf
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Self, decoding::Error> {


### PR DESCRIPTION
Bloom filter didn't need to consume itself when encoding. Writes are also infallible on a vec so no need for a result.