### PR TITLE
Stop exposing apply_change

### DIFF
--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -149,11 +149,6 @@ impl AutoCommit {
         self.doc.apply_changes(changes)
     }
 
-    pub fn apply_change(&mut self, change: Change) {
-        self.ensure_transaction_closed();
-        self.doc.apply_change(change)
-    }
-
     /// Takes all the changes in `other` which are not in `self` and applies them
     pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ChangeHash>, AutomergeError> {
         self.ensure_transaction_closed();

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -439,7 +439,7 @@ impl Automerge {
     }
 
     /// Apply a single change to this document.
-    pub fn apply_change(&mut self, change: Change) {
+    fn apply_change(&mut self, change: Change) {
         let ops = self.import_ops(&change, self.history.len());
         self.update_history(change);
         for op in ops {


### PR DESCRIPTION
It doesn't do checks or raise errors so shouldn't really be exposed.