### PR TITLE
add paths/materialize to api

### DIFF
--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -100,6 +100,7 @@ export class Automerge {
   keys(obj: ObjID, heads?: Heads): string[];
   text(obj: ObjID, heads?: Heads): string;
   length(obj: ObjID, heads?: Heads): number;
+  materialize(obj?: ObjID): any;
 
   // transactions
   commit(message?: string, time?: number): Heads;
@@ -115,7 +116,7 @@ export class Automerge {
 
   // sync over network
   receiveSyncMessage(state: SyncState, message: SyncMessage): void;
-  generateSyncMessage(state: SyncState): SyncMessage;
+  generateSyncMessage(state: SyncState): SyncMessage | null;
 
   // low level change functions
   applyChanges(changes: Change[]): void;

--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -340,8 +340,11 @@ pub(crate) fn map_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
             {
                 Reflect::set(&map, &k.into(), &map_to_js(doc, &exid)).unwrap();
             }
-            Ok(Some((Value::Object(_), exid))) => {
+            Ok(Some((Value::Object(o), exid))) if o == am::ObjType::List => {
                 Reflect::set(&map, &k.into(), &list_to_js(doc, &exid)).unwrap();
+            }
+            Ok(Some((Value::Object(o), exid))) if o == am::ObjType::Text => {
+                Reflect::set(&map, &k.into(), &doc.text(&exid).unwrap().into()).unwrap();
             }
             Ok(Some((Value::Scalar(v), _))) => {
                 Reflect::set(&map, &k.into(), &ScalarValue(v).into()).unwrap();
@@ -352,7 +355,7 @@ pub(crate) fn map_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
     map.into()
 }
 
-fn list_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
+pub(crate) fn list_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
     let len = doc.length(obj);
     let array = Array::new();
     for i in 0..len {

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -12,7 +12,9 @@ mod interop;
 mod sync;
 mod value;
 
-use interop::{get_heads, js_get, js_set, map_to_js, to_js_err, to_objtype, to_prop, AR, JS};
+use interop::{
+    get_heads, js_get, js_set, list_to_js, map_to_js, to_js_err, to_objtype, to_prop, AR, JS,
+};
 use sync::SyncState;
 use value::{datatype, ScalarValue};
 
@@ -465,9 +467,52 @@ impl Automerge {
         map_to_js(&self.0, &ROOT)
     }
 
+    pub fn materialize(&self, obj: JsValue) -> Result<JsValue, JsValue> {
+        let obj = self.import(obj).unwrap_or(ROOT);
+        match self.0.object_type(&obj)? {
+            am::ObjType::Map => Ok(map_to_js(&self.0, &obj)),
+            am::ObjType::List => Ok(list_to_js(&self.0, &obj)),
+            am::ObjType::Text => Ok(self.0.text(&obj)?.into()),
+            am::ObjType::Table => Ok(map_to_js(&self.0, &obj)),
+        }
+    }
+
     fn import(&self, id: JsValue) -> Result<ObjId, JsValue> {
         if let Some(s) = id.as_string() {
-            Ok(self.0.import(&s)?)
+            if let Some(post) = s.strip_prefix('/') {
+                let mut obj = ROOT;
+                let mut is_map = true;
+                let parts = post.split('/');
+                for prop in parts {
+                    if prop.is_empty() {
+                        break;
+                    }
+                    let val = if is_map {
+                        self.0.value(obj, prop)?
+                    } else {
+                        self.0.value(obj, am::Prop::Seq(prop.parse().unwrap()))?
+                    };
+                    match val {
+                        Some((am::Value::Object(am::ObjType::Map), id)) => {
+                            is_map = true;
+                            obj = id;
+                        }
+                        Some((am::Value::Object(am::ObjType::Table), id)) => {
+                            is_map = true;
+                            obj = id;
+                        }
+                        Some((am::Value::Object(_), id)) => {
+                            is_map = false;
+                            obj = id;
+                        }
+                        None => return Err(to_js_err(format!("invalid path '{}'", s))),
+                        _ => return Err(to_js_err(format!("path '{}' is not an object", s))),
+                    };
+                }
+                Ok(obj)
+            } else {
+                Ok(self.0.import(&s)?)
+            }
         } else {
             Err(to_js_err("invalid objid"))
         }

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -469,11 +469,12 @@ impl Automerge {
 
     pub fn materialize(&self, obj: JsValue) -> Result<JsValue, JsValue> {
         let obj = self.import(obj).unwrap_or(ROOT);
-        match self.0.object_type(&obj)? {
-            am::ObjType::Map => Ok(map_to_js(&self.0, &obj)),
-            am::ObjType::List => Ok(list_to_js(&self.0, &obj)),
-            am::ObjType::Text => Ok(self.0.text(&obj)?.into()),
-            am::ObjType::Table => Ok(map_to_js(&self.0, &obj)),
+        match self.0.object_type(&obj) {
+            Some(am::ObjType::Map) => Ok(map_to_js(&self.0, &obj)),
+            Some(am::ObjType::List) => Ok(list_to_js(&self.0, &obj)),
+            Some(am::ObjType::Text) => Ok(self.0.text(&obj)?.into()),
+            Some(am::ObjType::Table) => Ok(map_to_js(&self.0, &obj)),
+            None => Err(to_js_err(format!("invalid obj {}", obj))),
         }
     }
 

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -166,15 +166,16 @@ describe('Automerge', () => {
       let submap = doc.set_object(root, "letters", [])
       doc.insert(submap, 0, "a");
       doc.insert(submap, 0, "b");
-      assert.deepEqual(doc.toJS(), { letters: ["b", "a" ] })
+      assert.deepEqual(doc.materialize(), { letters: ["b", "a" ] })
       doc.push(submap, "c");
-      assert.deepEqual(doc.toJS(), { letters: ["b", "a", "c" ] })
+      assert.deepEqual(doc.materialize(), { letters: ["b", "a", "c" ] })
       doc.push(submap, 3, "timestamp");
-      assert.deepEqual(doc.toJS(), { letters: ["b", "a", "c", new Date(3) ] })
+      assert.deepEqual(doc.materialize(), { letters: ["b", "a", "c", new Date(3) ] })
       doc.splice(submap, 1, 1, ["d","e","f"]);
-      assert.deepEqual(doc.toJS(), { letters: ["b", "d", "e", "f", "c", new Date(3) ] })
+      assert.deepEqual(doc.materialize(), { letters: ["b", "d", "e", "f", "c", new Date(3) ] })
       doc.set(submap, 0, "z");
-      assert.deepEqual(doc.toJS(), { letters: ["z", "d", "e", "f", "c", new Date(3) ] })
+      assert.deepEqual(doc.materialize(), { letters: ["z", "d", "e", "f", "c", new Date(3) ] })
+      assert.deepEqual(doc.materialize(submap), ["z", "d", "e", "f", "c", new Date(3) ])
       assert.deepEqual(doc.length(submap),6)
 
       doc.free()
@@ -358,19 +359,30 @@ describe('Automerge', () => {
       doc4.free()
     })
 
+    it('paths can be used instead of objids', () => {
+      let doc = create("aaaa")
+      doc.set_object("_root","list",[{ foo: "bar"}, [1,2,3]])
+      assert.deepEqual(doc.materialize("/"), { list: [{ foo: "bar"}, [1,2,3]] }) 
+      assert.deepEqual(doc.materialize("/list"), [{ foo: "bar"}, [1,2,3]]) 
+      assert.deepEqual(doc.materialize("/list/0"), { foo: "bar"}) 
+    })
+
     it('recursive sets are possible', () => {
       let doc = create("aaaa")
       let l1 = doc.set_object("_root","list",[{ foo: "bar"}, [1,2,3]])
       let l2 = doc.insert_object(l1, 0, { zip: ["a", "b"] })
-      let l3 = doc.set_object("_root","info1","hello world") // 'text'
-      let l4 = doc.set("_root","info2","hello world")  // 'str'
-      let l5 = doc.set_object("_root","info3","hello world")
-      assert.deepEqual(doc.toJS(), {
+      let l3 = doc.set_object("_root","info1","hello world") // 'text' object
+               doc.set("_root","info2","hello world")  // 'str'
+      let l4 = doc.set_object("_root","info3","hello world")
+      assert.deepEqual(doc.materialize(), {
         "list": [ { zip: ["a", "b"] }, { foo: "bar"}, [ 1,2,3]],
-        "info1": "hello world".split(""),
+        "info1": "hello world",
         "info2": "hello world",
-        "info3": "hello world".split("")
+        "info3": "hello world",
       })
+      assert.deepEqual(doc.materialize(l2), { zip: ["a","b"] })
+      assert.deepEqual(doc.materialize(l1), [ { zip: ["a","b"] }, { foo: "bar" }, [ 1,2,3] ])
+      assert.deepEqual(doc.materialize(l4), "hello world")
       doc.free()
     })
 
@@ -446,6 +458,7 @@ describe('Automerge', () => {
       let doc = create()
       let s1 = initSyncState()
       let m1 = doc.generateSyncMessage(s1)
+      if (m1 === null) { throw new RangeError("message should not be null") }
       const message: DecodedSyncMessage = decodeSyncMessage(m1)
       assert.deepStrictEqual(message.heads, [])
       assert.deepStrictEqual(message.need, [])
@@ -459,6 +472,7 @@ describe('Automerge', () => {
         let n1 = create(), n2 = create()
         let s1 = initSyncState(), s2 = initSyncState()
         let m1 = n1.generateSyncMessage(s1)
+        if (m1 === null) { throw new RangeError("message should not be null") }
         n2.receiveSyncMessage(s2, m1)
         let m2 = n2.generateSyncMessage(s2)
         assert.deepStrictEqual(m2, null)
@@ -476,10 +490,11 @@ describe('Automerge', () => {
         n1.commit("",0)
       }
       n2.applyChanges(n1.getChanges([]))
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
 
       // generate a naive sync message
       let m1 = n1.generateSyncMessage(s1)
+      if (m1 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(s1.lastSentHeads, n1.getHeads())
 
       // heads are equal so this message should be null
@@ -499,9 +514,9 @@ describe('Automerge', () => {
         n1.commit("",0)
       }
 
-      assert.notDeepStrictEqual(n1.toJS(), n2.toJS())
+      assert.notDeepStrictEqual(n1.materialize(), n2.materialize())
       sync(n1, n2)
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should sync peers where one has commits the other does not', () => {
@@ -515,9 +530,9 @@ describe('Automerge', () => {
         n1.commit("",0)
       }
 
-      assert.notDeepStrictEqual(n1.toJS(), n2.toJS())
+      assert.notDeepStrictEqual(n1.materialize(), n2.materialize())
       sync(n1, n2)
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should work with prior sync state', () => {
@@ -538,9 +553,9 @@ describe('Automerge', () => {
         n1.commit("",0)
       }
 
-      assert.notDeepStrictEqual(n1.toJS(), n2.toJS())
+      assert.notDeepStrictEqual(n1.materialize(), n2.materialize())
       sync(n1, n2, s1, s2)
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should not generate messages once synced', () => {
@@ -560,21 +575,25 @@ describe('Automerge', () => {
 
       // n1 reports what it has
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
 
       // n2 receives that message and sends changes along with what it has
       n2.receiveSyncMessage(s2, message)
       message = n2.generateSyncMessage(s2)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 5)
       //assert.deepStrictEqual(patch, null) // no changes arrived
 
       // n1 receives the changes and replies with the changes it now knows n2 needs
       n1.receiveSyncMessage(s1, message)
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 5)
 
       // n2 applies the changes and sends confirmation ending the exchange
       n2.receiveSyncMessage(s2, message)
       message = n2.generateSyncMessage(s2)
+      if (message === null) { throw new RangeError("message should not be null") }
 
       // n1 receives the message and has nothing more to say
       n1.receiveSyncMessage(s1, message)
@@ -607,6 +626,8 @@ describe('Automerge', () => {
       let msg1to2, msg2to1
       msg1to2 = n1.generateSyncMessage(s1)
       msg2to1 = n2.generateSyncMessage(s2)
+      if (msg1to2 === null) { throw new RangeError("message should not be null") }
+      if (msg2to1 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 0)
       assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync.length, 0)
       assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 0)
@@ -619,25 +640,29 @@ describe('Automerge', () => {
       // now both reply with their local changes the other lacks
       // (standard warning that 1% of the time this will result in a "need" message)
       msg1to2 = n1.generateSyncMessage(s1)
+      if (msg1to2 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 5)
       msg2to1 = n2.generateSyncMessage(s2)
+      if (msg2to1 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 5)
 
       // both should now apply the changes and update the frontend
       n1.receiveSyncMessage(s1, msg2to1)
       assert.deepStrictEqual(n1.getMissingDeps(), [])
       //assert.notDeepStrictEqual(patch1, null)
-      assert.deepStrictEqual(n1.toJS(), {x: 4, y: 4})
+      assert.deepStrictEqual(n1.materialize(), {x: 4, y: 4})
 
       n2.receiveSyncMessage(s2, msg1to2)
       assert.deepStrictEqual(n2.getMissingDeps(), [])
       //assert.notDeepStrictEqual(patch2, null)
-      assert.deepStrictEqual(n2.toJS(), {x: 4, y: 4})
+      assert.deepStrictEqual(n2.materialize(), {x: 4, y: 4})
 
       // The response acknowledges the changes received, and sends no further changes
       msg1to2 = n1.generateSyncMessage(s1)
+      if (msg1to2 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 0)
       msg2to1 = n2.generateSyncMessage(s2)
+      if (msg2to1 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 0)
 
       // After receiving acknowledgements, their shared heads should be equal
@@ -657,6 +682,7 @@ describe('Automerge', () => {
       // If we make one more change, and start another sync, its lastSync should be updated
       n1.set("_root","x",5)
       msg1to2 = n1.generateSyncMessage(s1)
+      if (msg1to2 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync, [head1, head2].sort())
     })
 
@@ -672,17 +698,20 @@ describe('Automerge', () => {
       n1.push(items, "x")
       n1.commit("",0)
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)
 
       n1.push(items, "y")
       n1.commit("",0)
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)
 
       n1.push(items, "z")
       n1.commit("",0)
 
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)
     })
 
@@ -704,9 +733,9 @@ describe('Automerge', () => {
         n1.commit("",0)
       }
 
-      assert.notDeepStrictEqual(n1.toJS(), n2.toJS())
+      assert.notDeepStrictEqual(n1.materialize(), n2.materialize())
       sync(n1, n2, s1, s2)
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should work without prior sync state', () => {
@@ -736,10 +765,10 @@ describe('Automerge', () => {
         n2.commit("",0)
       }
 
-      assert.notDeepStrictEqual(n1.toJS(), n2.toJS())
+      assert.notDeepStrictEqual(n1.materialize(), n2.materialize())
       sync(n1, n2)
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should work with prior sync state', () => {
@@ -771,10 +800,10 @@ describe('Automerge', () => {
       s1 = decodeSyncState(encodeSyncState(s1))
       s2 = decodeSyncState(encodeSyncState(s2))
 
-      assert.notDeepStrictEqual(n1.toJS(), n2.toJS())
+      assert.notDeepStrictEqual(n1.materialize(), n2.materialize())
       sync(n1, n2, s1, s2)
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should ensure non-empty state after sync', () => {
@@ -822,7 +851,7 @@ describe('Automerge', () => {
 
       // everyone should be on the same page here
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
 
       // now make a few more changes, then attempt to sync the fully-up-to-date n1 with the confused r
       for (let i = 6; i < 9; i++) {
@@ -834,12 +863,12 @@ describe('Automerge', () => {
       rSyncState = decodeSyncState(encodeSyncState(rSyncState))
 
       assert.notDeepStrictEqual(n1.getHeads(), r.getHeads())
-      assert.notDeepStrictEqual(n1.toJS(), r.toJS())
-      assert.deepStrictEqual(n1.toJS(), {x: 8})
-      assert.deepStrictEqual(r.toJS(), {x: 2})
+      assert.notDeepStrictEqual(n1.materialize(), r.materialize())
+      assert.deepStrictEqual(n1.materialize(), {x: 8})
+      assert.deepStrictEqual(r.materialize(), {x: 2})
       sync(n1, r, s1, rSyncState)
       assert.deepStrictEqual(n1.getHeads(), r.getHeads())
-      assert.deepStrictEqual(n1.toJS(), r.toJS())
+      assert.deepStrictEqual(n1.materialize(), r.materialize())
     })
 
     it('should resync after one node experiences data loss without disconnecting', () => {
@@ -855,7 +884,7 @@ describe('Automerge', () => {
       sync(n1, n2, s1, s2)
 
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
 
       let n2AfterDataLoss = create('89abcdef')
 
@@ -863,7 +892,7 @@ describe('Automerge', () => {
       // decodeSyncState(encodeSyncState(s1)) in order to simulate data loss without disconnecting
       sync(n1, n2AfterDataLoss, s1, initSyncState())
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should handle changes concurrent to the last sync heads', () => {
@@ -898,7 +927,7 @@ describe('Automerge', () => {
       // Now sync n1 and n2. n3's change is concurrent to n1 and n2's last sync heads
       sync(n1, n2, s12, s21)
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should handle histories with lots of branching and merging', () => {
@@ -933,7 +962,7 @@ describe('Automerge', () => {
 
       sync(n1, n2, s1, s2)
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
-      assert.deepStrictEqual(n1.toJS(), n2.toJS())
+      assert.deepStrictEqual(n1.materialize(), n2.materialize())
     })
 
     it('should handle a false-positive head', () => {
@@ -1033,12 +1062,16 @@ describe('Automerge', () => {
         let m1, m2
         m1 = n1.generateSyncMessage(s1)
         m2 = n2.generateSyncMessage(s2)
+        if (m1 === null) { throw new RangeError("message should not be null") }
+        if (m2 === null) { throw new RangeError("message should not be null") }
         n1.receiveSyncMessage(s1, m2)
         n2.receiveSyncMessage(s2, m1)
 
         // Then n1 and n2 send each other their changes, except for the false positive
         m1 = n1.generateSyncMessage(s1)
         m2 = n2.generateSyncMessage(s2)
+        if (m1 === null) { throw new RangeError("message should not be null") }
+        if (m2 === null) { throw new RangeError("message should not be null") }
         n1.receiveSyncMessage(s1, m2)
         n2.receiveSyncMessage(s2, m1)
         assert.strictEqual(decodeSyncMessage(m1).changes.length, 2) // n1c1 and n1c2
@@ -1178,21 +1211,25 @@ describe('Automerge', () => {
 
       // n1 creates a sync message for n2 with an ill-fated bloom
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.strictEqual(decodeSyncMessage(message).changes.length, 0)
 
       // n2 receives it and DOESN'T send a change back
       n2.receiveSyncMessage(s2, message)
       message = n2.generateSyncMessage(s2)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.strictEqual(decodeSyncMessage(message).changes.length, 0)
 
       // n1 should now realize it's missing that change and request it explicitly
       n1.receiveSyncMessage(s1, message)
       message = n1.generateSyncMessage(s1)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(message).need, n2.getHeads())
 
       // n2 should fulfill that request
       n2.receiveSyncMessage(s2, message)
       message = n2.generateSyncMessage(s2)
+      if (message === null) { throw new RangeError("message should not be null") }
       assert.strictEqual(decodeSyncMessage(message).changes.length, 1)
 
       // n1 should apply the change and the two should now be in sync
@@ -1246,15 +1283,18 @@ describe('Automerge', () => {
         // changes {n1c1, n1c2, n2c1, n2c2} twice (those are the changes that both n1 and n2 have, but
         // that n3 does not have). We want to prevent this duplication.
         message1 = n1.generateSyncMessage(s13) // message from n1 to n3
+        if (message1 === null) { throw new RangeError("message should not be null") }
         assert.strictEqual(decodeSyncMessage(message1).changes.length, 0)
         n3.receiveSyncMessage(s31, message1)
         message3 = n3.generateSyncMessage(s31) // message from n3 to n1
+        if (message3 === null) { throw new RangeError("message should not be null") }
         assert.strictEqual(decodeSyncMessage(message3).changes.length, 3) // {n3c1, n3c2, n3c3}
         n1.receiveSyncMessage(s13, message3)
 
         // Copy the Bloom filter received from n1 into the message sent from n3 to n2. This Bloom
         // filter indicates what changes n3 is going to receive from n1.
         message3 = n3.generateSyncMessage(s32) // message from n3 to n2
+        if (message3 === null) { throw new RangeError("message should not be null") }
         const modifiedMessage = decodeSyncMessage(message3)
         modifiedMessage.have.push(decodeSyncMessage(message1).have[0])
         assert.strictEqual(modifiedMessage.changes.length, 0)
@@ -1262,11 +1302,13 @@ describe('Automerge', () => {
 
         // n2 replies to n3, sending only n2c3 (the one change that n2 has but n1 doesn't)
         message2 = n2.generateSyncMessage(s23)
+        if (message2 === null) { throw new RangeError("message should not be null") }
         assert.strictEqual(decodeSyncMessage(message2).changes.length, 1) // {n2c3}
         n3.receiveSyncMessage(s32, message2)
 
         // n1 replies to n3
         message1 = n1.generateSyncMessage(s13)
+        if (message1 === null) { throw new RangeError("message should not be null") }
         assert.strictEqual(decodeSyncMessage(message1).changes.length, 5) // {n1c1, n1c2, n1c3, n2c1, n2c2}
         n3.receiveSyncMessage(s31, message1)
         assert.deepStrictEqual(n3.getHeads(), [n1c3, n2c3, n3c3].sort())
@@ -1290,10 +1332,12 @@ describe('Automerge', () => {
         sync(n1, n2, s1, s2)
         s1.lastSentHeads = [] // force generateSyncMessage to return a message even though nothing changed
         message = n1.generateSyncMessage(s1)
+        if (message === null) { throw new RangeError("message should not be null") }
         const modMsg = decodeSyncMessage(message)
         modMsg.need = lastSync // re-request change 2
         n2.receiveSyncMessage(s2, encodeSyncMessage(modMsg))
         message = n2.generateSyncMessage(s2)
+        if (message === null) { throw new RangeError("message should not be null") }
         assert.strictEqual(decodeSyncMessage(message).changes.length, 1)
         assert.strictEqual(decodeChange(decodeSyncMessage(message).changes[0]).hash, lastSync[0])
       })
@@ -1309,6 +1353,7 @@ describe('Automerge', () => {
 
         n2.applyChanges(n1.getChanges([]))
         message = n1.generateSyncMessage(s1)
+        if (message === null) { throw new RangeError("message should not be null") }
         message = decodeSyncMessage(message)
         message.need = ['0000000000000000000000000000000000000000000000000000000000000000']
         message = encodeSyncMessage(message)
@@ -1356,8 +1401,10 @@ describe('Automerge', () => {
 
         // Now n1 initiates a sync with n2, and n2 replies with {c5, c6}. n2 does not send {c7, c8}
         msg = n1.generateSyncMessage(s1)
+        if (msg === null) { throw new RangeError("message should not be null") }
         n2.receiveSyncMessage(s2, msg)
         msg = n2.generateSyncMessage(s2)
+        if (msg === null) { throw new RangeError("message should not be null") }
         decodedMsg = decodeSyncMessage(msg)
         decodedMsg.changes = [change5, change6]
         msg = encodeSyncMessage(decodedMsg)
@@ -1371,6 +1418,7 @@ describe('Automerge', () => {
 
         // n1 replies, confirming the receipt of {c5, c6} and requesting the remaining changes
         msg = n1.generateSyncMessage(s1)
+        if (msg === null) { throw new RangeError("message should not be null") }
         n2.receiveSyncMessage(s2, msg)
         assert.deepStrictEqual(decodeSyncMessage(msg).need, [c8])
         assert.deepStrictEqual(decodeSyncMessage(msg).have[0].lastSync, [c2, c6].sort())
@@ -1379,6 +1427,7 @@ describe('Automerge', () => {
 
         // n2 sends the remaining changes {c7, c8}
         msg = n2.generateSyncMessage(s2)
+        if (msg === null) { throw new RangeError("message should not be null") }
         n1.receiveSyncMessage(s1, msg)
         assert.strictEqual(decodeSyncMessage(msg).changes.length, 2)
         assert.deepStrictEqual(s1.sharedHeads, [c2, c8].sort())

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -298,7 +298,7 @@ impl Transactable for AutoCommit {
         self.doc.length_at(obj, heads)
     }
 
-    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Option<ObjType> {
         self.doc.object_type(obj)
     }
 

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -298,6 +298,10 @@ impl Transactable for AutoCommit {
         self.doc.length_at(obj, heads)
     }
 
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
+        self.doc.object_type(obj)
+    }
+
     // set(obj, prop, value) - value can be scalar or objtype
     // del(obj, prop)
     // inc(obj, prop, value)

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -236,6 +236,11 @@ impl Automerge {
         }
     }
 
+    pub fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
+        let obj = self.exid_to_obj(obj.as_ref())?;
+        self.ops.object_type(&obj).ok_or(AutomergeError::Fail)
+    }
+
     pub(crate) fn exid_to_obj(&self, id: &ExId) -> Result<ObjId, AutomergeError> {
         match id {
             ExId::Root => Ok(ObjId::root()),
@@ -806,7 +811,7 @@ impl Automerge {
                 .m
                 .actors
                 .lookup(&actor)
-                .ok_or_else(|| AutomergeError::InvalidOpId(s.to_owned()))?;
+                .ok_or_else(|| AutomergeError::InvalidActor(actor.to_hex_string()))?;
             Ok(ExId::Id(
                 counter,
                 self.ops.m.actors.cache[actor].clone(),

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -811,7 +811,7 @@ impl Automerge {
                 .m
                 .actors
                 .lookup(&actor)
-                .ok_or_else(|| AutomergeError::InvalidActor(actor.to_hex_string()))?;
+                .ok_or_else(|| AutomergeError::ForeignObjId(s.to_owned()))?;
             Ok(ExId::Id(
                 counter,
                 self.ops.m.actors.cache[actor].clone(),

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -236,9 +236,9 @@ impl Automerge {
         }
     }
 
-    pub fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
-        let obj = self.exid_to_obj(obj.as_ref())?;
-        self.ops.object_type(&obj).ok_or(AutomergeError::Fail)
+    pub fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Option<ObjType> {
+        let obj = self.exid_to_obj(obj.as_ref()).ok()?;
+        self.ops.object_type(&obj)
     }
 
     pub(crate) fn exid_to_obj(&self, id: &ExId) -> Result<ObjId, AutomergeError> {

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 pub enum AutomergeError {
     #[error("invalid opid format `{0}`")]
     InvalidOpId(String),
+    #[error("invalid actor `{0}`")]
+    InvalidActor(String),
     #[error("there was an ecoding problem")]
     Encoding,
     #[error("there was a decoding problem")]

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 pub enum AutomergeError {
     #[error("invalid opid format `{0}`")]
     InvalidOpId(String),
-    #[error("invalid actor `{0}`")]
-    InvalidActor(String),
+    #[error("obj id not from this document `{0}`")]
+    ForeignObjId(String),
     #[error("there was an ecoding problem")]
     Encoding,
     #[error("there was a decoding problem")]

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -187,6 +187,10 @@ impl<'a> Transactable for Transaction<'a> {
         self.doc.length_at(obj, heads)
     }
 
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
+        self.doc.object_type(obj)
+    }
+
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
         self.doc.text(obj)
     }

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -187,7 +187,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.doc.length_at(obj, heads)
     }
 
-    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Option<ObjType> {
         self.doc.object_type(obj)
     }
 

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -104,6 +104,9 @@ pub trait Transactable {
     /// Get the length of the given object at a point in history.
     fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize;
 
+    /// Get type for object
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError>;
+
     /// Get the string that this text object represents.
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError>;
 

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -105,7 +105,7 @@ pub trait Transactable {
     fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize;
 
     /// Get type for object
-    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError>;
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Option<ObjType>;
 
     /// Get the string that this text object represents.
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError>;


### PR DESCRIPTION
New api features of the wasm api.  Paths can be used instead of objid's. Also a materialize call has been added that recursively constructs a json object from a given path/objid.
