### PR TITLE
Misc API changes

### DIFF
--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -25,8 +25,8 @@ impl From<JS> for JsValue {
     }
 }
 
-impl From<am::SyncState> for JS {
-    fn from(state: am::SyncState) -> Self {
+impl From<am::sync::State> for JS {
+    fn from(state: am::sync::State) -> Self {
         let shared_heads: JS = state.shared_heads.into();
         let last_sent_heads: JS = state.last_sent_heads.into();
         let their_heads: JS = state.their_heads.into();
@@ -133,7 +133,7 @@ impl TryFrom<JS> for Vec<Change> {
     }
 }
 
-impl TryFrom<JS> for am::SyncState {
+impl TryFrom<JS> for am::sync::State {
     type Error = JsValue;
 
     fn try_from(value: JS) -> Result<Self, Self::Error> {
@@ -144,7 +144,7 @@ impl TryFrom<JS> for am::SyncState {
         let their_need = js_get(&value, "theirNeed")?.into();
         let their_have = js_get(&value, "theirHave")?.try_into()?;
         let sent_hashes = js_get(&value, "sentHashes")?.try_into()?;
-        Ok(am::SyncState {
+        Ok(am::sync::State {
             shared_heads,
             last_sent_heads,
             their_heads,
@@ -155,7 +155,7 @@ impl TryFrom<JS> for am::SyncState {
     }
 }
 
-impl TryFrom<JS> for Option<Vec<am::SyncHave>> {
+impl TryFrom<JS> for Option<Vec<am::sync::Have>> {
     type Error = JsValue;
 
     fn try_from(value: JS) -> Result<Self, Self::Error> {
@@ -167,17 +167,17 @@ impl TryFrom<JS> for Option<Vec<am::SyncHave>> {
     }
 }
 
-impl TryFrom<JS> for Vec<am::SyncHave> {
+impl TryFrom<JS> for Vec<am::sync::Have> {
     type Error = JsValue;
 
     fn try_from(value: JS) -> Result<Self, Self::Error> {
         let value = value.0.dyn_into::<Array>()?;
-        let have: Result<Vec<am::SyncHave>, JsValue> = value
+        let have: Result<Vec<am::sync::Have>, JsValue> = value
             .iter()
             .map(|s| {
                 let last_sync = js_get(&s, "lastSync")?.try_into()?;
                 let bloom = js_get(&s, "bloom")?.try_into()?;
-                Ok(am::SyncHave { last_sync, bloom })
+                Ok(am::sync::Have { last_sync, bloom })
             })
             .collect();
         let have = have?;
@@ -185,7 +185,7 @@ impl TryFrom<JS> for Vec<am::SyncHave> {
     }
 }
 
-impl TryFrom<JS> for am::BloomFilter {
+impl TryFrom<JS> for am::sync::BloomFilter {
     type Error = JsValue;
 
     fn try_from(value: JS) -> Result<Self, Self::Error> {
@@ -215,8 +215,8 @@ impl From<&[Change]> for AR {
     }
 }
 
-impl From<&[am::SyncHave]> for AR {
-    fn from(value: &[am::SyncHave]) -> Self {
+impl From<&[am::sync::Have]> for AR {
+    fn from(value: &[am::sync::Have]) -> Self {
         AR(value
             .iter()
             .map(|have| {

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -442,7 +442,7 @@ impl Automerge {
         message: Uint8Array,
     ) -> Result<(), JsValue> {
         let message = message.to_vec();
-        let message = am::SyncMessage::decode(message.as_slice()).map_err(to_js_err)?;
+        let message = am::sync::Message::decode(message.as_slice()).map_err(to_js_err)?;
         self.0
             .receive_sync_message(&mut state.0, message)
             .map_err(to_js_err)?;
@@ -574,7 +574,7 @@ pub fn decode_change(change: Uint8Array) -> Result<JsValue, JsValue> {
 
 #[wasm_bindgen(js_name = initSyncState)]
 pub fn init_sync_state() -> SyncState {
-    SyncState(am::SyncState::new())
+    SyncState(am::sync::State::new())
 }
 
 // this is needed to be compatible with the automerge-js api
@@ -596,7 +596,7 @@ pub fn encode_sync_message(message: JsValue) -> Result<Uint8Array, JsValue> {
     let changes = js_get(&message, "changes")?.try_into()?;
     let have = js_get(&message, "have")?.try_into()?;
     Ok(Uint8Array::from(
-        am::SyncMessage {
+        am::sync::Message {
             heads,
             need,
             have,
@@ -610,7 +610,7 @@ pub fn encode_sync_message(message: JsValue) -> Result<Uint8Array, JsValue> {
 #[wasm_bindgen(js_name = decodeSyncMessage)]
 pub fn decode_sync_message(msg: Uint8Array) -> Result<JsValue, JsValue> {
     let data = msg.to_vec();
-    let msg = am::SyncMessage::decode(&data).map_err(to_js_err)?;
+    let msg = am::sync::Message::decode(&data).map_err(to_js_err)?;
     let heads = AR::from(msg.heads.as_slice());
     let need = AR::from(msg.need.as_slice());
     let changes = AR::from(msg.changes.as_slice());

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -72,7 +72,7 @@ impl Automerge {
         (self.0.pending_ops() as u32).into()
     }
 
-    pub fn commit(&mut self, message: Option<String>, time: Option<f64>) -> Array {
+    pub fn commit(&mut self, message: Option<String>, time: Option<f64>) -> JsValue {
         let mut commit_opts = CommitOptions::default();
         if let Some(message) = message {
             commit_opts.set_message(message);
@@ -80,12 +80,8 @@ impl Automerge {
         if let Some(time) = time {
             commit_opts.set_time(time as i64);
         }
-        let heads = self.0.commit_with(commit_opts);
-        let heads: Array = heads
-            .iter()
-            .map(|h| JsValue::from_str(&hex::encode(&h.0)))
-            .collect();
-        heads
+        let hash = self.0.commit_with(commit_opts);
+        JsValue::from_str(&hex::encode(&hash.0))
     }
 
     pub fn merge(&mut self, other: &mut Automerge) -> Result<Array, JsValue> {
@@ -374,7 +370,7 @@ impl Automerge {
     #[wasm_bindgen(js_name = applyChanges)]
     pub fn apply_changes(&mut self, changes: JsValue) -> Result<(), JsValue> {
         let changes: Vec<_> = JS(changes).try_into()?;
-        self.0.apply_changes(&changes).map_err(to_js_err)?;
+        self.0.apply_changes(changes).map_err(to_js_err)?;
         Ok(())
     }
 

--- a/automerge-wasm/src/sync.rs
+++ b/automerge-wasm/src/sync.rs
@@ -9,7 +9,7 @@ use crate::interop::{to_js_err, AR, JS};
 
 #[wasm_bindgen]
 #[derive(Debug)]
-pub struct SyncState(pub(crate) am::SyncState);
+pub struct SyncState(pub(crate) am::sync::State);
 
 #[wasm_bindgen]
 impl SyncState {
@@ -45,7 +45,7 @@ impl SyncState {
 
     pub(crate) fn decode(data: Uint8Array) -> Result<SyncState, JsValue> {
         let data = data.to_vec();
-        let s = am::SyncState::decode(&data);
+        let s = am::sync::State::decode(&data);
         let s = s.map_err(to_js_err)?;
         Ok(SyncState(s))
     }

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -9,7 +9,7 @@ fn main() {
     let mut doc1 = Automerge::new();
     let (cards, card1) = doc1
         .transact_with::<_, _, AutomergeError, _>(
-            || CommitOptions::default().with_message("Add card".to_owned()),
+            |_| CommitOptions::default().with_message("Add card".to_owned()),
             |tx| {
                 let cards = tx.set_object(ROOT, "cards", ObjType::List).unwrap();
                 let card1 = tx.insert_object(&cards, 0, ObjType::Map)?;
@@ -22,7 +22,7 @@ fn main() {
             },
         )
         .unwrap()
-        .into_result();
+        .result;
 
     let mut doc2 = Automerge::new();
     doc2.merge(&mut doc1).unwrap();
@@ -31,7 +31,7 @@ fn main() {
     let mut doc2 = Automerge::load(&binary).unwrap();
 
     doc1.transact_with::<_, _, AutomergeError, _>(
-        || CommitOptions::default().with_message("Mark card as done".to_owned()),
+        |_| CommitOptions::default().with_message("Mark card as done".to_owned()),
         |tx| {
             tx.set(&card1, "done", true)?;
             Ok(())
@@ -40,7 +40,7 @@ fn main() {
     .unwrap();
 
     doc2.transact_with::<_, _, AutomergeError, _>(
-        || CommitOptions::default().with_message("Delete card".to_owned()),
+        |_| CommitOptions::default().with_message("Delete card".to_owned()),
         |tx| {
             tx.del(&cards, 0)?;
             Ok(())

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -4,7 +4,7 @@ use crate::{
     change::export_change, transaction::TransactionInner, ActorId, Automerge, AutomergeError,
     Change, ChangeHash, Prop, Value,
 };
-use crate::{Keys, KeysAt, ObjType, ScalarValue, SyncMessage, SyncState};
+use crate::{sync, Keys, KeysAt, ObjType, ScalarValue};
 
 /// An automerge document that automatically manages transactions.
 #[derive(Debug, Clone)]
@@ -206,15 +206,15 @@ impl AutoCommit {
         self.doc.dump()
     }
 
-    pub fn generate_sync_message(&mut self, sync_state: &mut SyncState) -> Option<SyncMessage> {
+    pub fn generate_sync_message(&mut self, sync_state: &mut sync::State) -> Option<sync::Message> {
         self.ensure_transaction_closed();
         self.doc.generate_sync_message(sync_state)
     }
 
     pub fn receive_sync_message(
         &mut self,
-        sync_state: &mut SyncState,
-        message: SyncMessage,
+        sync_state: &mut sync::State,
+        message: sync::Message,
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.receive_sync_message(sync_state, message)

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -1,6 +1,5 @@
 use crate::exid::ExId;
 use crate::transaction::{CommitOptions, Transactable};
-use crate::types::Patch;
 use crate::{
     change::export_change, transaction::TransactionInner, ActorId, Automerge, AutomergeError,
     Change, ChangeHash, Prop, Value,
@@ -145,7 +144,7 @@ impl AutoCommit {
         self.doc.load_incremental(data)
     }
 
-    pub fn apply_changes(&mut self, changes: &[Change]) -> Result<Patch, AutomergeError> {
+    pub fn apply_changes(&mut self, changes: Vec<Change>) -> Result<(), AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.apply_changes(changes)
     }
@@ -216,7 +215,7 @@ impl AutoCommit {
         &mut self,
         sync_state: &mut SyncState,
         message: SyncMessage,
-    ) -> Result<Option<Patch>, AutomergeError> {
+    ) -> Result<(), AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.receive_sync_message(sync_state, message)
     }
@@ -234,13 +233,11 @@ impl AutoCommit {
         self.doc.get_heads()
     }
 
-    pub fn commit(&mut self) -> Vec<ChangeHash> {
+    pub fn commit(&mut self) -> ChangeHash {
         // ensure that even no changes triggers a change
         self.ensure_transaction_open();
-        self.transaction
-            .take()
-            .map(|tx| tx.commit(&mut self.doc, None, None))
-            .unwrap_or_else(|| self.doc.get_heads())
+        let tx = self.transaction.take().unwrap();
+        tx.commit(&mut self.doc, None, None)
     }
 
     /// Commit the current operations with some options.
@@ -258,12 +255,10 @@ impl AutoCommit {
     /// i64;
     /// doc.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
     /// ```
-    pub fn commit_with(&mut self, options: CommitOptions) -> Vec<ChangeHash> {
+    pub fn commit_with(&mut self, options: CommitOptions) -> ChangeHash {
         self.ensure_transaction_open();
-        self.transaction
-            .take()
-            .map(|tx| tx.commit(&mut self.doc, options.message, options.time))
-            .unwrap_or_else(|| self.doc.get_heads())
+        let tx = self.transaction.take().unwrap();
+        tx.commit(&mut self.doc, options.message, options.time)
     }
 
     pub fn rollback(&mut self) -> usize {

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -4,12 +4,9 @@ use crate::change::encode_document;
 use crate::exid::ExId;
 use crate::keys::Keys;
 use crate::op_set::OpSet;
-use crate::transaction::{
-    CommitOptions, Transaction, TransactionFailure, TransactionInner, TransactionResult,
-    TransactionSuccess,
-};
+use crate::transaction::{self, CommitOptions, Failure, Success, Transaction, TransactionInner};
 use crate::types::{
-    ActorId, ChangeHash, Clock, ElemId, Export, Exportable, Key, ObjId, Op, OpId, OpType, Patch,
+    ActorId, ChangeHash, Clock, ElemId, Export, Exportable, Key, ObjId, Op, OpId, OpType,
     ScalarValue, Value,
 };
 use crate::KeysAt;
@@ -115,18 +112,18 @@ impl Automerge {
 
     /// Run a transaction on this document in a closure, automatically handling commit or rollback
     /// afterwards.
-    pub fn transact<F, O, E>(&mut self, f: F) -> TransactionResult<O, E>
+    pub fn transact<F, O, E>(&mut self, f: F) -> transaction::Result<O, E>
     where
         F: FnOnce(&mut Transaction) -> Result<O, E>,
     {
         let mut tx = self.transaction();
         let result = f(&mut tx);
         match result {
-            Ok(result) => Ok(TransactionSuccess {
+            Ok(result) => Ok(Success {
                 result,
-                heads: tx.commit(),
+                hash: tx.commit(),
             }),
-            Err(error) => Err(TransactionFailure {
+            Err(error) => Err(Failure {
                 error,
                 cancelled: tx.rollback(),
             }),
@@ -134,19 +131,22 @@ impl Automerge {
     }
 
     /// Like [`Self::transact`] but with a function for generating the commit options.
-    pub fn transact_with<F, O, E, C>(&mut self, c: C, f: F) -> TransactionResult<O, E>
+    pub fn transact_with<F, O, E, C>(&mut self, c: C, f: F) -> transaction::Result<O, E>
     where
         F: FnOnce(&mut Transaction) -> Result<O, E>,
-        C: FnOnce() -> CommitOptions,
+        C: FnOnce(&O) -> CommitOptions,
     {
         let mut tx = self.transaction();
         let result = f(&mut tx);
         match result {
-            Ok(result) => Ok(TransactionSuccess {
-                result,
-                heads: tx.commit_with(c()),
-            }),
-            Err(error) => Err(TransactionFailure {
+            Ok(result) => {
+                let commit_options = c(&result);
+                Ok(Success {
+                    result,
+                    hash: tx.commit_with(commit_options),
+                })
+            }
+            Err(error) => Err(Failure {
                 error,
                 cancelled: tx.rollback(),
             }),
@@ -372,14 +372,14 @@ impl Automerge {
     pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {
         let changes = Change::load_document(data)?;
         let mut doc = Self::new();
-        doc.apply_changes(&changes)?;
+        doc.apply_changes(changes)?;
         Ok(doc)
     }
 
     pub fn load_incremental(&mut self, data: &[u8]) -> Result<usize, AutomergeError> {
         let changes = Change::load_document(data)?;
         let start = self.ops.len();
-        self.apply_changes(&changes)?;
+        self.apply_changes(changes)?;
         let delta = self.ops.len() - start;
         Ok(delta)
     }
@@ -394,26 +394,26 @@ impl Automerge {
         dup
     }
 
-    pub fn apply_changes(&mut self, changes: &[Change]) -> Result<Patch, AutomergeError> {
+    pub fn apply_changes(&mut self, changes: Vec<Change>) -> Result<(), AutomergeError> {
         for c in changes {
             if !self.history_index.contains_key(&c.hash) {
-                if self.duplicate_seq(c) {
+                if self.duplicate_seq(&c) {
                     return Err(AutomergeError::DuplicateSeqNumber(
                         c.seq,
                         c.actor_id().clone(),
                     ));
                 }
-                if self.is_causally_ready(c) {
-                    self.apply_change(c.clone());
+                if self.is_causally_ready(&c) {
+                    self.apply_change(c);
                 } else {
-                    self.queue.push(c.clone());
+                    self.queue.push(c);
                 }
             }
         }
         while let Some(c) = self.pop_next_causally_ready_change() {
             self.apply_change(c);
         }
-        Ok(Patch {})
+        Ok(())
     }
 
     pub fn apply_change(&mut self, change: Change) {
@@ -487,7 +487,7 @@ impl Automerge {
             .into_iter()
             .cloned()
             .collect::<Vec<_>>();
-        self.apply_changes(&changes)?;
+        self.apply_changes(changes)?;
         Ok(self.get_heads())
     }
 

--- a/automerge/src/lib.rs
+++ b/automerge/src/lib.rs
@@ -40,7 +40,7 @@ mod legacy;
 mod op_set;
 mod op_tree;
 mod query;
-mod sync;
+pub mod sync;
 pub mod transaction;
 mod types;
 mod value;
@@ -55,7 +55,6 @@ pub use exid::ExId as ObjId;
 pub use keys::Keys;
 pub use keys_at::KeysAt;
 pub use legacy::Change as ExpandedChange;
-pub use sync::{BloomFilter, SyncHave, SyncMessage, SyncState};
 pub use types::{ActorId, ChangeHash, ObjType, OpType, Prop};
 pub use value::{ScalarValue, Value};
 

--- a/automerge/src/sync.rs
+++ b/automerge/src/sync.rs
@@ -6,7 +6,6 @@ use std::{
     io::Write,
 };
 
-use crate::types::Patch;
 use crate::{
     decoding, decoding::Decoder, encoding::Encodable, Automerge, AutomergeError, Change, ChangeHash,
 };
@@ -98,9 +97,7 @@ impl Automerge {
         &mut self,
         sync_state: &mut SyncState,
         message: SyncMessage,
-    ) -> Result<Option<Patch>, AutomergeError> {
-        let mut patch = None;
-
+    ) -> Result<(), AutomergeError> {
         let before_heads = self.get_heads();
 
         let SyncMessage {
@@ -112,7 +109,7 @@ impl Automerge {
 
         let changes_is_empty = message_changes.is_empty();
         if !changes_is_empty {
-            patch = Some(self.apply_changes(&message_changes)?);
+            self.apply_changes(message_changes)?;
             sync_state.shared_heads = advance_heads(
                 &before_heads.iter().collect(),
                 &self.get_heads().into_iter().collect(),
@@ -153,7 +150,7 @@ impl Automerge {
         sync_state.their_heads = Some(message_heads);
         sync_state.their_need = Some(message_need);
 
-        Ok(patch)
+        Ok(())
     }
 
     fn make_bloom_filter(&self, last_sync: Vec<ChangeHash>) -> SyncHave {

--- a/automerge/src/sync.rs
+++ b/automerge/src/sync.rs
@@ -14,13 +14,13 @@ mod bloom;
 mod state;
 
 pub use bloom::BloomFilter;
-pub use state::{SyncHave, SyncState};
+pub use state::{Have, State};
 
 const HASH_SIZE: usize = 32; // 256 bits = 32 bytes
 const MESSAGE_TYPE_SYNC: u8 = 0x42; // first byte of a sync message, for identification
 
 impl Automerge {
-    pub fn generate_sync_message(&self, sync_state: &mut SyncState) -> Option<SyncMessage> {
+    pub fn generate_sync_message(&self, sync_state: &mut State) -> Option<Message> {
         let our_heads = self.get_heads();
 
         let our_need = self.get_missing_deps(sync_state.their_heads.as_ref().unwrap_or(&vec![]));
@@ -43,10 +43,10 @@ impl Automerge {
                     .iter()
                     .all(|hash| self.get_change_by_hash(hash).is_some())
                 {
-                    let reset_msg = SyncMessage {
+                    let reset_msg = Message {
                         heads: our_heads,
                         need: Vec::new(),
-                        have: vec![SyncHave::default()],
+                        have: vec![Have::default()],
                         changes: Vec::new(),
                     };
                     return Some(reset_msg);
@@ -83,7 +83,7 @@ impl Automerge {
             .sent_hashes
             .extend(changes_to_send.iter().map(|c| c.hash));
 
-        let sync_message = SyncMessage {
+        let sync_message = Message {
             heads: our_heads,
             have: our_have,
             need: our_need,
@@ -95,12 +95,12 @@ impl Automerge {
 
     pub fn receive_sync_message(
         &mut self,
-        sync_state: &mut SyncState,
-        message: SyncMessage,
+        sync_state: &mut State,
+        message: Message,
     ) -> Result<(), AutomergeError> {
         let before_heads = self.get_heads();
 
-        let SyncMessage {
+        let Message {
             heads: message_heads,
             changes: message_changes,
             need: message_need,
@@ -153,19 +153,19 @@ impl Automerge {
         Ok(())
     }
 
-    fn make_bloom_filter(&self, last_sync: Vec<ChangeHash>) -> SyncHave {
+    fn make_bloom_filter(&self, last_sync: Vec<ChangeHash>) -> Have {
         let new_changes = self.get_changes(&last_sync);
         let hashes = new_changes
             .into_iter()
             .map(|change| change.hash)
             .collect::<Vec<_>>();
-        SyncHave {
+        Have {
             last_sync,
             bloom: BloomFilter::from(&hashes[..]),
         }
     }
 
-    fn get_changes_to_send(&self, have: Vec<SyncHave>, need: &[ChangeHash]) -> Vec<&Change> {
+    fn get_changes_to_send(&self, have: Vec<Have>, need: &[ChangeHash]) -> Vec<&Change> {
         if have.is_empty() {
             need.iter()
                 .filter_map(|hash| self.get_change_by_hash(hash))
@@ -175,7 +175,7 @@ impl Automerge {
             let mut bloom_filters = Vec::with_capacity(have.len());
 
             for h in have {
-                let SyncHave { last_sync, bloom } = h;
+                let Have { last_sync, bloom } = h;
                 for hash in last_sync {
                     last_sync_hashes.insert(hash);
                 }
@@ -237,14 +237,14 @@ impl Automerge {
 }
 
 #[derive(Debug, Clone)]
-pub struct SyncMessage {
+pub struct Message {
     pub heads: Vec<ChangeHash>,
     pub need: Vec<ChangeHash>,
-    pub have: Vec<SyncHave>,
+    pub have: Vec<Have>,
     pub changes: Vec<Change>,
 }
 
-impl SyncMessage {
+impl Message {
     pub fn encode(self) -> Vec<u8> {
         let mut buf = vec![MESSAGE_TYPE_SYNC];
 
@@ -265,7 +265,7 @@ impl SyncMessage {
         buf
     }
 
-    pub fn decode(bytes: &[u8]) -> Result<SyncMessage, decoding::Error> {
+    pub fn decode(bytes: &[u8]) -> Result<Message, decoding::Error> {
         let mut decoder = Decoder::new(Cow::Borrowed(bytes));
 
         let message_type = decoder.read::<u8>()?;
@@ -284,7 +284,7 @@ impl SyncMessage {
             let last_sync = decode_hashes(&mut decoder)?;
             let bloom_bytes: Vec<u8> = decoder.read()?;
             let bloom = BloomFilter::try_from(bloom_bytes.as_slice())?;
-            have.push(SyncHave { last_sync, bloom });
+            have.push(Have { last_sync, bloom });
         }
 
         let change_count = decoder.read::<u32>()?;
@@ -294,7 +294,7 @@ impl SyncMessage {
             changes.push(Change::from_bytes(change)?);
         }
 
-        Ok(SyncMessage {
+        Ok(Message {
             heads,
             need,
             have,

--- a/automerge/src/sync.rs
+++ b/automerge/src/sync.rs
@@ -236,11 +236,16 @@ impl Automerge {
     }
 }
 
+/// The sync message to be sent.
 #[derive(Debug, Clone)]
 pub struct Message {
+    /// The heads of the sender.
     pub heads: Vec<ChangeHash>,
+    /// The hashes of any changes that are being explicitly requested from the recipient.
     pub need: Vec<ChangeHash>,
+    /// A summary of the changes that the sender already has.
     pub have: Vec<Have>,
+    /// The changes for the recipient to apply.
     pub changes: Vec<Change>,
 }
 

--- a/automerge/src/sync/state.rs
+++ b/automerge/src/sync/state.rs
@@ -5,6 +5,7 @@ use crate::{decoding, decoding::Decoder, ChangeHash};
 
 const SYNC_STATE_TYPE: u8 = 0x43; // first byte of an encoded sync state, for identification
 
+/// The state of synchronisation with a peer.
 #[derive(Debug, Clone, Default)]
 pub struct State {
     pub shared_heads: Vec<ChangeHash>,
@@ -15,9 +16,15 @@ pub struct State {
     pub sent_hashes: HashSet<ChangeHash>,
 }
 
+/// A summary of the changes that the sender of the message already has.
+/// This is implicitly a request to the recipient to send all changes that the
+/// sender does not already have.
 #[derive(Debug, Clone, Default)]
 pub struct Have {
+    /// The heads at the time of the last successful sync with this recipient.
     pub last_sync: Vec<ChangeHash>,
+    /// A bloom filter summarising all of the changes that the sender of the message has added
+    /// since the last sync.
     pub bloom: BloomFilter,
 }
 

--- a/automerge/src/sync/state.rs
+++ b/automerge/src/sync/state.rs
@@ -1,27 +1,27 @@
 use std::{borrow::Cow, collections::HashSet};
 
-use super::{decode_hashes, encode_hashes};
-use crate::{decoding, decoding::Decoder, BloomFilter, ChangeHash};
+use super::{decode_hashes, encode_hashes, BloomFilter};
+use crate::{decoding, decoding::Decoder, ChangeHash};
 
 const SYNC_STATE_TYPE: u8 = 0x43; // first byte of an encoded sync state, for identification
 
 #[derive(Debug, Clone, Default)]
-pub struct SyncState {
+pub struct State {
     pub shared_heads: Vec<ChangeHash>,
     pub last_sent_heads: Vec<ChangeHash>,
     pub their_heads: Option<Vec<ChangeHash>>,
     pub their_need: Option<Vec<ChangeHash>>,
-    pub their_have: Option<Vec<SyncHave>>,
+    pub their_have: Option<Vec<Have>>,
     pub sent_hashes: HashSet<ChangeHash>,
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct SyncHave {
+pub struct Have {
     pub last_sync: Vec<ChangeHash>,
     pub bloom: BloomFilter,
 }
 
-impl SyncState {
+impl State {
     pub fn new() -> Self {
         Default::default()
     }

--- a/automerge/src/transaction.rs
+++ b/automerge/src/transaction.rs
@@ -8,7 +8,7 @@ pub use self::commit::CommitOptions;
 pub use self::transactable::Transactable;
 pub(crate) use inner::TransactionInner;
 pub use manual_transaction::Transaction;
-pub use result::TransactionFailure;
-pub use result::TransactionSuccess;
+pub use result::Failure;
+pub use result::Success;
 
-pub type TransactionResult<O, E> = Result<TransactionSuccess<O>, TransactionFailure<E>>;
+pub type Result<O, E> = std::result::Result<Success<O>, Failure<E>>;

--- a/automerge/src/transaction/commit.rs
+++ b/automerge/src/transaction/commit.rs
@@ -1,8 +1,8 @@
 /// Optional metadata for a commit.
 #[derive(Debug, Default, Clone)]
 pub struct CommitOptions {
-    pub(crate) message: Option<String>,
-    pub(crate) time: Option<i64>,
+    pub message: Option<String>,
+    pub time: Option<i64>,
 }
 
 impl CommitOptions {

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -30,7 +30,7 @@ impl TransactionInner {
         doc: &mut Automerge,
         message: Option<String>,
         time: Option<i64>,
-    ) -> Vec<ChangeHash> {
+    ) -> ChangeHash {
         if message.is_some() {
             self.message = message;
         }
@@ -39,9 +39,11 @@ impl TransactionInner {
             self.time = t;
         }
 
-        doc.update_history(export_change(&self, &doc.ops.m.actors, &doc.ops.m.props));
-
-        doc.get_heads()
+        let change = export_change(&self, &doc.ops.m.actors, &doc.ops.m.props);
+        let hash = change.hash;
+        doc.update_history(change);
+        debug_assert_eq!(doc.get_heads(), vec![hash]);
+        hash
     }
 
     /// Undo the operations added in this transaction, returning the number of cancelled

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -32,7 +32,7 @@ impl<'a> Transaction<'a> {
 
     /// Commit the operations performed in this transaction, returning the hashes corresponding to
     /// the new heads.
-    pub fn commit(mut self) -> Vec<ChangeHash> {
+    pub fn commit(mut self) -> ChangeHash {
         self.inner.take().unwrap().commit(self.doc, None, None)
     }
 
@@ -52,7 +52,7 @@ impl<'a> Transaction<'a> {
     /// i64;
     /// tx.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
     /// ```
-    pub fn commit_with(mut self, options: CommitOptions) -> Vec<ChangeHash> {
+    pub fn commit_with(mut self, options: CommitOptions) -> ChangeHash {
         self.inner
             .take()
             .unwrap()

--- a/automerge/src/transaction/result.rs
+++ b/automerge/src/transaction/result.rs
@@ -2,53 +2,18 @@ use crate::ChangeHash;
 
 /// The result of a successful, and committed, transaction.
 #[derive(Debug)]
-pub struct TransactionSuccess<O> {
-    pub(crate) result: O,
-    pub(crate) heads: Vec<ChangeHash>,
-}
-
-impl<O> TransactionSuccess<O> {
-    /// Get the result of the transaction.
-    pub fn result(&self) -> &O {
-        &self.result
-    }
-
-    /// Get the result of the transaction.
-    pub fn into_result(self) -> O {
-        self.result
-    }
-
-    /// Get the new heads of the document after commiting the transaction.
-    pub fn heads(&self) -> &[ChangeHash] {
-        &self.heads
-    }
-
-    /// Get the new heads of the document after commiting the transaction.
-    pub fn into_heads(self) -> Vec<ChangeHash> {
-        self.heads
-    }
+pub struct Success<O> {
+    /// The result of the transaction.
+    pub result: O,
+    /// The hash of the change, also the head of the document.
+    pub hash: ChangeHash,
 }
 
 /// The result of a failed, and rolled back, transaction.
 #[derive(Debug)]
-pub struct TransactionFailure<E> {
-    pub(crate) error: E,
-    pub(crate) cancelled: usize,
-}
-
-impl<E> TransactionFailure<E> {
-    /// Get the error of the transaction.
-    pub fn error(&self) -> &E {
-        &self.error
-    }
-
-    /// Get the error of the transaction.
-    pub fn into_error(self) -> E {
-        self.error
-    }
-
-    /// Get the number of cancelled operations in the transaction.
-    pub fn cancelled(&self) -> usize {
-        self.cancelled
-    }
+pub struct Failure<E> {
+    /// The error returned from the transaction.
+    pub error: E,
+    /// The number of operations cancelled.
+    pub cancelled: usize,
 }

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -313,9 +313,6 @@ pub enum Prop {
     Seq(usize),
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone)]
-pub struct Patch {}
-
 impl Key {
     pub fn elemid(&self) -> Option<ElemId> {
         match self {


### PR DESCRIPTION
- Commit now returns just a single hash rather than a vec. Since the
  change we create from committing has all of the heads as deps there
  can only be one hash/head after committing.
- Apply changes now takes a Vec rather than a slice. This avoids having
  to clone them inside.
- transact_with now passes the result of the closure to the commit
  options function
- Remove patch struct
- Change receive_sync_message to return a () instead of the
  `Option<Patch>`
- Change `Transaction*` structs to just `*` and use the transaction
  module
- Make CommitOptions fields public
- Move sync structs to module rather than being globally public