### PR TITLE
Fix nth query's last_elem

### DIFF
--- a/automerge/src/query/nth_at.rs
+++ b/automerge/src/query/nth_at.rs
@@ -8,7 +8,6 @@ pub(crate) struct NthAt<const B: usize> {
     target: usize,
     seen: usize,
     last_seen: Option<ElemId>,
-    last_elem: Option<ElemId>,
     window: VisWindow,
     pub ops: Vec<Op>,
     pub ops_pos: Vec<usize>,
@@ -25,7 +24,6 @@ impl<const B: usize> NthAt<B> {
             ops: vec![],
             ops_pos: vec![],
             pos: 0,
-            last_elem: None,
             window: Default::default(),
         }
     }
@@ -37,7 +35,6 @@ impl<const B: usize> TreeQuery<B> for NthAt<B> {
             if self.seen > self.target {
                 return QueryResult::Finish;
             };
-            self.last_elem = element.elemid();
             self.last_seen = None
         }
         let visible = self.window.visible_at(element, self.pos, &self.clock);

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -89,6 +89,23 @@ impl From<Vec<u8>> for ActorId {
     }
 }
 
+impl<const N: usize> From<[u8; N]> for ActorId {
+    fn from(array: [u8; N]) -> Self {
+        ActorId::from(&array)
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for ActorId {
+    fn from(slice: &[u8; N]) -> Self {
+        let inner = if let Ok(arr) = ArrayVec::try_from(slice.as_slice()) {
+            TinyVec::Inline(arr)
+        } else {
+            TinyVec::Heap(slice.to_vec())
+        };
+        ActorId(inner)
+    }
+}
+
 impl FromStr for ActorId {
     type Err = error::InvalidActorId;
 


### PR DESCRIPTION
This copies the test from https://github.com/automerge/automerge-rs/issues/311 into Rust and fixes the bug causing it. (Closes #311)

From some debugging it seems that (at least one of) the problems are around the `last_elem` variable not getting set in the query. The insert operation (which would set the `last_elem`) is in the first child node but gets skipped over so that in the second child node we are missing this state.

This is fixed by getting the elemid directly from the first op captured during the query when we want the key. This works as inserts are followed by non-inserts and non-inserts have an `elemid()` of the insert operation they overwrite.