### PR TITLE
Remove obj and change from Op

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -445,7 +445,7 @@ impl Automerge {
 
     /// Apply a single change to this document.
     fn apply_change(&mut self, change: Change) {
-        let ops = self.import_ops(&change, self.history.len());
+        let ops = self.import_ops(&change);
         self.update_history(change);
         for (obj, op) in ops {
             self.insert_op(&obj, op);
@@ -470,7 +470,7 @@ impl Automerge {
         None
     }
 
-    fn import_ops(&mut self, change: &Change, change_id: usize) -> Vec<(ObjId, Op)> {
+    fn import_ops(&mut self, change: &Change) -> Vec<(ObjId, Op)> {
         change
             .iter_ops()
             .enumerate()
@@ -496,7 +496,6 @@ impl Automerge {
                 (
                     obj,
                     Op {
-                        change: change_id,
                         id,
                         action: c.action,
                         key,

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -164,15 +164,15 @@ impl Automerge {
         f
     }
 
-    fn insert_op(&mut self, op: Op) -> Op {
-        let q = self.ops.search(op.obj, query::SeekOp::new(&op));
+    fn insert_op(&mut self, obj: &ObjId, op: Op) -> Op {
+        let q = self.ops.search(obj, query::SeekOp::new(&op));
 
         for i in q.succ {
-            self.ops.replace(op.obj, i, |old_op| old_op.add_succ(&op));
+            self.ops.replace(obj, i, |old_op| old_op.add_succ(&op));
         }
 
         if !op.is_del() {
-            self.ops.insert(q.pos, op.clone());
+            self.ops.insert(q.pos, obj, op.clone());
         }
         op
     }
@@ -211,7 +211,7 @@ impl Automerge {
             match self.ops.object_type(&inner_obj) {
                 Some(ObjType::Map) | Some(ObjType::Table) => self.keys(obj).count(),
                 Some(ObjType::List) | Some(ObjType::Text) => {
-                    self.ops.search(inner_obj, query::Len::new()).len
+                    self.ops.search(&inner_obj, query::Len::new()).len
                 }
                 None => 0,
             }
@@ -227,7 +227,7 @@ impl Automerge {
             match self.ops.object_type(&inner_obj) {
                 Some(ObjType::Map) | Some(ObjType::Table) => self.keys_at(obj, heads).count(),
                 Some(ObjType::List) | Some(ObjType::Text) => {
-                    self.ops.search(inner_obj, query::LenAt::new(clock)).len
+                    self.ops.search(&inner_obj, query::LenAt::new(clock)).len
                 }
                 None => 0,
             }
@@ -270,7 +270,7 @@ impl Automerge {
     /// Get the string represented by the given text object.
     pub fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let query = self.ops.search(obj, query::ListVals::new());
+        let query = self.ops.search(&obj, query::ListVals::new());
         let mut buffer = String::new();
         for q in &query.ops {
             if let OpType::Set(ScalarValue::Str(s)) = &q.action {
@@ -288,7 +288,7 @@ impl Automerge {
     ) -> Result<String, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
         let clock = self.clock_at(heads);
-        let query = self.ops.search(obj, query::ListValsAt::new(clock));
+        let query = self.ops.search(&obj, query::ListValsAt::new(clock));
         let mut buffer = String::new();
         for q in &query.ops {
             if let OpType::Set(ScalarValue::Str(s)) = &q.action {
@@ -338,7 +338,7 @@ impl Automerge {
                 let prop = self.ops.m.props.lookup(&p);
                 if let Some(p) = prop {
                     self.ops
-                        .search(obj, query::Prop::new(p))
+                        .search(&obj, query::Prop::new(p))
                         .ops
                         .into_iter()
                         .map(|o| (o.value(), self.id_to_exid(o.id)))
@@ -349,7 +349,7 @@ impl Automerge {
             }
             Prop::Seq(n) => self
                 .ops
-                .search(obj, query::Nth::new(n))
+                .search(&obj, query::Nth::new(n))
                 .ops
                 .into_iter()
                 .map(|o| (o.value(), self.id_to_exid(o.id)))
@@ -373,7 +373,7 @@ impl Automerge {
                 let prop = self.ops.m.props.lookup(&p);
                 if let Some(p) = prop {
                     self.ops
-                        .search(obj, query::PropAt::new(p, clock))
+                        .search(&obj, query::PropAt::new(p, clock))
                         .ops
                         .into_iter()
                         .map(|o| (o.value(), self.id_to_exid(o.id)))
@@ -384,7 +384,7 @@ impl Automerge {
             }
             Prop::Seq(n) => self
                 .ops
-                .search(obj, query::NthAt::new(n, clock))
+                .search(&obj, query::NthAt::new(n, clock))
                 .ops
                 .into_iter()
                 .map(|o| (o.value(), self.id_to_exid(o.id)))
@@ -447,8 +447,8 @@ impl Automerge {
     fn apply_change(&mut self, change: Change) {
         let ops = self.import_ops(&change, self.history.len());
         self.update_history(change);
-        for op in ops {
-            self.insert_op(op);
+        for (obj, op) in ops {
+            self.insert_op(&obj, op);
         }
     }
 
@@ -470,7 +470,7 @@ impl Automerge {
         None
     }
 
-    fn import_ops(&mut self, change: &Change, change_id: usize) -> Vec<Op> {
+    fn import_ops(&mut self, change: &Change, change_id: usize) -> Vec<(ObjId, Op)> {
         change
             .iter_ops()
             .enumerate()
@@ -493,16 +493,18 @@ impl Automerge {
                         Key::Seq(ElemId(OpId(i.0, self.ops.m.actors.cache(i.1.clone()))))
                     }
                 };
-                Op {
-                    change: change_id,
-                    id,
-                    action: c.action,
+                (
                     obj,
-                    key,
-                    succ: Default::default(),
-                    pred,
-                    insert: c.insert,
-                }
+                    Op {
+                        change: change_id,
+                        id,
+                        action: c.action,
+                        key,
+                        succ: Default::default(),
+                        pred,
+                        insert: c.insert,
+                    },
+                )
             })
             .collect()
     }
@@ -838,21 +840,21 @@ impl Automerge {
             "pred",
             "succ"
         );
-        for i in self.ops.iter() {
-            let id = self.to_string(i.id);
-            let obj = self.to_string(i.obj);
-            let key = match i.key {
+        for (obj, op) in self.ops.iter() {
+            let id = self.to_string(op.id);
+            let obj = self.to_string(obj);
+            let key = match op.key {
                 Key::Map(n) => self.ops.m.props[n].clone(),
                 Key::Seq(n) => self.to_string(n),
             };
-            let value: String = match &i.action {
+            let value: String = match &op.action {
                 OpType::Set(value) => format!("{}", value),
                 OpType::Make(obj) => format!("make({})", obj),
                 OpType::Inc(obj) => format!("inc({})", obj),
                 OpType::Del => format!("del{}", 0),
             };
-            let pred: Vec<_> = i.pred.iter().map(|id| self.to_string(*id)).collect();
-            let succ: Vec<_> = i.succ.iter().map(|id| self.to_string(*id)).collect();
+            let pred: Vec<_> = op.pred.iter().map(|id| self.to_string(*id)).collect();
+            let succ: Vec<_> = op.succ.iter().map(|id| self.to_string(*id)).collect();
             log!(
                 "  {:12} {:12} {:12} {} {:?} {:?}",
                 id,

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -1019,7 +1019,7 @@ impl DocOpEncoder {
         props: &'b [String],
     ) -> (Vec<u8>, Vec<u8>)
     where
-        I: IntoIterator<Item = &'c Op>,
+        I: IntoIterator<Item = (&'c ObjId, &'c Op)>,
     {
         let mut e = Self::new();
         e.encode(ops, actors, props);
@@ -1041,12 +1041,12 @@ impl DocOpEncoder {
 
     fn encode<'a, I>(&mut self, ops: I, actors: &[usize], props: &[String])
     where
-        I: IntoIterator<Item = &'a Op>,
+        I: IntoIterator<Item = (&'a ObjId, &'a Op)>,
     {
-        for op in ops {
+        for (obj, op) in ops {
             self.actor.append_value(actors[op.id.actor()]);
             self.ctr.append_value(op.id.counter());
-            self.obj.append(&op.obj, actors);
+            self.obj.append(obj, actors);
             self.key.append(op.key, actors, props);
             self.insert.append(op.insert);
             self.succ.append(&op.succ, actors);

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -59,31 +59,31 @@ impl<const B: usize> OpSetInternal<B> {
         }
     }
 
-    pub fn search<Q>(&self, obj: ObjId, query: Q) -> Q
+    pub fn search<Q>(&self, obj: &ObjId, query: Q) -> Q
     where
         Q: TreeQuery<B>,
     {
-        if let Some((_typ, tree)) = self.trees.get(&obj) {
+        if let Some((_typ, tree)) = self.trees.get(obj) {
             tree.search(query, &self.m)
         } else {
             query
         }
     }
 
-    pub fn replace<F>(&mut self, obj: ObjId, index: usize, f: F) -> Option<Op>
+    pub fn replace<F>(&mut self, obj: &ObjId, index: usize, f: F) -> Option<Op>
     where
         F: FnMut(&mut Op),
     {
-        if let Some((_typ, tree)) = self.trees.get_mut(&obj) {
+        if let Some((_typ, tree)) = self.trees.get_mut(obj) {
             tree.replace(index, f)
         } else {
             None
         }
     }
 
-    pub fn remove(&mut self, obj: ObjId, index: usize) -> Op {
+    pub fn remove(&mut self, obj: &ObjId, index: usize) -> Op {
         // this happens on rollback - be sure to go back to the old state
-        let (_typ, tree) = self.trees.get_mut(&obj).unwrap();
+        let (_typ, tree) = self.trees.get_mut(obj).unwrap();
         self.length -= 1;
         let op = tree.remove(index);
         if let OpType::Make(_) = &op.action {
@@ -96,13 +96,13 @@ impl<const B: usize> OpSetInternal<B> {
         self.length
     }
 
-    pub fn insert(&mut self, index: usize, element: Op) {
+    pub fn insert(&mut self, index: usize, obj: &ObjId, element: Op) {
         if let OpType::Make(typ) = element.action {
             self.trees
                 .insert(element.id.into(), (typ, Default::default()));
         }
 
-        if let Some((_typ, tree)) = self.trees.get_mut(&element.obj) {
+        if let Some((_typ, tree)) = self.trees.get_mut(obj) {
             //let tree = self.trees.get_mut(&element.obj).unwrap();
             tree.insert(index, element);
             self.length += 1;
@@ -129,7 +129,7 @@ impl<const B: usize> Default for OpSetInternal<B> {
 }
 
 impl<'a, const B: usize> IntoIterator for &'a OpSetInternal<B> {
-    type Item = &'a Op;
+    type Item = (&'a ObjId, &'a Op);
 
     type IntoIter = Iter<'a, B>;
 
@@ -153,13 +153,13 @@ pub(crate) struct Iter<'a, const B: usize> {
 }
 
 impl<'a, const B: usize> Iterator for Iter<'a, B> {
-    type Item = &'a Op;
+    type Item = (&'a ObjId, &'a Op);
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut result = None;
         for obj in self.objs.iter().skip(self.index) {
             let (_typ, tree) = self.inner.trees.get(obj)?;
-            result = tree.get(self.sub_index);
+            result = tree.get(self.sub_index).map(|op| (*obj, op));
             if result.is_some() {
                 self.sub_index += 1;
                 break;

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -640,13 +640,11 @@ mod tests {
 
     use super::*;
 
-    fn op(n: usize) -> Op {
+    fn op() -> Op {
         let zero = OpId(0, 0);
         Op {
-            change: n,
             id: zero,
             action: amp::OpType::Set(0.into()),
-            obj: zero.into(),
             key: zero.into(),
             succ: vec![],
             pred: vec![],
@@ -658,13 +656,13 @@ mod tests {
     fn insert() {
         let mut t = OpTree::new();
 
-        t.insert(0, op(1));
-        t.insert(1, op(1));
-        t.insert(0, op(1));
-        t.insert(0, op(1));
-        t.insert(0, op(1));
-        t.insert(3, op(1));
-        t.insert(4, op(1));
+        t.insert(0, op());
+        t.insert(1, op());
+        t.insert(0, op());
+        t.insert(0, op());
+        t.insert(0, op());
+        t.insert(3, op());
+        t.insert(4, op());
     }
 
     #[test]
@@ -672,7 +670,7 @@ mod tests {
         let mut t = OpTree::new();
 
         for i in 0..100 {
-            t.insert(i % 2, op(i));
+            t.insert(i % 2, op());
         }
     }
 
@@ -682,8 +680,8 @@ mod tests {
         let mut v = Vec::new();
 
         for i in 0..100 {
-            t.insert(i % 3, op(i));
-            v.insert(i % 3, op(i));
+            t.insert(i % 3, op());
+            v.insert(i % 3, op());
 
             assert_eq!(v, t.iter().cloned().collect::<Vec<_>>())
         }

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -186,7 +186,6 @@ impl TransactionInner {
         let is_make = matches!(&action, OpType::Make(_));
 
         let op = Op {
-            change: doc.history.len(),
             id,
             action,
             key,
@@ -247,7 +246,6 @@ impl TransactionInner {
         let pred = query.ops.iter().map(|op| op.id).collect();
 
         let op = Op {
-            change: doc.history.len(),
             id,
             action,
             key: Key::Map(prop),
@@ -285,7 +283,6 @@ impl TransactionInner {
         let is_make = matches!(&action, OpType::Make(_));
 
         let op = Op {
-            change: doc.history.len(),
             id,
             action,
             key,

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -15,7 +15,7 @@ pub struct TransactionInner {
     pub(crate) extra_bytes: Vec<u8>,
     pub(crate) hash: Option<ChangeHash>,
     pub(crate) deps: Vec<ChangeHash>,
-    pub(crate) operations: Vec<Op>,
+    pub(crate) operations: Vec<(ObjId, Op)>,
 }
 
 impl TransactionInner {
@@ -57,14 +57,14 @@ impl TransactionInner {
 
         let num = self.operations.len();
         // remove in reverse order so sets are removed before makes etc...
-        for op in self.operations.iter().rev() {
+        for (obj, op) in self.operations.iter().rev() {
             for pred_id in &op.pred {
-                if let Some(p) = doc.ops.search(op.obj, OpIdSearch::new(*pred_id)).index() {
-                    doc.ops.replace(op.obj, p, |o| o.remove_succ(op));
+                if let Some(p) = doc.ops.search(obj, OpIdSearch::new(*pred_id)).index() {
+                    doc.ops.replace(obj, p, |o| o.remove_succ(op));
                 }
             }
-            if let Some(pos) = doc.ops.search(op.obj, OpIdSearch::new(op.id)).index() {
-                doc.ops.remove(op.obj, pos);
+            if let Some(pos) = doc.ops.search(obj, OpIdSearch::new(op.id)).index() {
+                doc.ops.remove(obj, pos);
             }
         }
         num
@@ -125,18 +125,25 @@ impl TransactionInner {
         OpId(self.start_op + self.operations.len() as u64, self.actor)
     }
 
-    fn insert_local_op(&mut self, doc: &mut Automerge, op: Op, pos: usize, succ_pos: &[usize]) {
+    fn insert_local_op(
+        &mut self,
+        doc: &mut Automerge,
+        op: Op,
+        pos: usize,
+        obj: ObjId,
+        succ_pos: &[usize],
+    ) {
         for succ in succ_pos {
-            doc.ops.replace(op.obj, *succ, |old_op| {
+            doc.ops.replace(&obj, *succ, |old_op| {
                 old_op.add_succ(&op);
             });
         }
 
         if !op.is_del() {
-            doc.ops.insert(pos, op.clone());
+            doc.ops.insert(pos, &obj, op.clone());
         }
 
-        self.operations.push(op);
+        self.operations.push((obj, op));
     }
 
     pub fn insert<V: Into<ScalarValue>>(
@@ -173,7 +180,7 @@ impl TransactionInner {
     ) -> Result<Option<OpId>, AutomergeError> {
         let id = self.next_id();
 
-        let query = doc.ops.search(obj, query::InsertNth::new(index));
+        let query = doc.ops.search(&obj, query::InsertNth::new(index));
 
         let key = query.key()?;
         let is_make = matches!(&action, OpType::Make(_));
@@ -182,15 +189,14 @@ impl TransactionInner {
             change: doc.history.len(),
             id,
             action,
-            obj,
             key,
             succ: Default::default(),
             pred: Default::default(),
             insert: true,
         };
 
-        doc.ops.insert(query.pos(), op.clone());
-        self.operations.push(op);
+        doc.ops.insert(query.pos(), &obj, op.clone());
+        self.operations.push((obj, op));
 
         if is_make {
             Ok(Some(id))
@@ -225,7 +231,7 @@ impl TransactionInner {
 
         let id = self.next_id();
         let prop = doc.ops.m.props.cache(prop);
-        let query = doc.ops.search(obj, query::Prop::new(prop));
+        let query = doc.ops.search(&obj, query::Prop::new(prop));
 
         // no key present to delete
         if query.ops.is_empty() && action == OpType::Del {
@@ -244,14 +250,13 @@ impl TransactionInner {
             change: doc.history.len(),
             id,
             action,
-            obj,
             key: Key::Map(prop),
             succ: Default::default(),
             pred,
             insert: false,
         };
 
-        self.insert_local_op(doc, op, query.pos, &query.ops_pos);
+        self.insert_local_op(doc, op, query.pos, obj, &query.ops_pos);
 
         if is_make {
             Ok(Some(id))
@@ -267,7 +272,7 @@ impl TransactionInner {
         index: usize,
         action: OpType,
     ) -> Result<Option<OpId>, AutomergeError> {
-        let query = doc.ops.search(obj, query::Nth::new(index));
+        let query = doc.ops.search(&obj, query::Nth::new(index));
 
         let id = self.next_id();
         let pred = query.ops.iter().map(|op| op.id).collect();
@@ -283,14 +288,13 @@ impl TransactionInner {
             change: doc.history.len(),
             id,
             action,
-            obj,
             key,
             succ: Default::default(),
             pred,
             insert: false,
         };
 
-        self.insert_local_op(doc, op, query.pos, &query.ops_pos);
+        self.insert_local_op(doc, op, query.pos, obj, &query.ops_pos);
 
         if is_make {
             Ok(Some(id))

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -342,7 +342,6 @@ pub(crate) struct Op {
     pub change: usize,
     pub id: OpId,
     pub action: OpType,
-    pub obj: ObjId,
     pub key: Key,
     pub succ: Vec<OpId>,
     pub pred: Vec<OpId>,

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -339,7 +339,6 @@ pub(crate) struct ElemId(pub OpId);
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Op {
-    pub change: usize,
     pub id: OpId,
     pub action: OpType,
     pub key: Key,


### PR DESCRIPTION
The `Op`s live in an `OpTree` which is one per object. The object id is already stored with the tree so we don't need to keep it in the Op too as it takes up space.

The `change` field was never actually read so seemed redundant.