### PR TITLE
Make start_op be nonzero to prevent bad loads

### DIFF
--- a/automerge-cli/src/examine.rs
+++ b/automerge-cli/src/examine.rs
@@ -35,7 +35,7 @@ pub fn examine(
     if is_tty {
         let json_changes = serde_json::to_value(uncompressed_changes).unwrap();
         colored_json::write_colored_json(&json_changes, &mut output).unwrap();
-        writeln!(&mut output).unwrap();
+        writeln!(output).unwrap();
     } else {
         let json_changes = serde_json::to_string_pretty(&uncompressed_changes).unwrap();
         output

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -1,10 +1,10 @@
 use crate::exid::ExId;
 use crate::transaction::{CommitOptions, Transactable};
-use crate::{
-    change::export_change, transaction::TransactionInner, ActorId, Automerge, AutomergeError,
-    Change, ChangeHash, Prop, Value,
-};
 use crate::{sync, Keys, KeysAt, ObjType, ScalarValue};
+use crate::{
+    transaction::TransactionInner, ActorId, Automerge, AutomergeError, Change, ChangeHash, Prop,
+    Value,
+};
 
 /// An automerge document that automatically manages transactions.
 #[derive(Debug, Clone)]
@@ -52,65 +52,8 @@ impl AutoCommit {
 
     fn ensure_transaction_open(&mut self) {
         if self.transaction.is_none() {
-            let actor = self.doc.get_actor_index();
-
-            let seq = self.doc.states.entry(actor).or_default().len() as u64 + 1;
-            let mut deps = self.doc.get_heads();
-            if seq > 1 {
-                let last_hash = self.get_hash(actor, seq - 1).unwrap();
-                if !deps.contains(&last_hash) {
-                    deps.push(last_hash);
-                }
-            }
-
-            self.transaction = Some(TransactionInner {
-                actor,
-                seq,
-                start_op: self.doc.max_op + 1,
-                time: 0,
-                message: None,
-                extra_bytes: Default::default(),
-                hash: None,
-                operations: vec![],
-                deps,
-            });
+            self.transaction = Some(self.doc.transaction_inner());
         }
-    }
-
-    fn get_hash(&mut self, actor: usize, seq: u64) -> Result<ChangeHash, AutomergeError> {
-        self.doc
-            .states
-            .get(&actor)
-            .and_then(|v| v.get(seq as usize - 1))
-            .and_then(|&i| self.doc.history.get(i))
-            .map(|c| c.hash)
-            .ok_or(AutomergeError::InvalidSeq(seq))
-    }
-
-    fn update_history(&mut self, change: Change) -> usize {
-        self.doc.max_op = std::cmp::max(self.doc.max_op, change.start_op + change.len() as u64 - 1);
-
-        self.update_deps(&change);
-
-        let history_index = self.doc.history.len();
-
-        self.doc
-            .states
-            .entry(self.doc.ops.m.actors.cache(change.actor_id().clone()))
-            .or_default()
-            .push(history_index);
-
-        self.doc.history_index.insert(change.hash, history_index);
-        self.doc.history.push(change);
-
-        history_index
-    }
-
-    fn update_deps(&mut self, change: &Change) {
-        for d in &change.deps {
-            self.doc.deps.remove(d);
-        }
-        self.doc.deps.insert(change.hash);
     }
 
     pub fn fork(&mut self) -> Self {
@@ -123,11 +66,7 @@ impl AutoCommit {
 
     fn ensure_transaction_closed(&mut self) {
         if let Some(tx) = self.transaction.take() {
-            self.update_history(export_change(
-                tx,
-                &self.doc.ops.m.actors,
-                &self.doc.ops.m.props,
-            ));
+            tx.commit(&mut self.doc, None, None);
         }
     }
 
@@ -229,10 +168,7 @@ impl AutoCommit {
     }
 
     pub fn commit(&mut self) -> ChangeHash {
-        // ensure that even no changes triggers a change
-        self.ensure_transaction_open();
-        let tx = self.transaction.take().unwrap();
-        tx.commit(&mut self.doc, None, None)
+        self.commit_with(CommitOptions::default())
     }
 
     /// Commit the current operations with some options.
@@ -251,6 +187,7 @@ impl AutoCommit {
     /// doc.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
     /// ```
     pub fn commit_with(&mut self, options: CommitOptions) -> ChangeHash {
+        // ensure that even no changes triggers a change
         self.ensure_transaction_open();
         let tx = self.transaction.take().unwrap();
         tx.commit(&mut self.doc, options.message, options.time)

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -946,7 +946,7 @@ impl ChangeEncoder {
             self.seq.append_value(change.seq);
             // FIXME iterops.count is crazy slow
             self.max_op
-                .append_value(change.start_op + change.iter_ops().count() as u64 - 1);
+                .append_value(change.start_op.get() + change.iter_ops().count() as u64 - 1);
             self.time.append_value(change.time as u64);
             self.message.append_value(change.message());
             self.deps_num.append_value(change.deps.len());

--- a/automerge/src/decoding.rs
+++ b/automerge/src/decoding.rs
@@ -1,4 +1,5 @@
 use core::fmt::Debug;
+use std::num::NonZeroU64;
 use std::{borrow::Cow, io, io::Read, str};
 
 use crate::error;
@@ -350,6 +351,15 @@ impl Decodable for u64 {
         R: Read,
     {
         leb128::read::unsigned(bytes).ok()
+    }
+}
+
+impl Decodable for NonZeroU64 {
+    fn decode<R>(bytes: &mut R) -> Option<Self>
+    where
+        R: Read,
+    {
+        NonZeroU64::new(leb128::read::unsigned(bytes).ok()?)
     }
 }
 

--- a/automerge/src/encoding.rs
+++ b/automerge/src/encoding.rs
@@ -3,6 +3,7 @@ use std::{
     io,
     io::{Read, Write},
     mem,
+    num::NonZeroU64,
 };
 
 use flate2::{bufread::DeflateEncoder, Compression};
@@ -240,7 +241,7 @@ where
 }
 
 pub(crate) trait Encodable {
-    fn encode_with_actors_to_vec(&self, actors: &mut Vec<ActorId>) -> io::Result<Vec<u8>> {
+    fn encode_with_actors_to_vec(&self, actors: &mut [ActorId]) -> io::Result<Vec<u8>> {
         let mut buf = Vec::new();
         self.encode_with_actors(&mut buf, actors)?;
         Ok(buf)
@@ -288,6 +289,12 @@ impl Encodable for Option<String> {
 impl Encodable for u64 {
     fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize> {
         leb128::write::unsigned(buf, *self)
+    }
+}
+
+impl Encodable for NonZeroU64 {
+    fn encode<R: Write>(&self, buf: &mut R) -> io::Result<usize> {
+        leb128::write::unsigned(buf, self.get())
     }
 }
 

--- a/automerge/src/legacy/mod.rs
+++ b/automerge/src/legacy/mod.rs
@@ -1,6 +1,8 @@
 mod serde_impls;
 mod utility_impls;
 
+use std::num::NonZeroU64;
+
 pub(crate) use crate::types::{ActorId, ChangeHash, ObjType, OpType, ScalarValue};
 pub(crate) use crate::value::DataType;
 
@@ -246,9 +248,9 @@ pub struct Change {
     pub hash: Option<ChangeHash>,
     /// The index of this change in the changes from this actor.
     pub seq: u64,
-    /// The start operation index.
+    /// The start operation index. Starts at 1.
     #[serde(rename = "startOp")]
-    pub start_op: u64,
+    pub start_op: NonZeroU64,
     /// The time that this change was committed.
     pub time: i64,
     /// The message of this change.

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU64;
+
 use crate::automerge::Actor;
 use crate::exid::ExId;
 use crate::query::{self, OpIdSearch};
@@ -9,7 +11,7 @@ use crate::{AutomergeError, ObjType, OpType, ScalarValue};
 pub struct TransactionInner {
     pub(crate) actor: usize,
     pub(crate) seq: u64,
-    pub(crate) start_op: u64,
+    pub(crate) start_op: NonZeroU64,
     pub(crate) time: i64,
     pub(crate) message: Option<String>,
     pub(crate) extra_bytes: Vec<u8>,
@@ -123,7 +125,10 @@ impl TransactionInner {
     }
 
     fn next_id(&mut self) -> OpId {
-        OpId(self.start_op + self.operations.len() as u64, self.actor)
+        OpId(
+            self.start_op.get() + self.operations.len() as u64,
+            self.actor,
+        )
     }
 
     fn insert_local_op(


### PR DESCRIPTION
Doing some light fuzz testing revealed that during load we can get to a case where start_op is 0 but it shouldn't actually be possible. This change pushes that into the type system.