### PR TITLE
Add `parent_object` and `path_to_object` functions

### DIFF
--- a/automerge/examples/watch.rs
+++ b/automerge/examples/watch.rs
@@ -10,25 +10,25 @@ fn main() {
 
     // a simple scalar change in the root object
     let mut tx = doc.transaction();
-    tx.set(ROOT, "hello", "world").unwrap();
+    tx.put(ROOT, "hello", "world").unwrap();
     let heads2 = tx.commit();
     get_changes(&heads1, &doc);
 
     let mut tx = doc.transaction();
     let map = tx
-        .set_object(ROOT, "my new map", automerge::ObjType::Map)
+        .put_object(ROOT, "my new map", automerge::ObjType::Map)
         .unwrap();
-    tx.set(&map, "blah", 1).unwrap();
-    tx.set(&map, "blah2", 1).unwrap();
+    tx.put(&map, "blah", 1).unwrap();
+    tx.put(&map, "blah2", 1).unwrap();
     let list = tx
-        .set_object(&map, "my list", automerge::ObjType::List)
+        .put_object(&map, "my list", automerge::ObjType::List)
         .unwrap();
     // tx.insert(&list, 0, "yay").unwrap();
     let m = tx.insert_object(&list, 0, automerge::ObjType::Map).unwrap();
-    tx.set(&m, "hi", 2).unwrap();
+    tx.put(&m, "hi", 2).unwrap();
     tx.insert(&list, 1, "woo").unwrap();
     let m = tx.insert_object(&list, 2, automerge::ObjType::Map).unwrap();
-    tx.set(&m, "hi", 2).unwrap();
+    tx.put(&m, "hi", 2).unwrap();
     let _heads3 = tx.commit();
     get_changes(&[heads2], &doc);
 

--- a/automerge/examples/watch.rs
+++ b/automerge/examples/watch.rs
@@ -21,9 +21,14 @@ fn main() {
     tx.set(&map, "blah", 1).unwrap();
     tx.set(&map, "blah2", 1).unwrap();
     let list = tx
-        .set_object(&map, "blaho", automerge::ObjType::List)
+        .set_object(&map, "my list", automerge::ObjType::List)
         .unwrap();
-    tx.insert(list, 0, "yay").unwrap();
+    // tx.insert(&list, 0, "yay").unwrap();
+    let m = tx.insert_object(&list, 0, automerge::ObjType::Map).unwrap();
+    tx.set(&m, "hi", 2).unwrap();
+    tx.insert(&list, 1, "woo").unwrap();
+    let m = tx.insert_object(&list, 2, automerge::ObjType::Map).unwrap();
+    tx.set(&m, "hi", 2).unwrap();
     let _heads3 = tx.commit();
     get_changes(&[heads2], &doc);
 
@@ -40,9 +45,11 @@ fn get_changes(heads: &[ChangeHash], doc: &Automerge) {
             // get the object that it changed
             let obj = doc.import(&op.obj.to_string()).unwrap();
             // get the prop too
-            let prop = op.key;
+            let prop = format!("{:?}", op.key);
+            println!("{:?}", op);
             println!(
-                "changed {:?} in obj {:?}, path {:?}",
+                "{} {:?} in obj {:?}, object path {:?}",
+                if op.insert { "inserted" } else { "changed" },
                 prop,
                 obj,
                 get_path_for_obj(doc, &obj)
@@ -55,7 +62,7 @@ fn get_path_for_obj(doc: &Automerge, obj: &ObjId) -> String {
     let mut s = String::new();
     let mut obj = obj.clone();
     while let Some((parent, key)) = doc.parent_object(obj) {
-        s = format!("{:?}/{}", key, s);
+        s = format!("{}/{}", key, s);
         obj = parent;
     }
     s

--- a/automerge/examples/watch.rs
+++ b/automerge/examples/watch.rs
@@ -1,0 +1,62 @@
+use automerge::transaction::Transactable;
+use automerge::Automerge;
+use automerge::ChangeHash;
+use automerge::ObjId;
+use automerge::ROOT;
+
+fn main() {
+    let mut doc = Automerge::new();
+    let heads1 = doc.get_heads();
+
+    // a simple scalar change in the root object
+    let mut tx = doc.transaction();
+    tx.set(ROOT, "hello", "world").unwrap();
+    let heads2 = tx.commit();
+    get_changes(&heads1, &doc);
+
+    let mut tx = doc.transaction();
+    let map = tx
+        .set_object(ROOT, "my new map", automerge::ObjType::Map)
+        .unwrap();
+    tx.set(&map, "blah", 1).unwrap();
+    tx.set(&map, "blah2", 1).unwrap();
+    let list = tx
+        .set_object(&map, "blaho", automerge::ObjType::List)
+        .unwrap();
+    tx.insert(list, 0, "yay").unwrap();
+    let _heads3 = tx.commit();
+    get_changes(&[heads2], &doc);
+
+    // now if a peer were to send us a change that added a key in map we wouldn't know the path to
+    // the change or we might not have a reference to the map objid.
+}
+
+fn get_changes(heads: &[ChangeHash], doc: &Automerge) {
+    let changes = doc.get_changes(heads);
+    // changes should be in topological order
+    for change in changes {
+        let change = change.decode();
+        for op in change.operations {
+            // get the object that it changed
+            let obj = doc.import(&op.obj.to_string()).unwrap();
+            // get the prop too
+            let prop = op.key;
+            println!(
+                "changed {:?} in obj {:?}, path {:?}",
+                prop,
+                obj,
+                get_path_for_obj(doc, &obj)
+            );
+        }
+    }
+}
+
+fn get_path_for_obj(doc: &Automerge, obj: &ObjId) -> String {
+    let mut s = String::new();
+    let mut obj = obj.clone();
+    while let Some((parent, key)) = doc.parent_object(obj) {
+        s = format!("{:?}/{}", key, s);
+        obj = parent;
+    }
+    s
+}

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -392,4 +392,8 @@ impl Transactable for AutoCommit {
     fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
         self.doc.parent_object(obj)
     }
+
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Vec<(ExId, Prop)> {
+        self.doc.path_to_object(obj)
+    }
 }

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -388,4 +388,8 @@ impl Transactable for AutoCommit {
     ) -> Result<Vec<(Value, ExId)>, AutomergeError> {
         self.doc.values_at(obj, prop, heads)
     }
+
+    fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
+        self.doc.parent_object(obj)
+    }
 }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -295,7 +295,7 @@ impl Automerge {
             } else {
                 self.ops
                     .parent_object(&obj)
-                    .map(|(id, key)| (self.id_to_exid(id.0), self.export_key(obj, key)))
+                    .map(|(id, key)| (self.id_to_exid(id.0), self.export_key(id, key)))
             }
         } else {
             None
@@ -308,7 +308,7 @@ impl Automerge {
             Key::Seq(opid) => {
                 let i = self
                     .ops
-                    .search(&obj, query::OpIdSearch::new(opid.0))
+                    .search(&obj, query::ElemIdPos::new(opid))
                     .index()
                     .unwrap();
                 Prop::Seq(i)

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -287,6 +287,8 @@ impl Automerge {
     // PropAt::()
     // NthAt::()
 
+    /// Get the object id of the object that contains this object and the prop that this object is
+    /// at in that object.
     pub fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
         if let Ok(obj) = self.exid_to_obj(obj.as_ref()) {
             if obj == ObjId::root() {
@@ -302,6 +304,7 @@ impl Automerge {
         }
     }
 
+    /// Export a key to a prop.
     fn export_key(&self, obj: ObjId, key: Key) -> Prop {
         match key {
             Key::Map(m) => Prop::Map(self.ops.m.props.get(m).into()),

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1680,4 +1680,17 @@ mod tests {
         assert!(doc1.value(&list, 1).unwrap().is_none());
         assert!(doc2.value(&list, 1).unwrap().is_none());
     }
+
+    #[test]
+    fn get_parent_objects() {
+        let mut doc = AutoCommit::new();
+        let map = doc.put_object(ROOT, "a", ObjType::Map).unwrap();
+        let list = doc.insert_object(&map, 0, ObjType::List).unwrap();
+        doc.insert(&list, 0, 2).unwrap();
+        let text = doc.put_object(&list, 0, ObjType::Text).unwrap();
+
+        assert_eq!(doc.parent_object(&map), Some((ROOT, Prop::Map("a".into()))));
+        assert_eq!(doc.parent_object(&list), Some((map, Prop::Seq(0))));
+        assert_eq!(doc.parent_object(&text), Some((list, Prop::Seq(0))));
+    }
 }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -308,7 +308,7 @@ impl Automerge {
             Key::Seq(opid) => {
                 let i = self
                     .ops
-                    .search(obj, query::OpIdSearch::new(opid.0))
+                    .search(&obj, query::OpIdSearch::new(opid.0))
                     .index()
                     .unwrap();
                 Prop::Seq(i)

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -164,7 +164,7 @@ impl<'a> Iterator for Iter<'a> {
         let mut result = None;
         for obj in self.objs.iter().skip(self.index) {
             let tree = self.inner.trees.get(obj)?;
-            result = tree.internal.get(self.sub_index);
+            result = tree.internal.get(self.sub_index).map(|op| (*obj, op));
             if result.is_some() {
                 self.sub_index += 1;
                 break;

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -1,7 +1,7 @@
 use crate::clock::Clock;
 use crate::indexed_cache::IndexedCache;
-use crate::op_tree::OpTreeInternal;
-use crate::query::{self, TreeQuery};
+use crate::op_tree::OpTree;
+use crate::query::{self, OpIdSearch, TreeQuery};
 use crate::types::{ActorId, Key, ObjId, Op, OpId, OpType};
 use crate::ObjType;
 use fxhash::FxBuildHasher;
@@ -13,7 +13,7 @@ pub(crate) type OpSet = OpSetInternal;
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct OpSetInternal {
     /// The map of objects to their type and ops.
-    trees: HashMap<ObjId, (ObjType, OpTreeInternal), FxBuildHasher>,
+    trees: HashMap<ObjId, OpTree, FxBuildHasher>,
     /// The number of operations in the opset.
     length: usize,
     /// Metadata about the operations in this opset.
@@ -23,7 +23,7 @@ pub(crate) struct OpSetInternal {
 impl OpSetInternal {
     pub fn new() -> Self {
         let mut trees: HashMap<_, _, _> = Default::default();
-        trees.insert(ObjId::root(), (ObjType::Map, Default::default()));
+        trees.insert(ObjId::root(), OpTree::new());
         OpSetInternal {
             trees,
             length: 0,
@@ -45,17 +45,23 @@ impl OpSetInternal {
         }
     }
 
+    pub fn parent_object(&self, obj: &ObjId) -> Option<(ObjId, Key)> {
+        let parent = self.trees.get(obj)?.parent?;
+        let key = self.search(&parent, OpIdSearch::new(obj.0)).key().unwrap();
+        Some((parent, key))
+    }
+
     pub fn keys(&self, obj: ObjId) -> Option<query::Keys> {
-        if let Some((_typ, tree)) = self.trees.get(&obj) {
-            tree.keys()
+        if let Some(tree) = self.trees.get(&obj) {
+            tree.internal.keys()
         } else {
             None
         }
     }
 
     pub fn keys_at(&self, obj: ObjId, clock: Clock) -> Option<query::KeysAt> {
-        if let Some((_typ, tree)) = self.trees.get(&obj) {
-            tree.keys_at(clock)
+        if let Some(tree) = self.trees.get(&obj) {
+            tree.internal.keys_at(clock)
         } else {
             None
         }
@@ -65,8 +71,8 @@ impl OpSetInternal {
     where
         Q: TreeQuery<'a>,
     {
-        if let Some((_typ, tree)) = self.trees.get(obj) {
-            tree.search(query, &self.m)
+        if let Some(tree) = self.trees.get(obj) {
+            tree.internal.search(query, &self.m)
         } else {
             query
         }
@@ -76,16 +82,16 @@ impl OpSetInternal {
     where
         F: FnMut(&mut Op),
     {
-        if let Some((_typ, tree)) = self.trees.get_mut(obj) {
-            tree.update(index, f)
+        if let Some(tree) = self.trees.get_mut(obj) {
+            tree.internal.update(index, f)
         }
     }
 
     pub fn remove(&mut self, obj: &ObjId, index: usize) -> Op {
         // this happens on rollback - be sure to go back to the old state
-        let (_typ, tree) = self.trees.get_mut(obj).unwrap();
+        let tree = self.trees.get_mut(obj).unwrap();
         self.length -= 1;
-        let op = tree.remove(index);
+        let op = tree.internal.remove(index);
         if let OpType::Make(_) = &op.action {
             self.trees.remove(&op.id.into());
         }
@@ -98,19 +104,25 @@ impl OpSetInternal {
 
     pub fn insert(&mut self, index: usize, obj: &ObjId, element: Op) {
         if let OpType::Make(typ) = element.action {
-            self.trees
-                .insert(element.id.into(), (typ, Default::default()));
+            self.trees.insert(
+                element.id.into(),
+                OpTree {
+                    internal: Default::default(),
+                    objtype: typ,
+                    parent: Some(*obj),
+                },
+            );
         }
 
-        if let Some((_typ, tree)) = self.trees.get_mut(obj) {
+        if let Some(tree) = self.trees.get_mut(obj) {
             //let tree = self.trees.get_mut(&element.obj).unwrap();
-            tree.insert(index, element);
+            tree.internal.insert(index, element);
             self.length += 1;
         }
     }
 
     pub fn object_type(&self, id: &ObjId) -> Option<ObjType> {
-        self.trees.get(id).map(|(typ, _)| *typ)
+        self.trees.get(id).map(|tree| tree.objtype)
     }
 
     #[cfg(feature = "optree-visualisation")]
@@ -151,8 +163,8 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let mut result = None;
         for obj in self.objs.iter().skip(self.index) {
-            let (_typ, tree) = self.inner.trees.get(obj)?;
-            result = tree.get(self.sub_index).map(|op| (*obj, op));
+            let tree = self.inner.trees.get(obj)?;
+            result = tree.internal.get(self.sub_index);
             if result.is_some() {
                 self.sub_index += 1;
                 break;

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet;
 
 pub(crate) const B: usize = 16;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct OpTree {
     pub internal: OpTreeInternal,
     pub objtype: ObjType,
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn insert() {
-        let mut t: OpTree<16> = OpTree::new();
+        let mut t: OpTree = OpTree::new();
 
         t.internal.insert(0, op());
         t.internal.insert(1, op());
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn insert_book() {
-        let mut t: OpTree<16> = OpTree::new();
+        let mut t: OpTree = OpTree::new();
 
         for i in 0..100 {
             t.internal.insert(i % 2, op());
@@ -692,7 +692,7 @@ mod tests {
 
     #[test]
     fn insert_book_vec() {
-        let mut t: OpTree<16> = OpTree::new();
+        let mut t: OpTree = OpTree::new();
         let mut v = Vec::new();
 
         for i in 0..100 {

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -5,17 +5,35 @@ use std::{
 };
 
 pub(crate) use crate::op_set::OpSetMetadata;
-use crate::types::{Op, OpId};
 use crate::{
     clock::Clock,
     query::{self, Index, QueryResult, TreeQuery},
+};
+use crate::{
+    types::{ObjId, Op, OpId},
+    ObjType,
 };
 use std::collections::HashSet;
 
 pub(crate) const B: usize = 16;
 
-#[allow(dead_code)]
-pub(crate) type OpTree = OpTreeInternal;
+#[derive(Debug, Clone)]
+pub(crate) struct OpTree {
+    pub internal: OpTreeInternal,
+    pub objtype: ObjType,
+    /// The id of the parent object, root has no parent.
+    pub parent: Option<ObjId>,
+}
+
+impl OpTree {
+    pub fn new() -> Self {
+        Self {
+            internal: Default::default(),
+            objtype: ObjType::Map,
+            parent: None,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct OpTreeInternal {
@@ -652,36 +670,36 @@ mod tests {
 
     #[test]
     fn insert() {
-        let mut t = OpTree::new();
+        let mut t: OpTree<16> = OpTree::new();
 
-        t.insert(0, op());
-        t.insert(1, op());
-        t.insert(0, op());
-        t.insert(0, op());
-        t.insert(0, op());
-        t.insert(3, op());
-        t.insert(4, op());
+        t.internal.insert(0, op());
+        t.internal.insert(1, op());
+        t.internal.insert(0, op());
+        t.internal.insert(0, op());
+        t.internal.insert(0, op());
+        t.internal.insert(3, op());
+        t.internal.insert(4, op());
     }
 
     #[test]
     fn insert_book() {
-        let mut t = OpTree::new();
+        let mut t: OpTree<16> = OpTree::new();
 
         for i in 0..100 {
-            t.insert(i % 2, op());
+            t.internal.insert(i % 2, op());
         }
     }
 
     #[test]
     fn insert_book_vec() {
-        let mut t = OpTree::new();
+        let mut t: OpTree<16> = OpTree::new();
         let mut v = Vec::new();
 
         for i in 0..100 {
-            t.insert(i % 3, op());
+            t.internal.insert(i % 3, op());
             v.insert(i % 3, op());
 
-            assert_eq!(v, t.iter().cloned().collect::<Vec<_>>())
+            assert_eq!(v, t.internal.iter().cloned().collect::<Vec<_>>())
         }
     }
 }

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
+mod elem_id_pos;
 mod insert;
 mod keys;
 mod keys_at;
@@ -20,6 +21,7 @@ mod prop_at;
 mod seek_op;
 mod seek_op_with_patch;
 
+pub(crate) use elem_id_pos::ElemIdPos;
 pub(crate) use insert::InsertNth;
 pub(crate) use keys::Keys;
 pub(crate) use keys_at::KeysAt;

--- a/automerge/src/query/elem_id_pos.rs
+++ b/automerge/src/query/elem_id_pos.rs
@@ -1,0 +1,53 @@
+use crate::{op_tree::OpTreeNode, types::ElemId};
+
+use super::{QueryResult, TreeQuery};
+
+pub(crate) struct ElemIdPos {
+    elemid: ElemId,
+    pos: usize,
+    found: bool,
+}
+
+impl ElemIdPos {
+    pub fn new(elemid: ElemId) -> Self {
+        Self {
+            elemid,
+            pos: 0,
+            found: false,
+        }
+    }
+
+    pub fn index(&self) -> Option<usize> {
+        if self.found {
+            Some(self.pos)
+        } else {
+            None
+        }
+    }
+}
+
+impl<const B: usize> TreeQuery<B> for ElemIdPos {
+    fn query_node(&mut self, child: &OpTreeNode<B>) -> QueryResult {
+        dbg!(child, &self.elemid);
+        // if index has our element then we can cont
+        if child.index.has(&Some(self.elemid)) {
+            // element is in this node somewhere
+            QueryResult::Descend
+        } else {
+            // not in this node, try the next one
+            self.pos += child.index.len;
+            QueryResult::Next
+        }
+    }
+
+    fn query_element(&mut self, element: &crate::types::Op) -> QueryResult {
+        if element.elemid() == Some(self.elemid) {
+            // this is it
+            self.found = true;
+            return QueryResult::Finish;
+        } else if element.visible() {
+            self.pos += 1;
+        }
+        QueryResult::Next
+    }
+}

--- a/automerge/src/query/elem_id_pos.rs
+++ b/automerge/src/query/elem_id_pos.rs
@@ -2,6 +2,7 @@ use crate::{op_tree::OpTreeNode, types::ElemId};
 
 use super::{QueryResult, TreeQuery};
 
+/// Lookup the index in the list that this elemid occupies.
 pub(crate) struct ElemIdPos {
     elemid: ElemId,
     pos: usize,
@@ -28,8 +29,7 @@ impl ElemIdPos {
 
 impl<'a> TreeQuery<'a> for ElemIdPos {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
-        dbg!(child, &self.elemid);
-        // if index has our element then we can cont
+        // if index has our element then we can continue
         if child.index.has_visible(&Some(self.elemid)) {
             // element is in this node somewhere
             QueryResult::Descend

--- a/automerge/src/query/elem_id_pos.rs
+++ b/automerge/src/query/elem_id_pos.rs
@@ -26,16 +26,16 @@ impl ElemIdPos {
     }
 }
 
-impl TreeQuery for ElemIdPos {
+impl<'a> TreeQuery<'a> for ElemIdPos {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         dbg!(child, &self.elemid);
         // if index has our element then we can cont
-        if child.index.has(&Some(self.elemid)) {
+        if child.index.has_visible(&Some(self.elemid)) {
             // element is in this node somewhere
             QueryResult::Descend
         } else {
             // not in this node, try the next one
-            self.pos += child.index.len;
+            self.pos += child.index.visible_len();
             QueryResult::Next
         }
     }

--- a/automerge/src/query/elem_id_pos.rs
+++ b/automerge/src/query/elem_id_pos.rs
@@ -26,8 +26,8 @@ impl ElemIdPos {
     }
 }
 
-impl<const B: usize> TreeQuery<B> for ElemIdPos {
-    fn query_node(&mut self, child: &OpTreeNode<B>) -> QueryResult {
+impl TreeQuery for ElemIdPos {
+    fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         dbg!(child, &self.elemid);
         // if index has our element then we can cont
         if child.index.has(&Some(self.elemid)) {

--- a/automerge/src/query/opid.rs
+++ b/automerge/src/query/opid.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::OpTreeNode;
 use crate::query::{QueryResult, TreeQuery};
-use crate::types::{Op, OpId};
+use crate::types::{Key, Op, OpId};
 
 /// Search for an OpId in a tree.
 /// Returns the index of the operation in the tree.
@@ -9,6 +9,7 @@ pub(crate) struct OpIdSearch {
     target: OpId,
     pos: usize,
     found: bool,
+    key: Option<Key>,
 }
 
 impl OpIdSearch {
@@ -17,6 +18,7 @@ impl OpIdSearch {
             target,
             pos: 0,
             found: false,
+            key: None,
         }
     }
 
@@ -27,6 +29,10 @@ impl OpIdSearch {
         } else {
             None
         }
+    }
+
+    pub fn key(&self) -> &Option<Key> {
+        &self.key
     }
 }
 
@@ -43,6 +49,7 @@ impl<'a> TreeQuery<'a> for OpIdSearch {
     fn query_element(&mut self, element: &Op) -> QueryResult {
         if element.id == self.target {
             self.found = true;
+            self.key = Some(element.key);
             QueryResult::Finish
         } else {
             self.pos += 1;

--- a/automerge/src/query/opid.rs
+++ b/automerge/src/query/opid.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::OpTreeNode;
 use crate::query::{QueryResult, TreeQuery};
-use crate::types::{Key, Op, OpId};
+use crate::types::{ElemId, Key, Op, OpId};
 
 /// Search for an OpId in a tree.
 /// Returns the index of the operation in the tree.
@@ -49,7 +49,11 @@ impl<'a> TreeQuery<'a> for OpIdSearch {
     fn query_element(&mut self, element: &Op) -> QueryResult {
         if element.id == self.target {
             self.found = true;
-            self.key = Some(element.key);
+            if element.insert {
+                self.key = Some(Key::Seq(ElemId(element.id)));
+            } else {
+                self.key = Some(element.key);
+            }
             QueryResult::Finish
         } else {
             self.pos += 1;

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -236,6 +236,10 @@ impl<'a> Transactable for Transaction<'a> {
     ) -> Result<Vec<(Value, ExId)>, AutomergeError> {
         self.doc.values_at(obj, prop, heads)
     }
+
+    fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
+        self.doc.parent_object(obj)
+    }
 }
 
 // If a transaction is not commited or rolled back manually then it can leave the document in an

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -240,6 +240,10 @@ impl<'a> Transactable for Transaction<'a> {
     fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
         self.doc.parent_object(obj)
     }
+
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Vec<(ExId, Prop)> {
+        self.doc.path_to_object(obj)
+    }
 }
 
 // If a transaction is not commited or rolled back manually then it can leave the document in an

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -145,4 +145,8 @@ pub trait Transactable {
         prop: P,
         heads: &[ChangeHash],
     ) -> Result<Vec<(Value, ExId)>, AutomergeError>;
+
+    /// Get the object id of the object that contains this object and the prop that this object is
+    /// at in that object.
+    fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)>;
 }

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -149,4 +149,6 @@ pub trait Transactable {
     /// Get the object id of the object that contains this object and the prop that this object is
     /// at in that object.
     fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)>;
+
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Vec<(ExId, Prop)>;
 }

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -357,7 +357,7 @@ pub(crate) struct OpId(pub u64, pub usize);
 pub(crate) struct ObjId(pub OpId);
 
 impl ObjId {
-    pub fn root() -> Self {
+    pub const fn root() -> Self {
         ObjId(OpId(0, 0))
     }
 }

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Eq;
 use std::fmt;
+use std::fmt::Display;
 use std::str::FromStr;
 use tinyvec::{ArrayVec, TinyVec};
 
@@ -329,6 +330,15 @@ pub(crate) enum Key {
 pub enum Prop {
     Map(String),
     Seq(usize),
+}
+
+impl Display for Prop {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Prop::Map(s) => write!(f, "{}", s),
+            Prop::Seq(i) => write!(f, "{}", i),
+        }
+    }
 }
 
 impl Key {

--- a/automerge/src/visualisation.rs
+++ b/automerge/src/visualisation.rs
@@ -44,14 +44,14 @@ impl<'a> GraphVisualisation<'a> {
     pub(super) fn construct(
         trees: &'a HashMap<
             crate::types::ObjId,
-            (crate::types::ObjType, crate::op_tree::OpTreeInternal),
+            crate::op_tree::OpTree,
             BuildHasherDefault<FxHasher>,
         >,
         metadata: &'a crate::op_set::OpSetMetadata,
     ) -> GraphVisualisation<'a> {
         let mut nodes = HashMap::new();
-        for (obj_id, (_, tree)) in trees {
-            if let Some(root_node) = &tree.root_node {
+        for (obj_id, tree) in trees {
+            if let Some(root_node) = &tree.internal.root_node {
                 let tree_id = Self::construct_nodes(root_node, obj_id, &mut nodes, metadata);
                 let obj_tree_id = NodeId::default();
                 nodes.insert(


### PR DESCRIPTION
In a scenario where we want to detect what key in the document has changed we can iterate through the ops in changes as they are applied, however these contain an obscure object id. This functionality helps the user by adding a method of going back up the tree from a found object to build the path to the original object.

There are currently some awkward bits that I'm not sure how we want to address such as the operation having an ObjectId whereas we need an ObjId for the document so we have to convert it to string first then import it.