### PR TITLE
Change set to update to avoid cloning and make it more efficient

### DIFF
--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -78,7 +78,7 @@ impl<const B: usize> OpSetInternal<B> {
         F: FnMut(&mut Op),
     {
         if let Some((_typ, tree)) = self.trees.get_mut(obj) {
-            tree.replace(index, f)
+            tree.update(index, f)
         }
     }
 


### PR DESCRIPTION
Rather than:
- getting the op
- mutating it
- set it, cloning at each tree level for index insertion

We can do:
- go down to the op
- mutate in place
- on the way back up, modify the indices