### PR TITLE
Make save infallible

### DIFF
--- a/automerge-cli/src/export.rs
+++ b/automerge-cli/src/export.rs
@@ -113,7 +113,7 @@ mod tests {
         //let mut backend = am::Automerge::new();
         //backend.apply_local_change(initial_change).unwrap();
         let mut backend = initialize_from_json(&initial_state_json).unwrap();
-        let change_bytes = backend.save().unwrap();
+        let change_bytes = backend.save();
         assert_eq!(
             get_state_json(change_bytes).unwrap(),
             serde_json::json!({"sparrows": 15.0})
@@ -140,7 +140,7 @@ mod tests {
                 //backend.apply_local_change(initial_change).unwrap();
 
         */
-        let change_bytes = backend.save().unwrap();
+        let change_bytes = backend.save();
         assert_eq!(
             get_state_json(change_bytes).unwrap(),
             serde_json::json!({

--- a/automerge-cli/src/import.rs
+++ b/automerge-cli/src/import.rs
@@ -103,6 +103,6 @@ pub fn import_json(
 
     let json_value: serde_json::Value = serde_json::from_str(&buffer)?;
     let mut doc = initialize_from_json(&json_value)?;
-    writer.write_all(&doc.save()?)?;
+    writer.write_all(&doc.save())?;
     Ok(())
 }

--- a/automerge-cli/src/merge.rs
+++ b/automerge-cli/src/merge.rs
@@ -47,7 +47,7 @@ pub(super) fn merge<W: std::io::Write>(inputs: Inputs, mut output: W) -> Result<
             }
         }
     }
-    output.write_all(&backend.save().unwrap())?;
+    output.write_all(&backend.save())?;
     Ok(())
 }
 

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -332,11 +332,8 @@ impl Automerge {
         Ok(())
     }
 
-    pub fn save(&mut self) -> Result<Uint8Array, JsValue> {
-        self.0
-            .save()
-            .map(|v| Uint8Array::from(v.as_slice()))
-            .map_err(to_js_err)
+    pub fn save(&mut self) -> Uint8Array {
+        Uint8Array::from(self.0.save().as_slice())
     }
 
     #[wasm_bindgen(js_name = saveIncremental)]

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -26,7 +26,7 @@ fn main() {
     let mut doc2 = Automerge::new();
     doc2.merge(&mut doc1).unwrap();
 
-    let binary = doc1.save().unwrap();
+    let binary = doc1.save();
     let mut doc2 = Automerge::load(&binary).unwrap();
 
     doc1.transact_with::<_, _, AutomergeError, _>(

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -162,7 +162,7 @@ impl AutoCommit {
         self.doc.merge(&mut other.doc)
     }
 
-    pub fn save(&mut self) -> Result<Vec<u8>, AutomergeError> {
+    pub fn save(&mut self) -> Vec<u8> {
         self.ensure_transaction_closed();
         self.doc.save()
     }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -487,15 +487,12 @@ impl Automerge {
         Ok(self.get_heads())
     }
 
-    pub fn save(&mut self) -> Result<Vec<u8>, AutomergeError> {
+    pub fn save(&mut self) -> Vec<u8> {
         let heads = self.get_heads();
         let c = self.history.iter();
         let ops = self.ops.iter();
-        // TODO - can we make encode_document error free
         let bytes = encode_document(heads, c, ops, &self.ops.m.actors, &self.ops.m.props.cache);
-        if bytes.is_ok() {
-            self.saved = self.get_heads();
-        }
+        self.saved = self.get_heads();
         bytes
     }
 
@@ -907,7 +904,7 @@ mod tests {
         assert!(tx.value(&list_id, 3)?.unwrap().0 == "c".into());
         assert!(tx.length(&list_id) == 4);
         tx.commit();
-        doc.save()?;
+        doc.save();
         Ok(())
     }
 
@@ -946,7 +943,7 @@ mod tests {
         tx.set(ROOT, "foo", 1)?;
         tx.commit();
 
-        let save1 = doc.save().unwrap();
+        let save1 = doc.save();
 
         let mut tx = doc.transaction();
         tx.set(ROOT, "bar", 2)?;
@@ -967,7 +964,7 @@ mod tests {
 
         assert!(doc.save_incremental().is_empty());
 
-        let save_b = doc.save().unwrap();
+        let save_b = doc.save();
 
         assert!(save_b.len() < save_a.len());
 
@@ -976,7 +973,7 @@ mod tests {
 
         assert!(doc_a.values(ROOT, "baz")? == doc_b.values(ROOT, "baz")?);
 
-        assert!(doc_a.save().unwrap() == doc_b.save().unwrap());
+        assert!(doc_a.save() == doc_b.save());
 
         Ok(())
     }
@@ -1197,12 +1194,12 @@ mod tests {
     fn rolling_back_transaction_has_no_effect() {
         let mut doc = Automerge::new();
         let old_states = doc.states.clone();
-        let bytes = doc.save().unwrap();
+        let bytes = doc.save();
         let tx = doc.transaction();
         tx.rollback();
         let new_states = doc.states.clone();
         assert_eq!(old_states, new_states);
-        let new_bytes = doc.save().unwrap();
+        let new_bytes = doc.save();
         assert_eq!(bytes, new_bytes);
     }
 

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -42,7 +42,7 @@ pub(crate) fn encode_document<'a, 'b>(
     doc_ops: impl Iterator<Item = &'b Op>,
     actors_index: &IndexedCache<ActorId>,
     props: &'a [String],
-) -> Result<Vec<u8>, AutomergeError> {
+) -> Vec<u8> {
     let mut bytes: Vec<u8> = Vec::new();
 
     let actors_map = actors_index.encode_index();
@@ -72,13 +72,13 @@ pub(crate) fn encode_document<'a, 'b>(
 
     let mut chunk = Vec::new();
 
-    actors.len().encode(&mut chunk)?;
+    actors.len().encode_vec(&mut chunk);
 
     for a in actors.into_iter() {
-        a.to_bytes().encode(&mut chunk)?;
+        a.to_bytes().encode_vec(&mut chunk);
     }
 
-    heads.len().encode(&mut chunk)?;
+    heads.len().encode_vec(&mut chunk);
     for head in heads.iter() {
         chunk.write_all(&head.0).unwrap();
     }
@@ -97,7 +97,7 @@ pub(crate) fn encode_document<'a, 'b>(
 
     bytes.splice(HASH_RANGE, hash_result[0..4].iter().copied());
 
-    Ok(bytes)
+    bytes
 }
 
 /// When encoding a change we take all the actor IDs referenced by a change and place them in an

--- a/automerge/src/encoding.rs
+++ b/automerge/src/encoding.rs
@@ -251,6 +251,10 @@ pub(crate) trait Encodable {
     }
 
     fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize>;
+
+    fn encode_vec(&self, buf: &mut Vec<u8>) -> usize {
+        self.encode(buf).unwrap()
+    }
 }
 
 impl Encodable for SmolStr {

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -841,7 +841,7 @@ fn insertion_consistent_with_causality() {
 #[test]
 fn save_and_restore_empty() {
     let mut doc = new_doc();
-    let loaded = Automerge::load(&doc.save().unwrap()).unwrap();
+    let loaded = Automerge::load(&doc.save()).unwrap();
 
     assert_doc!(&loaded, map! {});
 }
@@ -868,7 +868,7 @@ fn save_restore_complex() {
     doc1.set(&first_todo, "title", "kill plants").unwrap();
     doc1.merge(&mut doc2).unwrap();
 
-    let reloaded = Automerge::load(&doc1.save().unwrap()).unwrap();
+    let reloaded = Automerge::load(&doc1.save()).unwrap();
 
     assert_doc!(
         &reloaded,
@@ -902,10 +902,10 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
     doc1.insert(&list, 1, "b")?;
     doc1.insert(&list, 2, "c")?;
 
-    let mut doc2 = AutoCommit::load(&doc1.save()?)?;
+    let mut doc2 = AutoCommit::load(&doc1.save())?;
     doc2.set_actor(actor2);
 
-    let mut doc3 = AutoCommit::load(&doc1.save()?)?;
+    let mut doc3 = AutoCommit::load(&doc1.save())?;
     doc3.set_actor(actor3);
 
     doc1.set(&list, 1, Value::counter(0))?;
@@ -954,7 +954,7 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     assert_eq!(doc1.length(&list), 2);
 
-    let doc4 = AutoCommit::load(&doc1.save()?)?;
+    let doc4 = AutoCommit::load(&doc1.save())?;
 
     assert_eq!(doc4.length(&list), 2);
 
@@ -962,7 +962,7 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     assert_eq!(doc1.length(&list), 1);
 
-    let doc5 = AutoCommit::load(&doc1.save()?)?;
+    let doc5 = AutoCommit::load(&doc1.save())?;
 
     assert_eq!(doc5.length(&list), 1);
 

--- a/edit-trace/benches/main.rs
+++ b/edit-trace/benches/main.rs
@@ -24,11 +24,11 @@ fn replay_trace_autotx(commands: Vec<(usize, usize, Vec<Value>)>) -> AutoCommit 
 }
 
 fn save_trace(mut doc: Automerge) {
-    doc.save().unwrap();
+    doc.save();
 }
 
 fn save_trace_autotx(mut doc: AutoCommit) {
-    doc.save().unwrap();
+    doc.save();
 }
 
 fn load_trace(bytes: &[u8]) {
@@ -75,7 +75,7 @@ fn bench(c: &mut Criterion) {
         b.iter_batched(|| doc.clone(), save_trace, criterion::BatchSize::LargeInput)
     });
 
-    let bytes = doc.save().unwrap();
+    let bytes = doc.save();
     group.bench_with_input(
         BenchmarkId::new("load", commands_len),
         &bytes,
@@ -108,7 +108,7 @@ fn bench(c: &mut Criterion) {
         },
     );
 
-    let bytes = doc.save().unwrap();
+    let bytes = doc.save();
     group.bench_with_input(
         BenchmarkId::new("load autotx", commands_len),
         &bytes,


### PR DESCRIPTION
Save writes to a vec which is infallible and so the API should reflect that.