### PR TITLE
return touched objects from apply_changes

### DIFF
--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -104,7 +104,7 @@ export class Automerge {
 
   // transactions
   commit(message?: string, time?: number): Heads;
-  merge(other: Automerge): Heads;
+  merge(other: Automerge): ObjID[];
   getActorId(): Actor;
   pendingOps(): number;
   rollback(): number;
@@ -112,14 +112,14 @@ export class Automerge {
   // save and load to local store
   save(): Uint8Array;
   saveIncremental(): Uint8Array;
-  loadIncremental(data: Uint8Array): number;
+  loadIncremental(data: Uint8Array): ObjID[];
 
   // sync over network
-  receiveSyncMessage(state: SyncState, message: SyncMessage): void;
+  receiveSyncMessage(state: SyncState, message: SyncMessage): ObjID[];
   generateSyncMessage(state: SyncState): SyncMessage | null;
 
   // low level change functions
-  applyChanges(changes: Change[]): void;
+  applyChanges(changes: Change[]): ObjID[];
   getChanges(have_deps: Heads): Change[];
   getChangesAdded(other: Automerge): Change[];
   getHeads(): Heads;

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -89,12 +89,9 @@ impl Automerge {
     }
 
     pub fn merge(&mut self, other: &mut Automerge) -> Result<Array, JsValue> {
-        let heads = self.0.merge(&mut other.0)?;
-        let heads: Array = heads
-            .iter()
-            .map(|h| JsValue::from_str(&hex::encode(&h.0)))
-            .collect();
-        Ok(heads)
+        let objs = self.0.merge(&mut other.0)?;
+        let objs: Array = objs.iter().map(|o| JsValue::from(o.to_string())).collect();
+        Ok(objs)
     }
 
     pub fn rollback(&mut self) -> f64 {
@@ -365,17 +362,19 @@ impl Automerge {
     }
 
     #[wasm_bindgen(js_name = loadIncremental)]
-    pub fn load_incremental(&mut self, data: Uint8Array) -> Result<f64, JsValue> {
+    pub fn load_incremental(&mut self, data: Uint8Array) -> Result<Array, JsValue> {
         let data = data.to_vec();
-        let len = self.0.load_incremental(&data).map_err(to_js_err)?;
-        Ok(len as f64)
+        let objs = self.0.load_incremental(&data).map_err(to_js_err)?;
+        let objs: Array = objs.iter().map(|o| JsValue::from(o.to_string())).collect();
+        Ok(objs)
     }
 
     #[wasm_bindgen(js_name = applyChanges)]
-    pub fn apply_changes(&mut self, changes: JsValue) -> Result<(), JsValue> {
+    pub fn apply_changes(&mut self, changes: JsValue) -> Result<Array, JsValue> {
         let changes: Vec<_> = JS(changes).try_into()?;
-        self.0.apply_changes(changes).map_err(to_js_err)?;
-        Ok(())
+        let objs = self.0.apply_changes(changes).map_err(to_js_err)?;
+        let objs: Array = objs.iter().map(|o| JsValue::from(o.to_string())).collect();
+        Ok(objs)
     }
 
     #[wasm_bindgen(js_name = getChanges)]
@@ -444,13 +443,15 @@ impl Automerge {
         &mut self,
         state: &mut SyncState,
         message: Uint8Array,
-    ) -> Result<(), JsValue> {
+    ) -> Result<Array, JsValue> {
         let message = message.to_vec();
         let message = am::sync::Message::decode(message.as_slice()).map_err(to_js_err)?;
-        self.0
+        let objs = self
+            .0
             .receive_sync_message(&mut state.0, message)
             .map_err(to_js_err)?;
-        Ok(())
+        let objs: Array = objs.iter().map(|o| JsValue::from(o.to_string())).collect();
+        Ok(objs)
     }
 
     #[wasm_bindgen(js_name = generateSyncMessage)]

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -276,8 +276,9 @@ describe('Automerge', () => {
       let docA = loadDoc(saveA);
       let docB = loadDoc(saveB);
       let docC = loadDoc(saveMidway)
-      docC.loadIncremental(save3)
+      let touched = docC.loadIncremental(save3)
 
+      assert.deepEqual(touched, ["_root"]);
       assert.deepEqual(docA.keys("_root"), docB.keys("_root"));
       assert.deepEqual(docA.save(), docB.save());
       assert.deepEqual(docA.save(), docC.save());
@@ -344,9 +345,11 @@ describe('Automerge', () => {
       doc1.set(seq, 0, 20)
       doc2.set(seq, 0, 0, "counter")
       doc3.set(seq, 0, 10, "counter")
-      doc1.applyChanges(doc2.getChanges(doc1.getHeads()))
-      doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
+      let touched1 = doc1.applyChanges(doc2.getChanges(doc1.getHeads()))
+      let touched2 = doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values(seq, 0)
+      assert.deepEqual(touched1,["1@aaaa"])
+      assert.deepEqual(touched2,["1@aaaa"])
       assert.deepEqual(result,[
         ['int',20,'3@aaaa'],
         ['counter',0,'3@bbbb'],
@@ -1073,16 +1076,20 @@ describe('Automerge', () => {
         m2 = n2.generateSyncMessage(s2)
         if (m1 === null) { throw new RangeError("message should not be null") }
         if (m2 === null) { throw new RangeError("message should not be null") }
-        n1.receiveSyncMessage(s1, m2)
-        n2.receiveSyncMessage(s2, m1)
+        let touched1 =  n1.receiveSyncMessage(s1, m2)
+        let touched2 = n2.receiveSyncMessage(s2, m1)
+        assert.deepEqual(touched1, []);
+        assert.deepEqual(touched2, []);
 
         // Then n1 and n2 send each other their changes, except for the false positive
         m1 = n1.generateSyncMessage(s1)
         m2 = n2.generateSyncMessage(s2)
         if (m1 === null) { throw new RangeError("message should not be null") }
         if (m2 === null) { throw new RangeError("message should not be null") }
-        n1.receiveSyncMessage(s1, m2)
-        n2.receiveSyncMessage(s2, m1)
+        let touched3 = n1.receiveSyncMessage(s1, m2)
+        let touched4 = n2.receiveSyncMessage(s2, m1)
+        assert.deepEqual(touched3, []);
+        assert.deepEqual(touched4, ["_root"]);
         assert.strictEqual(decodeSyncMessage(m1).changes.length, 2) // n1c1 and n1c2
         assert.strictEqual(decodeSyncMessage(m2).changes.length, 1) // only n2c2; change n2c1 is not sent
 

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -139,18 +139,18 @@ impl AutoCommit {
         })
     }
 
-    pub fn load_incremental(&mut self, data: &[u8]) -> Result<usize, AutomergeError> {
+    pub fn load_incremental(&mut self, data: &[u8]) -> Result<Vec<ExId>, AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.load_incremental(data)
     }
 
-    pub fn apply_changes(&mut self, changes: Vec<Change>) -> Result<(), AutomergeError> {
+    pub fn apply_changes(&mut self, changes: Vec<Change>) -> Result<Vec<ExId>, AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.apply_changes(changes)
     }
 
     /// Takes all the changes in `other` which are not in `self` and applies them
-    pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ChangeHash>, AutomergeError> {
+    pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ExId>, AutomergeError> {
         self.ensure_transaction_closed();
         other.ensure_transaction_closed();
         self.doc.merge(&mut other.doc)
@@ -210,7 +210,7 @@ impl AutoCommit {
         &mut self,
         sync_state: &mut sync::State,
         message: sync::Message,
-    ) -> Result<(), AutomergeError> {
+    ) -> Result<Vec<ExId>, AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.receive_sync_message(sync_state, message)
     }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -264,7 +264,11 @@ impl Automerge {
     }
 
     pub(crate) fn id_to_exid(&self, id: OpId) -> ExId {
-        ExId::Id(id.0, self.ops.m.actors.cache[id.1].clone(), id.1)
+        if id == types::ROOT {
+            ExId::Root
+        } else {
+            ExId::Id(id.0, self.ops.m.actors.cache[id.1].clone(), id.1)
+        }
     }
 
     /// Get the string represented by the given text object.
@@ -404,12 +408,9 @@ impl Automerge {
     }
 
     /// Load an incremental save of a document.
-    pub fn load_incremental(&mut self, data: &[u8]) -> Result<usize, AutomergeError> {
+    pub fn load_incremental(&mut self, data: &[u8]) -> Result<Vec<ExId>, AutomergeError> {
         let changes = Change::load_document(data)?;
-        let start = self.ops.len();
-        self.apply_changes(changes)?;
-        let delta = self.ops.len() - start;
-        Ok(delta)
+        self.apply_changes(changes)
     }
 
     fn duplicate_seq(&self, change: &Change) -> bool {
@@ -423,7 +424,8 @@ impl Automerge {
     }
 
     /// Apply changes to this document.
-    pub fn apply_changes(&mut self, changes: Vec<Change>) -> Result<(), AutomergeError> {
+    pub fn apply_changes(&mut self, changes: Vec<Change>) -> Result<Vec<ExId>, AutomergeError> {
+        let mut objs = HashSet::new();
         for c in changes {
             if !self.history_index.contains_key(&c.hash) {
                 if self.duplicate_seq(&c) {
@@ -433,23 +435,24 @@ impl Automerge {
                     ));
                 }
                 if self.is_causally_ready(&c) {
-                    self.apply_change(c);
+                    self.apply_change(c, &mut objs);
                 } else {
                     self.queue.push(c);
                 }
             }
         }
         while let Some(c) = self.pop_next_causally_ready_change() {
-            self.apply_change(c);
+            self.apply_change(c, &mut objs);
         }
-        Ok(())
+        Ok(objs.into_iter().map(|obj| self.id_to_exid(obj.0)).collect())
     }
 
     /// Apply a single change to this document.
-    fn apply_change(&mut self, change: Change) {
+    fn apply_change(&mut self, change: Change, objs: &mut HashSet<ObjId>) {
         let ops = self.import_ops(&change);
         self.update_history(change, ops.len());
         for (obj, op) in ops {
+            objs.insert(obj);
             self.insert_op(&obj, op);
         }
     }
@@ -511,15 +514,14 @@ impl Automerge {
     }
 
     /// Takes all the changes in `other` which are not in `self` and applies them
-    pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ChangeHash>, AutomergeError> {
+    pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ExId>, AutomergeError> {
         // TODO: Make this fallible and figure out how to do this transactionally
         let changes = self
             .get_changes_added(other)
             .into_iter()
             .cloned()
             .collect::<Vec<_>>();
-        self.apply_changes(changes)?;
-        Ok(self.get_heads())
+        self.apply_changes(changes)
     }
 
     /// Save the entirety of this document in a compact form.

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -90,10 +90,6 @@ impl<const B: usize> OpSetInternal<B> {
         op
     }
 
-    pub fn len(&self) -> usize {
-        self.length
-    }
-
     pub fn insert(&mut self, index: usize, obj: &ObjId, element: Op) {
         if let OpType::Make(typ) = element.action {
             self.trees


### PR DESCRIPTION
Upwelling was asking for the ability to know what objects changed when doing an applyChanges(), receiveSyncMessage() or merge() and I thought that just returning those objects was a great idea and just generally more useful.  To underscore how little we use the current return values no tests broke when I made this change 😆 

Would love feedback.