### PR TITLE
fix the return type of values

### DIFF
--- a/automerge-cli/src/export.rs
+++ b/automerge-cli/src/export.rs
@@ -7,15 +7,15 @@ pub(crate) fn map_to_json(doc: &am::Automerge, obj: &am::ObjId) -> serde_json::V
     for k in keys {
         let val = doc.value(obj, &k);
         match val {
-            Ok(Some((am::Value::Object(o), exid)))
+            Ok(Some(am::Value::Object(o, exid)))
                 if o == am::ObjType::Map || o == am::ObjType::Table =>
             {
                 map.insert(k.to_owned(), map_to_json(doc, &exid));
             }
-            Ok(Some((am::Value::Object(_), exid))) => {
+            Ok(Some(am::Value::Object(_, exid))) => {
                 map.insert(k.to_owned(), list_to_json(doc, &exid));
             }
-            Ok(Some((am::Value::Scalar(v), _))) => {
+            Ok(Some(am::Value::Scalar(v))) => {
                 map.insert(k.to_owned(), scalar_to_json(&v));
             }
             _ => (),
@@ -30,15 +30,15 @@ fn list_to_json(doc: &am::Automerge, obj: &am::ObjId) -> serde_json::Value {
     for i in 0..len {
         let val = doc.value(obj, i as usize);
         match val {
-            Ok(Some((am::Value::Object(o), exid)))
+            Ok(Some(am::Value::Object(o, exid)))
                 if o == am::ObjType::Map || o == am::ObjType::Table =>
             {
                 array.push(map_to_json(doc, &exid));
             }
-            Ok(Some((am::Value::Object(_), exid))) => {
+            Ok(Some(am::Value::Object(_, exid))) => {
                 array.push(list_to_json(doc, &exid));
             }
-            Ok(Some((am::Value::Scalar(v), _))) => {
+            Ok(Some(am::Value::Scalar(v))) => {
                 array.push(scalar_to_json(&v));
             }
             _ => (),

--- a/automerge-js/src/index.js
+++ b/automerge-js/src/index.js
@@ -131,19 +131,20 @@ function conflictAt(context, objectId, prop) {
       if (values.length <= 1) {
         return
       }
-      let result = {}
-      for (const conflict of values) {
+      let result = []
+      for (const i in values) {
+        const conflict = values[i]
         const datatype = conflict[0]
         const value = conflict[1]
         switch (datatype) {
           case "map":
-            result[value] = mapProxy(context, value, [ prop ], true)
+            result.push(mapProxy(context, value, [ prop ], true))
             break;
           case "list":
-            result[value] = listProxy(context, value, [ prop ], true)
+            result.push(listProxy(context, value, [ prop ], true))
             break;
           case "text":
-            result[value] = textProxy(context, value, [ prop ], true)
+            result.push(textProxy(context, value, [ prop ], true))
             break;
           //case "table":
           //case "cursor":
@@ -154,13 +155,13 @@ function conflictAt(context, objectId, prop) {
           case "boolean":
           case "bytes":
           case "null":
-            result[conflict[2]] = value
+            result.push(value)
             break;
           case "counter":
-            result[conflict[2]] = new Counter(value)
+            result.push(new Counter(value))
             break;
           case "timestamp":
-            result[conflict[2]] = new Date(value)
+            result.push(new Date(value))
             break;
           default:
             throw RangeError(`datatype ${datatype} unimplemented`)

--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -335,18 +335,18 @@ pub(crate) fn map_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
     for k in keys {
         let val = doc.value(obj, &k);
         match val {
-            Ok(Some((Value::Object(o), exid)))
+            Ok(Some(Value::Object(o, exid)))
                 if o == am::ObjType::Map || o == am::ObjType::Table =>
             {
                 Reflect::set(&map, &k.into(), &map_to_js(doc, &exid)).unwrap();
             }
-            Ok(Some((Value::Object(o), exid))) if o == am::ObjType::List => {
+            Ok(Some(Value::Object(o, exid))) if o == am::ObjType::List => {
                 Reflect::set(&map, &k.into(), &list_to_js(doc, &exid)).unwrap();
             }
-            Ok(Some((Value::Object(o), exid))) if o == am::ObjType::Text => {
+            Ok(Some(Value::Object(o, exid))) if o == am::ObjType::Text => {
                 Reflect::set(&map, &k.into(), &doc.text(&exid).unwrap().into()).unwrap();
             }
-            Ok(Some((Value::Scalar(v), _))) => {
+            Ok(Some(Value::Scalar(v))) => {
                 Reflect::set(&map, &k.into(), &ScalarValue(v).into()).unwrap();
             }
             _ => (),
@@ -361,15 +361,15 @@ pub(crate) fn list_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
     for i in 0..len {
         let val = doc.value(obj, i as usize);
         match val {
-            Ok(Some((Value::Object(o), exid)))
+            Ok(Some(Value::Object(o, exid)))
                 if o == am::ObjType::Map || o == am::ObjType::Table =>
             {
                 array.push(&map_to_js(doc, &exid));
             }
-            Ok(Some((Value::Object(_), exid))) => {
+            Ok(Some(Value::Object(_, exid))) => {
                 array.push(&list_to_js(doc, &exid));
             }
-            Ok(Some((Value::Scalar(v), _))) => {
+            Ok(Some(Value::Scalar(v))) => {
                 array.push(&ScalarValue(v).into());
             }
             _ => (),

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -315,15 +315,15 @@ describe('Automerge', () => {
       doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values("_root", "cnt")
       assert.deepEqual(result,[
-        ['int',20,'2@aaaa'],
-        ['counter',0,'2@bbbb'],
-        ['counter',10,'2@cccc'],
+        ['int',20],
+        ['counter',0],
+        ['counter',10],
       ])
       doc1.inc("_root", "cnt", 5)
       result = doc1.values("_root", "cnt")
       assert.deepEqual(result, [
-        [ 'counter', 5, '2@bbbb' ],
-        [ 'counter', 15, '2@cccc' ],
+        [ 'counter', 5],
+        [ 'counter', 15],
       ])
 
       let save1 = doc1.save()
@@ -348,15 +348,15 @@ describe('Automerge', () => {
       doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values(seq, 0)
       assert.deepEqual(result,[
-        ['int',20,'3@aaaa'],
-        ['counter',0,'3@bbbb'],
-        ['counter',10,'3@cccc'],
+        ['int',20],
+        ['counter',0],
+        ['counter',10],
       ])
       doc1.inc(seq, 0, 5)
       result = doc1.values(seq, 0)
       assert.deepEqual(result, [
-        [ 'counter', 5, '3@bbbb' ],
-        [ 'counter', 15, '3@cccc' ],
+        [ 'counter', 5 ],
+        [ 'counter', 15 ],
       ])
 
       let save = doc1.save()

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -413,7 +413,7 @@ impl Transactable for AutoCommit {
         &self,
         obj: O,
         prop: P,
-    ) -> Result<Option<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Option<Value>, AutomergeError> {
         self.doc.value(obj, prop)
     }
 
@@ -422,7 +422,7 @@ impl Transactable for AutoCommit {
         obj: O,
         prop: P,
         heads: &[ChangeHash],
-    ) -> Result<Option<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Option<Value>, AutomergeError> {
         self.doc.value_at(obj, prop, heads)
     }
 
@@ -430,7 +430,7 @@ impl Transactable for AutoCommit {
         &self,
         obj: O,
         prop: P,
-    ) -> Result<Vec<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Vec<Value>, AutomergeError> {
         self.doc.values(obj, prop)
     }
 
@@ -439,7 +439,7 @@ impl Transactable for AutoCommit {
         obj: O,
         prop: P,
         heads: &[ChangeHash],
-    ) -> Result<Vec<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Vec<Value>, AutomergeError> {
         self.doc.values_at(obj, prop, heads)
     }
 }

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -207,7 +207,7 @@ impl<'a> Transactable for Transaction<'a> {
         &self,
         obj: O,
         prop: P,
-    ) -> Result<Option<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Option<Value>, AutomergeError> {
         self.doc.value(obj, prop)
     }
 
@@ -216,7 +216,7 @@ impl<'a> Transactable for Transaction<'a> {
         obj: O,
         prop: P,
         heads: &[ChangeHash],
-    ) -> Result<Option<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Option<Value>, AutomergeError> {
         self.doc.value_at(obj, prop, heads)
     }
 
@@ -224,7 +224,7 @@ impl<'a> Transactable for Transaction<'a> {
         &self,
         obj: O,
         prop: P,
-    ) -> Result<Vec<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Vec<Value>, AutomergeError> {
         self.doc.values(obj, prop)
     }
 
@@ -233,7 +233,7 @@ impl<'a> Transactable for Transaction<'a> {
         obj: O,
         prop: P,
         heads: &[ChangeHash],
-    ) -> Result<Vec<(Value, ExId)>, AutomergeError> {
+    ) -> Result<Vec<Value>, AutomergeError> {
         self.doc.values_at(obj, prop, heads)
     }
 }

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -120,7 +120,7 @@ pub trait Transactable {
         &self,
         obj: O,
         prop: P,
-    ) -> Result<Option<(Value, ExId)>, AutomergeError>;
+    ) -> Result<Option<Value>, AutomergeError>;
 
     /// Get the value at this prop in the object at a point in history.
     fn value_at<O: AsRef<ExId>, P: Into<Prop>>(
@@ -128,18 +128,18 @@ pub trait Transactable {
         obj: O,
         prop: P,
         heads: &[ChangeHash],
-    ) -> Result<Option<(Value, ExId)>, AutomergeError>;
+    ) -> Result<Option<Value>, AutomergeError>;
 
     fn values<O: AsRef<ExId>, P: Into<Prop>>(
         &self,
         obj: O,
         prop: P,
-    ) -> Result<Vec<(Value, ExId)>, AutomergeError>;
+    ) -> Result<Vec<Value>, AutomergeError>;
 
     fn values_at<O: AsRef<ExId>, P: Into<Prop>>(
         &self,
         obj: O,
         prop: P,
         heads: &[ChangeHash],
-    ) -> Result<Vec<(Value, ExId)>, AutomergeError>;
+    ) -> Result<Vec<Value>, AutomergeError>;
 }

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -424,14 +424,6 @@ impl Op {
         }
     }
 
-    pub fn value(&self) -> Value {
-        match &self.action {
-            OpType::Make(obj_type) => Value::Object(*obj_type),
-            OpType::Set(scalar) => Value::Scalar(scalar.clone()),
-            _ => panic!("cant convert op into a value - {:?}", self),
-        }
-    }
-
     #[allow(dead_code)]
     pub fn dump(&self) -> String {
         match &self.action {

--- a/automerge/tests/helpers/mod.rs
+++ b/automerge/tests/helpers/mod.rs
@@ -316,9 +316,9 @@ pub fn realize_prop<P: Into<automerge::Prop>>(
     obj_id: &automerge::ObjId,
     prop: P,
 ) -> RealizedObject {
-    let (val, obj_id) = doc.value(obj_id, prop).unwrap().unwrap();
+    let val = doc.value(obj_id, prop).unwrap().unwrap();
     match val {
-        automerge::Value::Object(obj_type) => realize_obj(doc, &obj_id, obj_type),
+        automerge::Value::Object(obj_type, obj_id) => realize_obj(doc, &obj_id, obj_type),
         automerge::Value::Scalar(v) => RealizedObject::Value(OrdScalarValue::from(v)),
     }
 }
@@ -353,9 +353,9 @@ fn realize_values<K: Into<automerge::Prop>>(
     key: K,
 ) -> BTreeSet<RealizedObject> {
     let mut values = BTreeSet::new();
-    for (value, objid) in doc.values(obj_id, key).unwrap() {
+    for value in doc.values(obj_id, key).unwrap() {
         let realized = match value {
-            automerge::Value::Object(objtype) => realize_obj(doc, &objid, objtype),
+            automerge::Value::Object(objtype, objid) => realize_obj(doc, &objid, objtype),
             automerge::Value::Scalar(v) => RealizedObject::Value(OrdScalarValue::from(v)),
         };
         values.insert(realized);

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -94,7 +94,7 @@ fn merge_concurrent_map_prop_updates() {
     doc2.set(&automerge::ROOT, "hello", "world").unwrap();
     doc1.merge(&mut doc2).unwrap();
     assert_eq!(
-        doc1.value(&automerge::ROOT, "foo").unwrap().unwrap().0,
+        doc1.value(&automerge::ROOT, "foo").unwrap().unwrap(),
         "bar".into()
     );
     assert_doc!(
@@ -857,29 +857,29 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     let values = doc1.values(&list, 1)?;
     assert_eq!(values.len(), 3);
-    assert_eq!(&values[0].0, &Value::counter(1));
-    assert_eq!(&values[1].0, &Value::counter(10));
-    assert_eq!(&values[2].0, &Value::counter(100));
+    assert_eq!(&values[0], &Value::counter(1));
+    assert_eq!(&values[1], &Value::counter(10));
+    assert_eq!(&values[2], &Value::counter(100));
 
     let values = doc1.values(&list, 2)?;
     assert_eq!(values.len(), 3);
-    assert_eq!(&values[0].0, &Value::counter(1));
-    assert_eq!(&values[1].0, &Value::counter(10));
-    assert_eq!(&values[2].0, &Value::int(100));
+    assert_eq!(&values[0], &Value::counter(1));
+    assert_eq!(&values[1], &Value::counter(10));
+    assert_eq!(&values[2], &Value::int(100));
 
     doc1.inc(&list, 1, 1)?;
     doc1.inc(&list, 2, 1)?;
 
     let values = doc1.values(&list, 1)?;
     assert_eq!(values.len(), 3);
-    assert_eq!(&values[0].0, &Value::counter(2));
-    assert_eq!(&values[1].0, &Value::counter(11));
-    assert_eq!(&values[2].0, &Value::counter(101));
+    assert_eq!(&values[0], &Value::counter(2));
+    assert_eq!(&values[1], &Value::counter(11));
+    assert_eq!(&values[2], &Value::counter(101));
 
     let values = doc1.values(&list, 2)?;
     assert_eq!(values.len(), 2);
-    assert_eq!(&values[0].0, &Value::counter(2));
-    assert_eq!(&values[1].0, &Value::counter(11));
+    assert_eq!(&values[0], &Value::counter(2));
+    assert_eq!(&values[1], &Value::counter(11));
 
     assert_eq!(doc1.length(&list), 3);
 


### PR DESCRIPTION
The return type of value() and values() has long been an ugly tuple.  With the new `set()` vs `set_object()` the only thing standing in the way of fixing this was the js `getConflicts()` needing the opid of each conflict.  I decided to break convention here and make the js implementation return a list of values instead of a map with opids.  Now the Value type can just contain all the information it needs in one place.
