### PR TITLE
Rename `del` and `inc` to `delete` and `increment`

### DIFF
--- a/automerge-cli/src/import.rs
+++ b/automerge-cli/src/import.rs
@@ -22,31 +22,31 @@ fn import_map(
     for (key, value) in map {
         match value {
             serde_json::Value::Null => {
-                doc.set(obj, key, ())?;
+                doc.put(obj, key, ())?;
             }
             serde_json::Value::Bool(b) => {
-                doc.set(obj, key, *b)?;
+                doc.put(obj, key, *b)?;
             }
             serde_json::Value::String(s) => {
-                doc.set(obj, key, s.as_ref())?;
+                doc.put(obj, key, s.as_ref())?;
             }
             serde_json::Value::Array(vec) => {
-                let id = doc.set_object(obj, key, am::ObjType::List)?;
+                let id = doc.put_object(obj, key, am::ObjType::List)?;
                 import_list(doc, &id, vec)?;
             }
             serde_json::Value::Number(n) => {
                 if let Some(m) = n.as_i64() {
-                    doc.set(obj, key, m)?;
+                    doc.put(obj, key, m)?;
                 } else if let Some(m) = n.as_u64() {
-                    doc.set(obj, key, m)?;
+                    doc.put(obj, key, m)?;
                 } else if let Some(m) = n.as_f64() {
-                    doc.set(obj, key, m)?;
+                    doc.put(obj, key, m)?;
                 } else {
                     anyhow::bail!("not a number");
                 }
             }
             serde_json::Value::Object(map) => {
-                let id = doc.set_object(obj, key, am::ObjType::Map)?;
+                let id = doc.put_object(obj, key, am::ObjType::Map)?;
                 import_map(doc, &id, map)?;
             }
         }

--- a/automerge-js/src/counter.js
+++ b/automerge-js/src/counter.js
@@ -50,7 +50,7 @@ class WriteableCounter extends Counter {
    */
   increment(delta) {
     delta = typeof delta === 'number' ? delta : 1
-    this.context.inc(this.objectId, this.key, delta)
+    this.context.increment(this.objectId, this.key, delta)
     this.value += delta
     return this.value
   }
@@ -60,7 +60,7 @@ class WriteableCounter extends Counter {
    * decreases the value of the counter by 1.
    */
   decrement(delta) {
-    return this.inc(typeof delta === 'number' ? -delta : -1)
+    return this.increment(typeof delta === 'number' ? -delta : -1)
   }
 }
 

--- a/automerge-js/src/proxies.js
+++ b/automerge-js/src/proxies.js
@@ -134,28 +134,28 @@ const MapHandler = {
     }
     switch (datatype) {
       case "list":
-        const list = context.setObject(objectId, key, [])
+        const list = context.putObject(objectId, key, [])
         const proxyList = listProxy(context, list, [ ... path, key ], readonly );
         for (let i = 0; i < value.length; i++) {
           proxyList[i] = value[i]
         }
         break;
       case "text":
-        const text = context.setObject(objectId, key, "", "text")
+        const text = context.putObject(objectId, key, "", "text")
         const proxyText = textProxy(context, text, [ ... path, key ], readonly );
         for (let i = 0; i < value.length; i++) {
           proxyText[i] = value.get(i)
         }
         break;
       case "map":
-        const map = context.setObject(objectId, key, {})
+        const map = context.putObject(objectId, key, {})
         const proxyMap = mapProxy(context, map, [ ... path, key ], readonly );
         for (const key in value) {
           proxyMap[key] = value[key]
         }
         break;
       default:
-        context.set(objectId, key, value, datatype)
+        context.put(objectId, key, value, datatype)
     }
     return true
   },
@@ -253,7 +253,7 @@ const ListHandler = {
         if (index >= context.length(objectId)) {
           list = context.insertObject(objectId, index, [])
         } else {
-          list = context.setObject(objectId, index, [])
+          list = context.putObject(objectId, index, [])
         }
         const proxyList = listProxy(context, list, [ ... path, index ], readonly);
         proxyList.splice(0,0,...value)
@@ -263,7 +263,7 @@ const ListHandler = {
         if (index >= context.length(objectId)) {
           text = context.insertObject(objectId, index, "", "text")
         } else {
-          text = context.setObject(objectId, index, "", "text")
+          text = context.putObject(objectId, index, "", "text")
         }
         const proxyText = textProxy(context, text, [ ... path, index ], readonly);
         proxyText.splice(0,0,...value)
@@ -273,7 +273,7 @@ const ListHandler = {
         if (index >= context.length(objectId)) {
           map = context.insertObject(objectId, index, {})
         } else {
-          map = context.setObject(objectId, index, {})
+          map = context.putObject(objectId, index, {})
         }
         const proxyMap = mapProxy(context, map, [ ... path, index ], readonly);
         for (const key in value) {
@@ -284,7 +284,7 @@ const ListHandler = {
         if (index >= context.length(objectId)) {
           context.insert(objectId, index, value, datatype)
         } else {
-          context.set(objectId, index, value, datatype)
+          context.put(objectId, index, value, datatype)
         }
     }
     return true
@@ -405,7 +405,7 @@ function listMethods(target) {
       let list = context.getObject(objectId)
       let [value, datatype] = valueAt(target, index)
       for (let index = parseListIndex(start || 0); index < parseListIndex(end || list.length); index++) {
-        context.set(objectId, index, value, datatype)
+        context.put(objectId, index, value, datatype)
       }
       return this
     },

--- a/automerge-js/src/proxies.js
+++ b/automerge-js/src/proxies.js
@@ -166,7 +166,7 @@ const MapHandler = {
     if (readonly) {
       throw new RangeError(`Object property "${key}" cannot be modified`)
     }
-    context.del(objectId, key)
+    context.delete(objectId, key)
     return true
   },
 
@@ -296,7 +296,7 @@ const ListHandler = {
     if (context.value(objectId, index)[0] == "counter") {
       throw new TypeError('Unsupported operation: deleting a counter from a list')
     }
-    context.del(objectId, index)
+    context.delete(objectId, index)
     return true
   },
 
@@ -395,7 +395,7 @@ function listMethods(target) {
       if (typeof numDelete === 'number') {
         context.splice(objectId, index, numDelete)
       } else {
-        context.del(objectId, index)
+        context.delete(objectId, index)
       }
       return this
     },
@@ -437,7 +437,7 @@ function listMethods(target) {
         return undefined
       }
       let last = valueAt(target, length - 1)
-      context.del(objectId, length - 1)
+      context.delete(objectId, length - 1)
       return last
     },
 
@@ -450,7 +450,7 @@ function listMethods(target) {
     shift() {
       if (context.length(objectId) == 0) return
       const first = valueAt(target, 0)
-      context.del(objectId, 0)
+      context.delete(objectId, 0)
       return first
     },
 
@@ -472,7 +472,7 @@ function listMethods(target) {
       for (let i = 0; i < del; i++) {
         let value = valueAt(target, index)
         result.push(value)
-        context.del(objectId, index)
+        context.delete(objectId, index)
       }
       const values = vals.map((val) => import_value(val))
       for (let [value,datatype] of values) {

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -92,8 +92,8 @@ export function decodeSyncState(data: Uint8Array): SyncState;
 
 export class Automerge {
   // change state
-  set(obj: ObjID, prop: Prop, value: Value, datatype?: Datatype): undefined;
-  setObject(obj: ObjID, prop: Prop, value: ObjType): ObjID;
+  put(obj: ObjID, prop: Prop, value: Value, datatype?: Datatype): undefined;
+  putObject(obj: ObjID, prop: Prop, value: ObjType): ObjID;
   insert(obj: ObjID, index: number, value: Value, datatype?: Datatype): undefined;
   insertObject(obj: ObjID, index: number, value: ObjType): ObjID;
   push(obj: ObjID, value: Value, datatype?: Datatype): undefined;

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -99,8 +99,8 @@ export class Automerge {
   push(obj: ObjID, value: Value, datatype?: Datatype): undefined;
   pushObject(obj: ObjID, value: ObjType): ObjID;
   splice(obj: ObjID, start: number, delete_count: number, text?: string | Array<Value>): ObjID[] | undefined;
-  inc(obj: ObjID, prop: Prop, value: number): void;
-  del(obj: ObjID, prop: Prop): void;
+  increment(obj: ObjID, prop: Prop, value: number): void;
+  delete(obj: ObjID, prop: Prop): void;
 
   // returns a single value - if there is a conflict return the winner
   value(obj: ObjID, prop: any, heads?: Heads): FullValue | null;

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -266,7 +266,7 @@ impl Automerge {
         let value: f64 = value
             .as_f64()
             .ok_or_else(|| to_js_err("inc needs a numberic value"))?;
-        self.0.inc(&obj, prop, value as i64)?;
+        self.0.increment(&obj, prop, value as i64)?;
         Ok(())
     }
 
@@ -418,7 +418,7 @@ impl Automerge {
     pub fn del(&mut self, obj: JsValue, prop: JsValue) -> Result<(), JsValue> {
         let obj = self.import(obj)?;
         let prop = to_prop(prop)?;
-        self.0.del(&obj, prop).map_err(to_js_err)?;
+        self.0.delete(&obj, prop).map_err(to_js_err)?;
         Ok(())
     }
 

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -203,7 +203,7 @@ impl Automerge {
         Ok(opid.to_string().into())
     }
 
-    pub fn set(
+    pub fn put(
         &mut self,
         obj: JsValue,
         prop: JsValue,
@@ -215,12 +215,12 @@ impl Automerge {
         let value = self
             .import_scalar(&value, &datatype.as_string())
             .ok_or_else(|| to_js_err("expected scalar value"))?;
-        self.0.set(&obj, prop, value)?;
+        self.0.put(&obj, prop, value)?;
         Ok(())
     }
 
-    #[wasm_bindgen(js_name = setObject)]
-    pub fn set_object(
+    #[wasm_bindgen(js_name = putObject)]
+    pub fn put_object(
         &mut self,
         obj: JsValue,
         prop: JsValue,
@@ -230,7 +230,7 @@ impl Automerge {
         let prop = self.import_prop(prop)?;
         let (value, subvals) =
             to_objtype(&value, &None).ok_or_else(|| to_js_err("expected object"))?;
-        let opid = self.0.set_object(&obj, prop, value)?;
+        let opid = self.0.put_object(&obj, prop, value)?;
         self.subset(&opid, subvals)?;
         Ok(opid.to_string().into())
     }
@@ -240,9 +240,9 @@ impl Automerge {
             let (value, subvals) = self.import_value(&v, None)?;
             //let opid = self.0.set(id, p, value)?;
             let opid = match (p, value) {
-                (Prop::Map(s), Value::Object(objtype)) => Some(self.0.set_object(obj, s, objtype)?),
+                (Prop::Map(s), Value::Object(objtype)) => Some(self.0.put_object(obj, s, objtype)?),
                 (Prop::Map(s), Value::Scalar(scalar)) => {
-                    self.0.set(obj, s, scalar)?;
+                    self.0.put(obj, s, scalar)?;
                     None
                 }
                 (Prop::Seq(i), Value::Object(objtype)) => {

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -260,12 +260,17 @@ impl Automerge {
         Ok(())
     }
 
-    pub fn inc(&mut self, obj: JsValue, prop: JsValue, value: JsValue) -> Result<(), JsValue> {
+    pub fn increment(
+        &mut self,
+        obj: JsValue,
+        prop: JsValue,
+        value: JsValue,
+    ) -> Result<(), JsValue> {
         let obj = self.import(obj)?;
         let prop = self.import_prop(prop)?;
         let value: f64 = value
             .as_f64()
-            .ok_or_else(|| to_js_err("inc needs a numberic value"))?;
+            .ok_or_else(|| to_js_err("increment needs a numeric value"))?;
         self.0.increment(&obj, prop, value as i64)?;
         Ok(())
     }
@@ -415,7 +420,7 @@ impl Automerge {
         }
     }
 
-    pub fn del(&mut self, obj: JsValue, prop: JsValue) -> Result<(), JsValue> {
+    pub fn delete(&mut self, obj: JsValue, prop: JsValue) -> Result<(), JsValue> {
         let obj = self.import(obj)?;
         let prop = to_prop(prop)?;
         self.0.delete(&obj, prop).map_err(to_js_err)?;

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -190,8 +190,8 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc.keys("_root"),["bip","foo"])
 
-      doc.del("_root", "foo")
-      doc.del("_root", "baz")
+      doc.delete("_root", "foo")
+      doc.delete("_root", "baz")
       let heads2 = doc.commit()
 
       assert.deepEqual(doc.keys("_root"),["bip"])
@@ -206,7 +206,7 @@ describe('Automerge', () => {
 
       doc.set(root, "xxx", "xxx");
       assert.deepEqual(doc.value(root, "xxx"),["str","xxx"])
-      doc.del(root, "xxx");
+      doc.delete(root, "xxx");
       assert.deepEqual(doc.value(root, "xxx"),undefined)
       doc.free()
     })
@@ -217,9 +217,9 @@ describe('Automerge', () => {
 
       doc.set(root, "counter", 10, "counter");
       assert.deepEqual(doc.value(root, "counter"),["counter",10])
-      doc.inc(root, "counter", 10);
+      doc.increment(root, "counter", 10);
       assert.deepEqual(doc.value(root, "counter"),["counter",20])
-      doc.inc(root, "counter", -5);
+      doc.increment(root, "counter", -5);
       assert.deepEqual(doc.value(root, "counter"),["counter",15])
       doc.free()
     })
@@ -319,7 +319,7 @@ describe('Automerge', () => {
         ['counter',0,'2@bbbb'],
         ['counter',10,'2@cccc'],
       ])
-      doc1.inc("_root", "cnt", 5)
+      doc1.increment("_root", "cnt", 5)
       result = doc1.values("_root", "cnt")
       assert.deepEqual(result, [
         [ 'counter', 5, '2@bbbb' ],
@@ -352,7 +352,7 @@ describe('Automerge', () => {
         ['counter',0,'3@bbbb'],
         ['counter',10,'3@cccc'],
       ])
-      doc1.inc(seq, 0, 5)
+      doc1.increment(seq, 0, 5)
       result = doc1.values(seq, 0)
       assert.deepEqual(result, [
         [ 'counter', 5, '3@bbbb' ],
@@ -414,8 +414,8 @@ describe('Automerge', () => {
       let r1 = doc.set("_root","foo","bar")
       let r2 = doc.setObject("_root","list",[])
       let r3 = doc.set("_root","counter",10, "counter")
-      let r4 = doc.inc("_root","counter",1)
-      let r5 = doc.del("_root","counter")
+      let r4 = doc.increment("_root","counter",1)
+      let r5 = doc.delete("_root","counter")
       let r6 = doc.insert(r2,0,10);
       let r7 = doc.insertObject(r2,0,{});
       let r8 = doc.splice(r2,1,0,["a","b","c"]);
@@ -508,7 +508,7 @@ describe('Automerge', () => {
       doc1.set('_root', 'favouriteBird', 'Robin')
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
-      doc1.del('_root', 'favouriteBird')
+      doc1.delete('_root', 'favouriteBird')
       doc2.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc2.popPatches(), [
         {action: 'assign', obj: '_root', key: 'favouriteBird', value: 'Robin', datatype: 'str', conflict: false},
@@ -552,7 +552,7 @@ describe('Automerge', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
       doc1.setObject('_root', 'birds', ['Goldfinch', 'Chaffinch'])
       doc2.loadIncremental(doc1.saveIncremental())
-      doc1.del('1@aaaa', 0)
+      doc1.delete('1@aaaa', 0)
       doc1.insert('1@aaaa', 1, 'Greenfinch')
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
@@ -719,7 +719,7 @@ describe('Automerge', () => {
       doc1.set('_root', 'bird', 'Greenfinch')
       doc2.loadIncremental(doc1.saveIncremental())
       doc1.set('_root', 'bird', 'Goldfinch')
-      doc2.del('_root', 'bird')
+      doc2.delete('_root', 'bird')
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
       doc1.enablePatches(true)
       doc2.enablePatches(true)
@@ -774,7 +774,7 @@ describe('Automerge', () => {
       doc2.loadIncremental(change1)
       doc3.loadIncremental(change1)
       doc4.loadIncremental(change1)
-      doc1.del('1@aaaa', 0)
+      doc1.delete('1@aaaa', 0)
       doc1.set('1@aaaa', 1, 'Song Thrush')
       doc2.set('1@aaaa', 0, 'Ring-necked parakeet')
       doc2.set('1@aaaa', 2, 'Redwing')
@@ -807,7 +807,7 @@ describe('Automerge', () => {
       doc1.set('_root', 'bird', 'Robin')
       doc2.set('_root', 'bird', 'Wren')
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
-      doc2.del('_root', 'bird')
+      doc2.delete('_root', 'bird')
       let change3 = doc2.saveIncremental()
       doc3.enablePatches(true)
       doc3.loadIncremental(change1)
@@ -866,7 +866,7 @@ describe('Automerge', () => {
       doc2.enablePatches(true)
       doc1.set('_root', 'starlings', 2, 'counter')
       doc2.loadIncremental(doc1.saveIncremental())
-      doc1.inc('_root', 'starlings', 1)
+      doc1.increment('_root', 'starlings', 1)
       doc1.dump()
       doc2.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc2.value('_root', 'starlings'), ['counter', 3])

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -55,17 +55,17 @@ describe('Automerge', () => {
       let root = "_root"
       let result
 
-      doc.set(root, "hello", "world")
-      doc.set(root, "number1", 5, "uint")
-      doc.set(root, "number2", 5)
-      doc.set(root, "number3", 5.5)
-      doc.set(root, "number4", 5.5, "f64")
-      doc.set(root, "number5", 5.5, "int")
-      doc.set(root, "bool", true)
-      doc.set(root, "time1", 1000, "timestamp")
-      doc.set(root, "time2", new Date(1001))
-      doc.setObject(root, "list", []);
-      doc.set(root, "null", null)
+      doc.put(root, "hello", "world")
+      doc.put(root, "number1", 5, "uint")
+      doc.put(root, "number2", 5)
+      doc.put(root, "number3", 5.5)
+      doc.put(root, "number4", 5.5, "f64")
+      doc.put(root, "number5", 5.5, "int")
+      doc.put(root, "bool", true)
+      doc.put(root, "time1", 1000, "timestamp")
+      doc.put(root, "time2", new Date(1001))
+      doc.putObject(root, "list", []);
+      doc.put(root, "null", null)
 
       result = doc.value(root,"hello")
       assert.deepEqual(result,["str","world"])
@@ -88,7 +88,7 @@ describe('Automerge', () => {
       result = doc.value(root,"bool")
       assert.deepEqual(result,["boolean",true])
 
-      doc.set(root, "bool", false, "boolean")
+      doc.put(root, "bool", false, "boolean")
 
       result = doc.value(root,"bool")
       assert.deepEqual(result,["boolean",false])
@@ -110,8 +110,8 @@ describe('Automerge', () => {
 
     it('should be able to use bytes', () => {
       let doc = create()
-      doc.set("_root","data1", new Uint8Array([10,11,12]));
-      doc.set("_root","data2", new Uint8Array([13,14,15]), "bytes");
+      doc.put("_root","data1", new Uint8Array([10,11,12]));
+      doc.put("_root","data2", new Uint8Array([13,14,15]), "bytes");
       let value1 = doc.value("_root", "data1")
       assert.deepEqual(value1, ["bytes", new Uint8Array([10,11,12])]);
       let value2 = doc.value("_root", "data2")
@@ -124,8 +124,8 @@ describe('Automerge', () => {
       let root = "_root"
       let result
 
-      let submap = doc.setObject(root, "submap", {})
-      doc.set(submap, "number", 6, "uint")
+      let submap = doc.putObject(root, "submap", {})
+      doc.put(submap, "number", 6, "uint")
       assert.strictEqual(doc.pendingOps(),2)
 
       result = doc.value(root,"submap")
@@ -140,7 +140,7 @@ describe('Automerge', () => {
       let doc = create()
       let root = "_root"
 
-      let submap = doc.setObject(root, "numbers", [])
+      let submap = doc.putObject(root, "numbers", [])
       doc.insert(submap, 0, "a");
       doc.insert(submap, 1, "b");
       doc.insert(submap, 2, "c");
@@ -152,7 +152,7 @@ describe('Automerge', () => {
       assert.deepEqual(doc.value(submap, 3),["str","c"])
       assert.deepEqual(doc.length(submap),4)
 
-      doc.set(submap, 2, "b v2");
+      doc.put(submap, 2, "b v2");
 
       assert.deepEqual(doc.value(submap, 2),["str","b v2"])
       assert.deepEqual(doc.length(submap),4)
@@ -163,7 +163,7 @@ describe('Automerge', () => {
       let doc = create()
       let root = "_root"
 
-      let submap = doc.setObject(root, "letters", [])
+      let submap = doc.putObject(root, "letters", [])
       doc.insert(submap, 0, "a");
       doc.insert(submap, 0, "b");
       assert.deepEqual(doc.materialize(), { letters: ["b", "a" ] })
@@ -173,7 +173,7 @@ describe('Automerge', () => {
       assert.deepEqual(doc.materialize(), { letters: ["b", "a", "c", new Date(3) ] })
       doc.splice(submap, 1, 1, ["d","e","f"]);
       assert.deepEqual(doc.materialize(), { letters: ["b", "d", "e", "f", "c", new Date(3) ] })
-      doc.set(submap, 0, "z");
+      doc.put(submap, 0, "z");
       assert.deepEqual(doc.materialize(), { letters: ["z", "d", "e", "f", "c", new Date(3) ] })
       assert.deepEqual(doc.materialize(submap), ["z", "d", "e", "f", "c", new Date(3) ])
       assert.deepEqual(doc.length(submap),6)
@@ -184,8 +184,8 @@ describe('Automerge', () => {
     it('should be able delete non-existant props', () => {
       let doc = create()
 
-      doc.set("_root", "foo","bar")
-      doc.set("_root", "bip","bap")
+      doc.put("_root", "foo","bar")
+      doc.put("_root", "bip","bap")
       let heads1 = doc.commit()
 
       assert.deepEqual(doc.keys("_root"),["bip","foo"])
@@ -204,7 +204,7 @@ describe('Automerge', () => {
       let doc = create()
       let root = "_root"
 
-      doc.set(root, "xxx", "xxx");
+      doc.put(root, "xxx", "xxx");
       assert.deepEqual(doc.value(root, "xxx"),["str","xxx"])
       doc.delete(root, "xxx");
       assert.deepEqual(doc.value(root, "xxx"),undefined)
@@ -215,7 +215,7 @@ describe('Automerge', () => {
       let doc = create()
       let root = "_root"
 
-      doc.set(root, "counter", 10, "counter");
+      doc.put(root, "counter", 10, "counter");
       assert.deepEqual(doc.value(root, "counter"),["counter",10])
       doc.increment(root, "counter", 10);
       assert.deepEqual(doc.value(root, "counter"),["counter",20])
@@ -228,7 +228,7 @@ describe('Automerge', () => {
       let doc = create()
       let root = "_root";
 
-      let text = doc.setObject(root, "text", "");
+      let text = doc.putObject(root, "text", "");
       if (!text) throw new Error('should not be undefined')
       doc.splice(text, 0, 0, "hello ")
       doc.splice(text, 6, 0, ["w","o","r","l","d"])
@@ -244,7 +244,7 @@ describe('Automerge', () => {
 
     it('should be able to insert objects into text', () => {
       let doc = create()
-      let text = doc.setObject("/", "text", "Hello world");
+      let text = doc.putObject("/", "text", "Hello world");
       let obj = doc.insertObject(text, 6, { hello: "world" });
       assert.deepEqual(doc.text(text), "Hello \ufffcworld");
       assert.deepEqual(doc.value(text, 6), ["map", obj]);
@@ -254,17 +254,17 @@ describe('Automerge', () => {
     it('should be able save all or incrementally', () => {
       let doc = create()
 
-      doc.set("_root", "foo", 1)
+      doc.put("_root", "foo", 1)
 
       let save1 = doc.save()
 
-      doc.set("_root", "bar", 2)
+      doc.put("_root", "bar", 2)
 
       let saveMidway = doc.clone().save();
 
       let save2 = doc.saveIncremental();
 
-      doc.set("_root", "baz", 3);
+      doc.put("_root", "baz", 3);
 
       let save3 = doc.saveIncremental();
 
@@ -289,7 +289,7 @@ describe('Automerge', () => {
 
     it('should be able to splice text', () => {
       let doc = create()
-      let text = doc.setObject("_root", "text", "");
+      let text = doc.putObject("_root", "text", "");
       doc.splice(text, 0, 0, "hello world");
       let heads1 = doc.commit();
       doc.splice(text, 6, 0, "big bad ");
@@ -305,12 +305,12 @@ describe('Automerge', () => {
 
     it('local inc increments all visible counters in a map', () => {
       let doc1 = create("aaaa")
-      doc1.set("_root", "hello", "world")
+      doc1.put("_root", "hello", "world")
       let doc2 = loadDoc(doc1.save(), "bbbb");
       let doc3 = loadDoc(doc1.save(), "cccc");
-      doc1.set("_root", "cnt", 20)
-      doc2.set("_root", "cnt", 0, "counter")
-      doc3.set("_root", "cnt", 10, "counter")
+      doc1.put("_root", "cnt", 20)
+      doc2.put("_root", "cnt", 0, "counter")
+      doc3.put("_root", "cnt", 10, "counter")
       doc1.applyChanges(doc2.getChanges(doc1.getHeads()))
       doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values("_root", "cnt")
@@ -337,13 +337,13 @@ describe('Automerge', () => {
 
     it('local inc increments all visible counters in a sequence', () => {
       let doc1 = create("aaaa")
-      let seq = doc1.setObject("_root", "seq", [])
+      let seq = doc1.putObject("_root", "seq", [])
       doc1.insert(seq, 0, "hello")
       let doc2 = loadDoc(doc1.save(), "bbbb");
       let doc3 = loadDoc(doc1.save(), "cccc");
-      doc1.set(seq, 0, 20)
-      doc2.set(seq, 0, 0, "counter")
-      doc3.set(seq, 0, 10, "counter")
+      doc1.put(seq, 0, 20)
+      doc2.put(seq, 0, 0, "counter")
+      doc3.put(seq, 0, 10, "counter")
       doc1.applyChanges(doc2.getChanges(doc1.getHeads()))
       doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
       let result = doc1.values(seq, 0)
@@ -370,7 +370,7 @@ describe('Automerge', () => {
 
     it('paths can be used instead of objids', () => {
       let doc = create("aaaa")
-      doc.setObject("_root","list",[{ foo: "bar"}, [1,2,3]])
+      doc.putObject("_root","list",[{ foo: "bar"}, [1,2,3]])
       assert.deepEqual(doc.materialize("/"), { list: [{ foo: "bar"}, [1,2,3]] })
       assert.deepEqual(doc.materialize("/list"), [{ foo: "bar"}, [1,2,3]])
       assert.deepEqual(doc.materialize("/list/0"), { foo: "bar"})
@@ -379,8 +379,8 @@ describe('Automerge', () => {
     it('should be able to fetch changes by hash', () => {
       let doc1 = create("aaaa")
       let doc2 = create("bbbb")
-      doc1.set("/","a","b")
-      doc2.set("/","b","c")
+      doc1.put("/","a","b")
+      doc2.put("/","b","c")
       let head1 = doc1.getHeads()
       let head2 = doc2.getHeads()
       let change1 = doc1.getChangeByHash(head1[0])
@@ -392,11 +392,11 @@ describe('Automerge', () => {
 
     it('recursive sets are possible', () => {
       let doc = create("aaaa")
-      let l1 = doc.setObject("_root","list",[{ foo: "bar"}, [1,2,3]])
+      let l1 = doc.putObject("_root","list",[{ foo: "bar"}, [1,2,3]])
       let l2 = doc.insertObject(l1, 0, { zip: ["a", "b"] })
-      let l3 = doc.setObject("_root","info1","hello world") // 'text' object
-               doc.set("_root","info2","hello world")  // 'str'
-      let l4 = doc.setObject("_root","info3","hello world")
+      let l3 = doc.putObject("_root","info1","hello world") // 'text' object
+               doc.put("_root","info2","hello world")  // 'str'
+      let l4 = doc.putObject("_root","info3","hello world")
       assert.deepEqual(doc.materialize(), {
         "list": [ { zip: ["a", "b"] }, { foo: "bar"}, [ 1,2,3]],
         "info1": "hello world",
@@ -411,9 +411,9 @@ describe('Automerge', () => {
 
     it('only returns an object id when objects are created', () => {
       let doc = create("aaaa")
-      let r1 = doc.set("_root","foo","bar")
-      let r2 = doc.setObject("_root","list",[])
-      let r3 = doc.set("_root","counter",10, "counter")
+      let r1 = doc.put("_root","foo","bar")
+      let r2 = doc.putObject("_root","list",[])
+      let r3 = doc.put("_root","counter",10, "counter")
       let r4 = doc.increment("_root","counter",1)
       let r5 = doc.delete("_root","counter")
       let r6 = doc.insert(r2,0,10);
@@ -434,10 +434,10 @@ describe('Automerge', () => {
 
     it('objects without properties are preserved', () => {
       let doc1 = create("aaaa")
-      let a = doc1.setObject("_root","a",{});
-      let b = doc1.setObject("_root","b",{});
-      let c = doc1.setObject("_root","c",{});
-      let d = doc1.set(c,"d","dd");
+      let a = doc1.putObject("_root","a",{});
+      let b = doc1.putObject("_root","b",{});
+      let c = doc1.putObject("_root","c",{});
+      let d = doc1.put(c,"d","dd");
       let saved = doc1.save();
       let doc2 = loadDoc(saved);
       assert.deepEqual(doc2.value("_root","a"),["map",a])
@@ -453,7 +453,7 @@ describe('Automerge', () => {
 
     it('should handle merging text conflicts then saving & loading', () => {
       let A = create("aabbcc")
-      let At = A.setObject('_root', 'text', "")
+      let At = A.putObject('_root', 'text', "")
       A.splice(At, 0, 0, 'hello')
 
       let B = A.fork()
@@ -479,7 +479,7 @@ describe('Automerge', () => {
   describe('patch generation', () => {
     it('should include root object key updates', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.set('_root', 'hello', 'world')
+      doc1.put('_root', 'hello', 'world')
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc2.popPatches(), [
@@ -491,7 +491,7 @@ describe('Automerge', () => {
 
     it('should include nested object creation', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.setObject('_root', 'birds', {friday: {robins: 3}})
+      doc1.putObject('_root', 'birds', {friday: {robins: 3}})
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc2.popPatches(), [
@@ -505,7 +505,7 @@ describe('Automerge', () => {
 
     it('should delete map keys', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.set('_root', 'favouriteBird', 'Robin')
+      doc1.put('_root', 'favouriteBird', 'Robin')
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
       doc1.delete('_root', 'favouriteBird')
@@ -520,7 +520,7 @@ describe('Automerge', () => {
 
     it('should include list element insertion', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.setObject('_root', 'birds', ['Goldfinch', 'Chaffinch'])
+      doc1.putObject('_root', 'birds', ['Goldfinch', 'Chaffinch'])
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc2.popPatches(), [
@@ -534,7 +534,7 @@ describe('Automerge', () => {
 
     it('should insert nested maps into a list', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.setObject('_root', 'birds', [])
+      doc1.putObject('_root', 'birds', [])
       doc2.loadIncremental(doc1.saveIncremental())
       doc1.insertObject('1@aaaa', 0, {species: 'Goldfinch', count: 3})
       doc2.enablePatches(true)
@@ -550,7 +550,7 @@ describe('Automerge', () => {
 
     it('should calculate list indexes based on visible elements', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.setObject('_root', 'birds', ['Goldfinch', 'Chaffinch'])
+      doc1.putObject('_root', 'birds', ['Goldfinch', 'Chaffinch'])
       doc2.loadIncremental(doc1.saveIncremental())
       doc1.delete('1@aaaa', 0)
       doc1.insert('1@aaaa', 1, 'Greenfinch')
@@ -568,7 +568,7 @@ describe('Automerge', () => {
 
     it('should handle concurrent insertions at the head of a list', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc'), doc4 = create('dddd')
-      doc1.setObject('_root', 'values', [])
+      doc1.putObject('_root', 'values', [])
       let change1 = doc1.saveIncremental()
       doc2.loadIncremental(change1)
       doc3.loadIncremental(change1)
@@ -601,7 +601,7 @@ describe('Automerge', () => {
 
     it('should handle concurrent insertions beyond the head', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc'), doc4 = create('dddd')
-      doc1.setObject('_root', 'values', ['a', 'b'])
+      doc1.putObject('_root', 'values', ['a', 'b'])
       let change1 = doc1.saveIncremental()
       doc2.loadIncremental(change1)
       doc3.loadIncremental(change1)
@@ -634,8 +634,8 @@ describe('Automerge', () => {
 
     it('should handle conflicts on root object keys', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc'), doc4 = create('dddd')
-      doc1.set('_root', 'bird', 'Greenfinch')
-      doc2.set('_root', 'bird', 'Goldfinch')
+      doc1.put('_root', 'bird', 'Greenfinch')
+      doc2.put('_root', 'bird', 'Goldfinch')
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
       doc3.enablePatches(true)
       doc4.enablePatches(true)
@@ -658,9 +658,9 @@ describe('Automerge', () => {
 
     it('should handle three-way conflicts', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc')
-      doc1.set('_root', 'bird', 'Greenfinch')
-      doc2.set('_root', 'bird', 'Chaffinch')
-      doc3.set('_root', 'bird', 'Goldfinch')
+      doc1.put('_root', 'bird', 'Greenfinch')
+      doc2.put('_root', 'bird', 'Chaffinch')
+      doc3.put('_root', 'bird', 'Goldfinch')
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental(), change3 = doc3.saveIncremental()
       doc1.enablePatches(true)
       doc2.enablePatches(true)
@@ -697,13 +697,13 @@ describe('Automerge', () => {
 
     it('should allow a conflict to be resolved', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc')
-      doc1.set('_root', 'bird', 'Greenfinch')
-      doc2.set('_root', 'bird', 'Chaffinch')
+      doc1.put('_root', 'bird', 'Greenfinch')
+      doc2.put('_root', 'bird', 'Chaffinch')
       doc3.enablePatches(true)
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
       doc1.loadIncremental(change2); doc3.loadIncremental(change1)
       doc2.loadIncremental(change1); doc3.loadIncremental(change2)
-      doc1.set('_root', 'bird', 'Goldfinch')
+      doc1.put('_root', 'bird', 'Goldfinch')
       doc3.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc3.values('_root', 'bird'), [['str', 'Goldfinch', '2@aaaa']])
       assert.deepEqual(doc3.popPatches(), [
@@ -716,9 +716,9 @@ describe('Automerge', () => {
 
     it('should handle a concurrent map key overwrite and delete', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.set('_root', 'bird', 'Greenfinch')
+      doc1.put('_root', 'bird', 'Greenfinch')
       doc2.loadIncremental(doc1.saveIncremental())
-      doc1.set('_root', 'bird', 'Goldfinch')
+      doc1.put('_root', 'bird', 'Goldfinch')
       doc2.delete('_root', 'bird')
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
       doc1.enablePatches(true)
@@ -740,13 +740,13 @@ describe('Automerge', () => {
 
     it('should handle a conflict on a list element', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc'), doc4 = create('dddd')
-      doc1.setObject('_root', 'birds', ['Thrush', 'Magpie'])
+      doc1.putObject('_root', 'birds', ['Thrush', 'Magpie'])
       let change1 = doc1.saveIncremental()
       doc2.loadIncremental(change1)
       doc3.loadIncremental(change1)
       doc4.loadIncremental(change1)
-      doc1.set('1@aaaa', 0, 'Song Thrush')
-      doc2.set('1@aaaa', 0, 'Redwing')
+      doc1.put('1@aaaa', 0, 'Song Thrush')
+      doc2.put('1@aaaa', 0, 'Redwing')
       let change2 = doc1.saveIncremental(), change3 = doc2.saveIncremental()
       doc3.enablePatches(true)
       doc4.enablePatches(true)
@@ -769,15 +769,15 @@ describe('Automerge', () => {
 
     it('should handle a concurrent list element overwrite and delete', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc'), doc4 = create('dddd')
-      doc1.setObject('_root', 'birds', ['Parakeet', 'Magpie', 'Thrush'])
+      doc1.putObject('_root', 'birds', ['Parakeet', 'Magpie', 'Thrush'])
       let change1 = doc1.saveIncremental()
       doc2.loadIncremental(change1)
       doc3.loadIncremental(change1)
       doc4.loadIncremental(change1)
       doc1.delete('1@aaaa', 0)
-      doc1.set('1@aaaa', 1, 'Song Thrush')
-      doc2.set('1@aaaa', 0, 'Ring-necked parakeet')
-      doc2.set('1@aaaa', 2, 'Redwing')
+      doc1.put('1@aaaa', 1, 'Song Thrush')
+      doc2.put('1@aaaa', 0, 'Ring-necked parakeet')
+      doc2.put('1@aaaa', 2, 'Redwing')
       let change2 = doc1.saveIncremental(), change3 = doc2.saveIncremental()
       doc3.enablePatches(true)
       doc4.enablePatches(true)
@@ -804,8 +804,8 @@ describe('Automerge', () => {
 
     it('should handle deletion of a conflict value', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb'), doc3 = create('cccc')
-      doc1.set('_root', 'bird', 'Robin')
-      doc2.set('_root', 'bird', 'Wren')
+      doc1.put('_root', 'bird', 'Robin')
+      doc2.put('_root', 'bird', 'Wren')
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
       doc2.delete('_root', 'bird')
       let change3 = doc2.saveIncremental()
@@ -828,8 +828,8 @@ describe('Automerge', () => {
 
     it('should handle conflicting nested objects', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
-      doc1.setObject('_root', 'birds', ['Parakeet'])
-      doc2.setObject('_root', 'birds', {'Sparrowhawk': 1})
+      doc1.putObject('_root', 'birds', ['Parakeet'])
+      doc2.putObject('_root', 'birds', {'Sparrowhawk': 1})
       let change1 = doc1.saveIncremental(), change2 = doc2.saveIncremental()
       doc1.enablePatches(true)
       doc2.enablePatches(true)
@@ -851,7 +851,7 @@ describe('Automerge', () => {
     it('should support date objects', () => {
       // FIXME: either use Date objects or use numbers consistently
       let doc1 = create('aaaa'), doc2 = create('bbbb'), now = new Date()
-      doc1.set('_root', 'createdAt', now.getTime(), 'timestamp')
+      doc1.put('_root', 'createdAt', now.getTime(), 'timestamp')
       doc2.enablePatches(true)
       doc2.loadIncremental(doc1.saveIncremental())
       assert.deepEqual(doc2.value('_root', 'createdAt'), ['timestamp', now])
@@ -864,7 +864,7 @@ describe('Automerge', () => {
     it.skip('should support counters in a map', () => {
       let doc1 = create('aaaa'), doc2 = create('bbbb')
       doc2.enablePatches(true)
-      doc1.set('_root', 'starlings', 2, 'counter')
+      doc1.put('_root', 'starlings', 2, 'counter')
       doc2.loadIncremental(doc1.saveIncremental())
       doc1.increment('_root', 'starlings', 1)
       doc1.dump()
@@ -912,7 +912,7 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       // make two nodes with the same changes
-      let list = n1.setObject("_root","n", [])
+      let list = n1.putObject("_root","n", [])
       n1.commit("",0)
       for (let i = 0; i < 10; i++) {
         n1.insert(list,i,i)
@@ -936,7 +936,7 @@ describe('Automerge', () => {
       let n1 = create(), n2 = create()
 
       // make changes for n1 that n2 should request
-      let list = n1.setObject("_root","n",[])
+      let list = n1.putObject("_root","n",[])
       n1.commit("",0)
       for (let i = 0; i < 10; i++) {
         n1.insert(list, i, i)
@@ -952,7 +952,7 @@ describe('Automerge', () => {
       let n1 = create(), n2 = create()
 
       // make changes for n1 that n2 should request
-      let list = n1.setObject("_root","n",[])
+      let list = n1.putObject("_root","n",[])
       n1.commit("",0)
       for (let i = 0; i < 10; i++) {
         n1.insert(list,i,i)
@@ -970,7 +970,7 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 5; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
@@ -978,7 +978,7 @@ describe('Automerge', () => {
 
       // modify the first node further
       for (let i = 5; i < 10; i++) {
-        n1.set("_root", "x", i)
+        n1.put("_root", "x", i)
         n1.commit("",0)
       }
 
@@ -994,11 +994,11 @@ describe('Automerge', () => {
 
       let message, patch
       for (let i = 0; i < 5; i++) {
-          n1.set("_root","x",i)
+          n1.put("_root","x",i)
           n1.commit("",0)
       }
       for (let i = 0; i < 5; i++) {
-          n2.set("_root","y",i)
+          n2.put("_root","y",i)
           n2.commit("",0)
       }
 
@@ -1041,11 +1041,11 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 5; i++) {
-        n1.set("_root", "x",  i)
+        n1.put("_root", "x",  i)
         n1.commit("",0)
       }
       for (let i = 0; i < 5; i++) {
-          n2.set("_root","y", i)
+          n2.put("_root","y", i)
           n2.commit("",0)
       }
 
@@ -1109,7 +1109,7 @@ describe('Automerge', () => {
       assert.deepStrictEqual(msg2to1, null)
 
       // If we make one more change, and start another sync, its lastSync should be updated
-      n1.set("_root","x",5)
+      n1.put("_root","x",5)
       msg1to2 = n1.generateSyncMessage(s1)
       if (msg1to2 === null) { throw new RangeError("message should not be null") }
       assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync, [head1, head2].sort())
@@ -1119,7 +1119,7 @@ describe('Automerge', () => {
       let n1 = create('01234567'), n2 = create('89abcdef')
       let s1 = initSyncState(), s2 = initSyncState(), message = null
 
-      let items = n1.setObject("_root", "items", [])
+      let items = n1.putObject("_root", "items", [])
       n1.commit("",0)
 
       sync(n1, n2, s1, s2)
@@ -1150,7 +1150,7 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 5; i++) {
-        n1.set("_root", "x", i)
+        n1.put("_root", "x", i)
         n1.commit("",0)
       }
 
@@ -1158,7 +1158,7 @@ describe('Automerge', () => {
 
       // modify the first node further
       for (let i = 5; i < 10; i++) {
-        n1.set("_root", "x", i)
+        n1.put("_root", "x", i)
         n1.commit("",0)
       }
 
@@ -1178,19 +1178,19 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 10; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
       sync(n1, n2)
 
       for (let i = 10; i < 15; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
       for (let i = 15; i < 18; i++) {
-        n2.set("_root","x",i)
+        n2.put("_root","x",i)
         n2.commit("",0)
       }
 
@@ -1211,18 +1211,18 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 10; i++) {
-          n1.set("_root","x",i)
+          n1.put("_root","x",i)
           n1.commit("",0)
       }
 
       sync(n1, n2, s1, s2)
 
       for (let i = 10; i < 15; i++) {
-         n1.set("_root","x",i)
+         n1.put("_root","x",i)
          n1.commit("",0)
       }
       for (let i = 15; i < 18; i++) {
-         n2.set("_root","x",i)
+         n2.put("_root","x",i)
          n2.commit("",0)
       }
 
@@ -1240,7 +1240,7 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 3; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
@@ -1260,7 +1260,7 @@ describe('Automerge', () => {
 
       // n1 makes three changes, which we sync to n2
       for (let i = 0; i < 3; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
@@ -1272,7 +1272,7 @@ describe('Automerge', () => {
 
       // sync another few commits
       for (let i = 3; i < 6; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
@@ -1284,7 +1284,7 @@ describe('Automerge', () => {
 
       // now make a few more changes, then attempt to sync the fully-up-to-date n1 with the confused r
       for (let i = 6; i < 9; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
@@ -1306,7 +1306,7 @@ describe('Automerge', () => {
 
       // n1 makes three changes, which we sync to n2
       for (let i = 0; i < 3; i++) {
-        n1.set("_root","x",i)
+        n1.put("_root","x",i)
         n1.commit("",0)
       }
 
@@ -1330,20 +1330,20 @@ describe('Automerge', () => {
 
       // Change 1 is known to all three nodes
       //n1 = Automerge.change(n1, {time: 0}, doc => doc.x = 1)
-      n1.set("_root","x",1); n1.commit("",0)
+      n1.put("_root","x",1); n1.commit("",0)
 
       sync(n1, n2, s12, s21)
       sync(n2, n3, s23, s32)
 
       // Change 2 is known to n1 and n2
-      n1.set("_root","x",2); n1.commit("",0)
+      n1.put("_root","x",2); n1.commit("",0)
 
       sync(n1, n2, s12, s21)
 
       // Each of the three nodes makes one change (changes 3, 4, 5)
-      n1.set("_root","x",3); n1.commit("",0)
-      n2.set("_root","x",4); n2.commit("",0)
-      n3.set("_root","x",5); n3.commit("",0)
+      n1.put("_root","x",3); n1.commit("",0)
+      n2.put("_root","x",4); n2.commit("",0)
+      n3.put("_root","x",5); n3.commit("",0)
 
       // Apply n3's latest change to n2. If running in Node, turn the Uint8Array into a Buffer, to
       // simulate transmission over a network (see https://github.com/automerge/automerge/pull/362)
@@ -1361,10 +1361,10 @@ describe('Automerge', () => {
 
     it('should handle histories with lots of branching and merging', () => {
       let n1 = create('01234567'), n2 = create('89abcdef'), n3 = create('fedcba98')
-      n1.set("_root","x",0); n1.commit("",0)
+      n1.put("_root","x",0); n1.commit("",0)
       n2.applyChanges([n1.getLastLocalChange()])
       n3.applyChanges([n1.getLastLocalChange()])
-      n3.set("_root","x",1); n3.commit("",0)
+      n3.put("_root","x",1); n3.commit("",0)
 
       //        - n1c1 <------ n1c2 <------ n1c3 <-- etc. <-- n1c20 <------ n1c21
       //       /          \/           \/                              \/
@@ -1373,8 +1373,8 @@ describe('Automerge', () => {
       //      \                                                          /
       //       ---------------------------------------------- n3c1 <-----
       for (let i = 1; i < 20; i++) {
-        n1.set("_root","n1",i); n1.commit("",0)
-        n2.set("_root","n2",i); n2.commit("",0)
+        n1.put("_root","n1",i); n1.commit("",0)
+        n2.put("_root","n2",i); n2.commit("",0)
         const change1 = n1.getLastLocalChange()
         const change2 = n2.getLastLocalChange()
         n1.applyChanges([change2])
@@ -1386,8 +1386,8 @@ describe('Automerge', () => {
 
       // Having n3's last change concurrent to the last sync heads forces us into the slower code path
       n2.applyChanges([n3.getLastLocalChange()])
-      n1.set("_root","n1","final"); n1.commit("",0)
-      n2.set("_root","n2","final"); n2.commit("",0)
+      n1.put("_root","n1","final"); n1.commit("",0)
+      n2.put("_root","n2","final"); n2.commit("",0)
 
       sync(n1, n2, s1, s2)
       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())
@@ -1404,15 +1404,15 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 10; i++) {
-        n1.set("_root","x",i); n1.commit("",0)
+        n1.put("_root","x",i); n1.commit("",0)
       }
 
       sync(n1, n2, s1, s2)
       for (let i = 1; ; i++) { // search for false positive; see comment above
         const n1up = n1.clone('01234567');
-        n1up.set("_root","x",`${i} @ n1`); n1up.commit("",0)
+        n1up.put("_root","x",`${i} @ n1`); n1up.commit("",0)
         const n2up = n2.clone('89abcdef');
-        n2up.set("_root","x",`${i} @ n2`); n2up.commit("",0)
+        n2up.put("_root","x",`${i} @ n2`); n2up.commit("",0)
         if (new BloomFilter(n1up.getHeads()).containsHash(n2up.getHeads()[0])) {
           n1.free(); n2.free()
           n1 = n1up; n2 = n2up; break
@@ -1441,25 +1441,25 @@ describe('Automerge', () => {
         s1 = initSyncState()
         s2 = initSyncState()
         for (let i = 0; i < 10; i++) {
-          n1.set("_root","x",i); n1.commit("",0)
+          n1.put("_root","x",i); n1.commit("",0)
         }
         sync(n1, n2, s1, s2)
 
         let n1hash1, n2hash1
         for (let i = 29; ; i++) { // search for false positive; see comment above
           const n1us1 = n1.clone('01234567')
-          n1us1.set("_root","x",`${i} @ n1`); n1us1.commit("",0)
+          n1us1.put("_root","x",`${i} @ n1`); n1us1.commit("",0)
 
           const n2us1 = n2.clone('89abcdef')
-          n2us1.set("_root","x",`${i} @ n1`); n2us1.commit("",0)
+          n2us1.put("_root","x",`${i} @ n1`); n2us1.commit("",0)
 
           n1hash1 = n1us1.getHeads()[0]; n2hash1 = n2us1.getHeads()[0]
 
           const n1us2 = n1us1.clone();
-          n1us2.set("_root","x",`final @ n1`); n1us2.commit("",0)
+          n1us2.put("_root","x",`final @ n1`); n1us2.commit("",0)
 
           const n2us2 = n2us1.clone();
-          n2us2.set("_root","x",`final @ n2`); n2us2.commit("",0)
+          n2us2.put("_root","x",`final @ n2`); n2us2.commit("",0)
 
           n1hash2 = n1us2.getHeads()[0]; n2hash2 = n2us2.getHeads()[0]
           if (new BloomFilter([n1hash1, n1hash2]).containsHash(n2hash1)) {
@@ -1525,33 +1525,33 @@ describe('Automerge', () => {
       let n1hash3, n2hash3
 
       for (let i = 0; i < 5; i++) {
-        n1.set("_root","x",i); n1.commit("",0)
+        n1.put("_root","x",i); n1.commit("",0)
       }
       sync(n1, n2, s1, s2)
       for (let i = 86; ; i++) { // search for false positive; see comment above
         const n1us1 = n1.clone('01234567')
-        n1us1.set("_root","x",`${i} @ n1`); n1us1.commit("",0)
+        n1us1.put("_root","x",`${i} @ n1`); n1us1.commit("",0)
 
         const n2us1 = n2.clone('89abcdef')
-        n2us1.set("_root","x",`${i} @ n2`); n2us1.commit("",0)
+        n2us1.put("_root","x",`${i} @ n2`); n2us1.commit("",0)
 
         //const n1us1 = Automerge.change(Automerge.clone(n1, {actorId: '01234567'}), {time: 0}, doc => doc.x = `${i} @ n1`)
         //const n2us1 = Automerge.change(Automerge.clone(n2, {actorId: '89abcdef'}), {time: 0}, doc => doc.x = `${i} @ n2`)
         const n1hash1 = n1us1.getHeads()[0]
 
         const n1us2 = n1us1.clone()
-        n1us2.set("_root","x",`${i + 1} @ n1`); n1us2.commit("",0)
+        n1us2.put("_root","x",`${i + 1} @ n1`); n1us2.commit("",0)
 
         const n2us2 = n2us1.clone()
-        n2us2.set("_root","x",`${i + 1} @ n2`); n2us2.commit("",0)
+        n2us2.put("_root","x",`${i + 1} @ n2`); n2us2.commit("",0)
 
         const n1hash2 = n1us2.getHeads()[0], n2hash2 = n2us2.getHeads()[0]
 
         const n1us3 = n1us2.clone()
-        n1us3.set("_root","x",`final @ n1`); n1us3.commit("",0)
+        n1us3.put("_root","x",`final @ n1`); n1us3.commit("",0)
 
         const n2us3 = n2us2.clone()
-        n2us3.set("_root","x",`final @ n2`); n2us3.commit("",0)
+        n2us3.put("_root","x",`final @ n2`); n2us3.commit("",0)
 
         n1hash3 = n1us3.getHeads()[0]; n2hash3 = n2us3.getHeads()[0]
 
@@ -1578,28 +1578,28 @@ describe('Automerge', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       for (let i = 0; i < 5; i++) {
-        n1.set("_root","x",i); n1.commit("",0)
+        n1.put("_root","x",i); n1.commit("",0)
       }
 
       sync(n1, n2, s1, s2)
 
-      n1.set("_root","x",5); n1.commit("",0)
+      n1.put("_root","x",5); n1.commit("",0)
 
       for (let i = 2; ; i++) { // search for false positive; see comment above
         const n2us1 = n2.clone('89abcdef')
-        n2us1.set("_root","x",`${i} @ n2`); n2us1.commit("",0)
+        n2us1.put("_root","x",`${i} @ n2`); n2us1.commit("",0)
         if (new BloomFilter(n1.getHeads()).containsHash(n2us1.getHeads()[0])) {
           n2 = n2us1; break
         }
       }
       for (let i = 141; ; i++) { // search for false positive; see comment above
         const n2us2 = n2.clone('89abcdef')
-        n2us2.set("_root","x",`${i} again`); n2us2.commit("",0)
+        n2us2.put("_root","x",`${i} again`); n2us2.commit("",0)
         if (new BloomFilter(n1.getHeads()).containsHash(n2us2.getHeads()[0])) {
           n2 = n2us2; break
         }
       }
-      n2.set("_root","x",`final @ n2`); n2.commit("",0)
+      n2.put("_root","x",`final @ n2`); n2.commit("",0)
 
       const allHeads = [...n1.getHeads(), ...n2.getHeads()].sort()
       s1 = decodeSyncState(encodeSyncState(s1))
@@ -1619,7 +1619,7 @@ describe('Automerge', () => {
       let message
 
       for (let i = 0; i < 10; i++) {
-        n1.set("_root","x",i); n1.commit("",0)
+        n1.put("_root","x",i); n1.commit("",0)
       }
 
       sync(n1, n2, s1, s2)
@@ -1628,8 +1628,8 @@ describe('Automerge', () => {
       s2 = decodeSyncState(encodeSyncState(s2))
 
       for (let i = 1; ; i++) { // brute-force search for false positive; see comment above
-        const n1up = n1.clone('01234567'); n1up.set("_root","x",`${i} @ n1`); n1up.commit("",0)
-        const n2up = n1.clone('89abcdef'); n2up.set("_root","x",`${i} @ n2`); n2up.commit("",0)
+        const n1up = n1.clone('01234567'); n1up.put("_root","x",`${i} @ n1`); n1up.commit("",0)
+        const n2up = n1.clone('89abcdef'); n2up.put("_root","x",`${i} @ n2`); n2up.commit("",0)
 
         // check if the bloom filter on n2 will believe n1 already has a particular hash
         // this will mean n2 won't offer that data to n2 by receiving a sync message from n1
@@ -1680,7 +1680,7 @@ describe('Automerge', () => {
         let message1, message2, message3
 
         for (let i = 0; i < 3; i++) {
-          n1.set("_root","x",i); n1.commit("",0)
+          n1.put("_root","x",i); n1.commit("",0)
         }
 
         // sync all 3 nodes
@@ -1688,18 +1688,18 @@ describe('Automerge', () => {
         sync(n1, n3, s13, s31)
         sync(n3, n2, s32, s23)
         for (let i = 0; i < 2; i++) {
-          n1.set("_root","x",`${i} @ n1`); n1.commit("",0)
+          n1.put("_root","x",`${i} @ n1`); n1.commit("",0)
         }
         for (let i = 0; i < 2; i++) {
-          n2.set("_root","x",`${i} @ n2`); n2.commit("",0)
+          n2.put("_root","x",`${i} @ n2`); n2.commit("",0)
         }
         n1.applyChanges(n2.getChanges([]))
         n2.applyChanges(n1.getChanges([]))
-        n1.set("_root","x",`3 @ n1`); n1.commit("",0)
-        n2.set("_root","x",`3 @ n2`); n2.commit("",0)
+        n1.put("_root","x",`3 @ n1`); n1.commit("",0)
+        n2.put("_root","x",`3 @ n2`); n2.commit("",0)
 
         for (let i = 0; i < 3; i++) {
-          n3.set("_root","x",`${i} @ n3`); n3.commit("",0)
+          n3.put("_root","x",`${i} @ n3`); n3.commit("",0)
         }
         const n1c3 = n1.getHeads()[0], n2c3 = n2.getHeads()[0], n3c3 = n3.getHeads()[0]
         s13 = decodeSyncState(encodeSyncState(s13))
@@ -1749,13 +1749,13 @@ describe('Automerge', () => {
         let message = null
 
         for (let i = 0; i < 3; i++) {
-          n1.set("_root","x",i); n1.commit("",0)
+          n1.put("_root","x",i); n1.commit("",0)
         }
 
         const lastSync = n1.getHeads()
 
         for (let i = 3; i < 6; i++) {
-          n1.set("_root","x",i); n1.commit("",0)
+          n1.put("_root","x",i); n1.commit("",0)
         }
 
         sync(n1, n2, s1, s2)
@@ -1777,7 +1777,7 @@ describe('Automerge', () => {
         let message = null
 
         for (let i = 0; i < 3; i++) {
-          n1.set("_root","x",i); n1.commit("",0)
+          n1.put("_root","x",i); n1.commit("",0)
         }
 
         n2.applyChanges(n1.getChanges([]))
@@ -1799,13 +1799,13 @@ describe('Automerge', () => {
         let s1 = initSyncState(), s2 = initSyncState()
         let msg, decodedMsg
 
-        n1.set("_root","x",0); n1.commit("",0)
+        n1.put("_root","x",0); n1.commit("",0)
         n3.applyChanges(n3.getChangesAdded(n1)) // merge()
         for (let i = 1; i <= 2; i++) {
-          n1.set("_root","x",i); n1.commit("",0)
+          n1.put("_root","x",i); n1.commit("",0)
         }
         for (let i = 3; i <= 4; i++) {
-          n3.set("_root","x",i); n3.commit("",0)
+          n3.put("_root","x",i); n3.commit("",0)
         }
         const c2 = n1.getHeads()[0], c4 = n3.getHeads()[0]
         n2.applyChanges(n2.getChangesAdded(n3)) // merge()
@@ -1818,12 +1818,12 @@ describe('Automerge', () => {
         assert.deepStrictEqual(s2.sharedHeads, [c2, c4].sort())
 
         // n2 and n3 apply {c5, c6, c7, c8}
-        n3.set("_root","x",5); n3.commit("",0)
+        n3.put("_root","x",5); n3.commit("",0)
         const change5 = n3.getLastLocalChange()
-        n3.set("_root","x",6); n3.commit("",0)
+        n3.put("_root","x",6); n3.commit("",0)
         const change6 = n3.getLastLocalChange(), c6 = n3.getHeads()[0]
         for (let i = 7; i <= 8; i++) {
-          n3.set("_root","x",i); n3.commit("",0)
+          n3.put("_root","x",i); n3.commit("",0)
         }
         const c8 = n3.getHeads()[0]
         n2.applyChanges(n2.getChangesAdded(n3)) // merge()

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -11,13 +11,13 @@ fn main() {
         .transact_with::<_, _, AutomergeError, _>(
             |_| CommitOptions::default().with_message("Add card".to_owned()),
             |tx| {
-                let cards = tx.set_object(ROOT, "cards", ObjType::List).unwrap();
+                let cards = tx.put_object(ROOT, "cards", ObjType::List).unwrap();
                 let card1 = tx.insert_object(&cards, 0, ObjType::Map)?;
-                tx.set(&card1, "title", "Rewrite everything in Clojure")?;
-                tx.set(&card1, "done", false)?;
+                tx.put(&card1, "title", "Rewrite everything in Clojure")?;
+                tx.put(&card1, "done", false)?;
                 let card2 = tx.insert_object(&cards, 0, ObjType::Map)?;
-                tx.set(&card2, "title", "Rewrite everything in Haskell")?;
-                tx.set(&card2, "done", false)?;
+                tx.put(&card2, "title", "Rewrite everything in Haskell")?;
+                tx.put(&card2, "done", false)?;
                 Ok((cards, card1))
             },
         )
@@ -33,7 +33,7 @@ fn main() {
     doc1.transact_with::<_, _, AutomergeError, _>(
         |_| CommitOptions::default().with_message("Mark card as done".to_owned()),
         |tx| {
-            tx.set(&card1, "done", true)?;
+            tx.put(&card1, "done", true)?;
             Ok(())
         },
     )

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -42,7 +42,7 @@ fn main() {
     doc2.transact_with::<_, _, AutomergeError, _>(
         |_| CommitOptions::default().with_message("Delete card".to_owned()),
         |tx| {
-            tx.del(&cards, 0)?;
+            tx.delete(&cards, 0)?;
             Ok(())
         },
     )

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -190,7 +190,7 @@ impl AutoCommit {
     /// # use automerge::ObjType;
     /// # use std::time::SystemTime;
     /// let mut doc = AutoCommit::new();
-    /// doc.set_object(&ROOT, "todos", ObjType::List).unwrap();
+    /// doc.put_object(&ROOT, "todos", ObjType::List).unwrap();
     /// let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as
     /// i64;
     /// doc.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
@@ -261,7 +261,7 @@ impl Transactable for AutoCommit {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
+    fn put<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         prop: P,
@@ -269,10 +269,10 @@ impl Transactable for AutoCommit {
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
-        tx.set(&mut self.doc, obj.as_ref(), prop, value)
+        tx.put(&mut self.doc, obj.as_ref(), prop, value)
     }
 
-    fn set_object<O: AsRef<ExId>, P: Into<Prop>>(
+    fn put_object<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
@@ -280,7 +280,7 @@ impl Transactable for AutoCommit {
     ) -> Result<ExId, AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
-        tx.set_object(&mut self.doc, obj.as_ref(), prop, value)
+        tx.put_object(&mut self.doc, obj.as_ref(), prop, value)
     }
 
     fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -305,7 +305,7 @@ impl Transactable for AutoCommit {
         tx.insert_object(&mut self.doc, obj, index, value)
     }
 
-    fn inc<O: AsRef<ExId>, P: Into<Prop>>(
+    fn increment<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
@@ -316,7 +316,7 @@ impl Transactable for AutoCommit {
         tx.inc(&mut self.doc, obj.as_ref(), prop, value)
     }
 
-    fn del<O: AsRef<ExId>, P: Into<Prop>>(
+    fn delete<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -313,7 +313,7 @@ impl Transactable for AutoCommit {
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
-        tx.inc(&mut self.doc, obj.as_ref(), prop, value)
+        tx.increment(&mut self.doc, obj.as_ref(), prop, value)
     }
 
     fn delete<O: AsRef<ExId>, P: Into<Prop>>(
@@ -323,7 +323,7 @@ impl Transactable for AutoCommit {
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let tx = self.transaction.as_mut().unwrap();
-        tx.del(&mut self.doc, obj.as_ref(), prop)
+        tx.delete(&mut self.doc, obj.as_ref(), prop)
     }
 
     /// Splice new elements into the given sequence. Returns a vector of the OpIds used to insert

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1075,7 +1075,7 @@ mod tests {
         let mut tx = doc.transaction();
         tx.set(ROOT, "xxx", "xxx")?;
         assert!(!tx.values(ROOT, "xxx")?.is_empty());
-        tx.del(ROOT, "xxx")?;
+        tx.delete(ROOT, "xxx")?;
         assert!(tx.values(ROOT, "xxx")?.is_empty());
         tx.commit();
         Ok(())
@@ -1087,9 +1087,9 @@ mod tests {
         let mut tx = doc.transaction();
         tx.set(ROOT, "counter", ScalarValue::counter(10))?;
         assert!(tx.value(ROOT, "counter")?.unwrap().0 == Value::counter(10));
-        tx.inc(ROOT, "counter", 10)?;
+        tx.increment(ROOT, "counter", 10)?;
         assert!(tx.value(ROOT, "counter")?.unwrap().0 == Value::counter(20));
-        tx.inc(ROOT, "counter", -5)?;
+        tx.increment(ROOT, "counter", -5)?;
         assert!(tx.value(ROOT, "counter")?.unwrap().0 == Value::counter(15));
         tx.commit();
         Ok(())
@@ -1182,7 +1182,7 @@ mod tests {
         doc.get_heads();
         let heads3 = doc.get_heads();
         let mut tx = doc.transaction();
-        tx.del(ROOT, "prop1")?;
+        tx.delete(ROOT, "prop1")?;
         tx.commit();
         doc.get_heads();
         let heads4 = doc.get_heads();
@@ -1264,12 +1264,12 @@ mod tests {
         let heads4 = doc.get_heads();
 
         let mut tx = doc.transaction();
-        tx.del(&list, 2)?;
+        tx.delete(&list, 2)?;
         tx.commit();
         let heads5 = doc.get_heads();
 
         let mut tx = doc.transaction();
-        tx.del(&list, 0)?;
+        tx.delete(&list, 0)?;
         tx.commit();
         let heads6 = doc.get_heads();
 
@@ -1399,7 +1399,7 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
         // deleting a missing key in a map should just be a noop
-        assert!(tx.del(ROOT, "a").is_ok());
+        assert!(tx.delete(ROOT, "a").is_ok());
         tx.commit();
         let last_change = doc.get_last_local_change().unwrap();
         assert_eq!(last_change.len(), 0);
@@ -1415,9 +1415,9 @@ mod tests {
 
         let mut tx = doc.transaction();
         // a real op
-        tx.del(ROOT, "a").unwrap();
+        tx.delete(ROOT, "a").unwrap();
         // a no-op
-        tx.del(ROOT, "a").unwrap();
+        tx.delete(ROOT, "a").unwrap();
         tx.commit();
         let last_change = doc.get_last_local_change().unwrap();
         assert_eq!(last_change.len(), 1);
@@ -1428,7 +1428,7 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
         // deleting an element in a list that does not exist is an error
-        assert!(tx.del(ROOT, 0).is_err());
+        assert!(tx.delete(ROOT, 0).is_err());
     }
 
     #[test]
@@ -1525,7 +1525,7 @@ mod tests {
                 }
                 Action::DelText(index) => {
                     println!("deleting at {} ", index);
-                    tx.del(&list, index).unwrap();
+                    tx.delete(&list, index).unwrap();
                 }
             }
         }
@@ -1578,7 +1578,7 @@ mod tests {
                 }
                 Action::DelText(index) => {
                     println!("deleting at {} ", index);
-                    tx.del(&list, index).unwrap();
+                    tx.delete(&list, index).unwrap();
                 }
             }
         }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -205,7 +205,7 @@ impl Automerge {
             self.ops.replace(obj, i, |old_op| old_op.add_succ(&op));
         }
 
-        if !op.is_del() {
+        if !op.is_delete() {
             self.ops.insert(q.pos, obj, op.clone());
         }
         op
@@ -218,7 +218,7 @@ impl Automerge {
             self.ops.replace(obj, i, |old_op| old_op.add_succ(&op));
         }
 
-        if !op.is_del() {
+        if !op.is_delete() {
             self.ops.insert(q.pos, obj, op.clone());
         }
 
@@ -231,7 +231,7 @@ impl Automerge {
         let patch = if op.insert {
             let value = (op.value(), self.id_to_exid(op.id));
             Patch::Insert(obj, q.seen, value)
-        } else if op.is_del() {
+        } else if op.is_delete() {
             if let Some(winner) = &q.values.last() {
                 let value = (winner.value(), self.id_to_exid(winner.id));
                 let conflict = q.values.len() > 1;
@@ -958,8 +958,8 @@ impl Automerge {
             let value: String = match &op.action {
                 OpType::Set(value) => format!("{}", value),
                 OpType::Make(obj) => format!("make({})", obj),
-                OpType::Inc(obj) => format!("inc({})", obj),
-                OpType::Del => format!("del{}", 0),
+                OpType::Increment(obj) => format!("inc({})", obj),
+                OpType::Delete => format!("del{}", 0),
             };
             let pred: Vec<_> = op.pred.iter().map(|id| self.to_string(*id)).collect();
             let succ: Vec<_> = op.succ.iter().map(|id| self.to_string(*id)).collect();

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -375,7 +375,7 @@ impl Automerge {
         let query = self.ops.search(&obj, query::ListVals::new());
         let mut buffer = String::new();
         for q in &query.ops {
-            if let OpType::Set(ScalarValue::Str(s)) = &q.action {
+            if let OpType::Put(ScalarValue::Str(s)) = &q.action {
                 buffer.push_str(s);
             } else {
                 buffer.push('\u{fffc}');
@@ -395,7 +395,7 @@ impl Automerge {
         let query = self.ops.search(&obj, query::ListValsAt::new(clock));
         let mut buffer = String::new();
         for q in &query.ops {
-            if let OpType::Set(ScalarValue::Str(s)) = &q.action {
+            if let OpType::Put(ScalarValue::Str(s)) = &q.action {
                 buffer.push_str(s);
             }
         }
@@ -956,7 +956,7 @@ impl Automerge {
                 Key::Seq(n) => self.to_string(n),
             };
             let value: String = match &op.action {
-                OpType::Set(value) => format!("{}", value),
+                OpType::Put(value) => format!("{}", value),
                 OpType::Make(obj) => format!("make({})", obj),
                 OpType::Increment(obj) => format!("inc({})", obj),
                 OpType::Delete => format!("del{}", 0),
@@ -1014,7 +1014,7 @@ mod tests {
         let mut doc = Automerge::new();
         doc.set_actor(ActorId::random());
         let mut tx = doc.transaction();
-        tx.set(ROOT, "hello", "world")?;
+        tx.put(ROOT, "hello", "world")?;
         tx.value(ROOT, "hello")?;
         tx.commit();
         Ok(())
@@ -1025,18 +1025,18 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
         // setting a scalar value shouldn't return an opid as no object was created.
-        tx.set(ROOT, "a", 1)?;
+        tx.put(ROOT, "a", 1)?;
 
         // setting the same value shouldn't return an opid as there is no change.
-        tx.set(ROOT, "a", 1)?;
+        tx.put(ROOT, "a", 1)?;
 
         assert_eq!(tx.pending_ops(), 1);
 
-        let map = tx.set_object(ROOT, "b", ObjType::Map)?;
+        let map = tx.put_object(ROOT, "b", ObjType::Map)?;
         // object already exists at b but setting a map again overwrites it so we get an opid.
-        tx.set(map, "a", 2)?;
+        tx.put(map, "a", 2)?;
 
-        tx.set_object(ROOT, "b", ObjType::Map)?;
+        tx.put_object(ROOT, "b", ObjType::Map)?;
 
         assert_eq!(tx.pending_ops(), 4);
         let map = tx.value(ROOT, "b").unwrap().unwrap().1;
@@ -1051,8 +1051,8 @@ mod tests {
         let mut doc = Automerge::new();
         doc.set_actor(ActorId::random());
         let mut tx = doc.transaction();
-        let list_id = tx.set_object(ROOT, "items", ObjType::List)?;
-        tx.set(ROOT, "zzz", "zzzval")?;
+        let list_id = tx.put_object(ROOT, "items", ObjType::List)?;
+        tx.put(ROOT, "zzz", "zzzval")?;
         assert!(tx.value(ROOT, "items")?.unwrap().1 == list_id);
         tx.insert(&list_id, 0, "a")?;
         tx.insert(&list_id, 0, "b")?;
@@ -1073,7 +1073,7 @@ mod tests {
         let mut doc = Automerge::new();
         doc.set_actor(ActorId::random());
         let mut tx = doc.transaction();
-        tx.set(ROOT, "xxx", "xxx")?;
+        tx.put(ROOT, "xxx", "xxx")?;
         assert!(!tx.values(ROOT, "xxx")?.is_empty());
         tx.delete(ROOT, "xxx")?;
         assert!(tx.values(ROOT, "xxx")?.is_empty());
@@ -1085,7 +1085,7 @@ mod tests {
     fn test_inc() -> Result<(), AutomergeError> {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "counter", ScalarValue::counter(10))?;
+        tx.put(ROOT, "counter", ScalarValue::counter(10))?;
         assert!(tx.value(ROOT, "counter")?.unwrap().0 == Value::counter(10));
         tx.increment(ROOT, "counter", 10)?;
         assert!(tx.value(ROOT, "counter")?.unwrap().0 == Value::counter(20));
@@ -1100,19 +1100,19 @@ mod tests {
         let mut doc = Automerge::new();
 
         let mut tx = doc.transaction();
-        tx.set(ROOT, "foo", 1)?;
+        tx.put(ROOT, "foo", 1)?;
         tx.commit();
 
         let save1 = doc.save();
 
         let mut tx = doc.transaction();
-        tx.set(ROOT, "bar", 2)?;
+        tx.put(ROOT, "bar", 2)?;
         tx.commit();
 
         let save2 = doc.save_incremental();
 
         let mut tx = doc.transaction();
-        tx.set(ROOT, "baz", 3)?;
+        tx.put(ROOT, "baz", 3)?;
         tx.commit();
 
         let save3 = doc.save_incremental();
@@ -1142,7 +1142,7 @@ mod tests {
     fn test_save_text() -> Result<(), AutomergeError> {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        let text = tx.set_object(ROOT, "text", ObjType::Text)?;
+        let text = tx.put_object(ROOT, "text", ObjType::Text)?;
         tx.commit();
         let heads1 = doc.get_heads();
         let mut tx = doc.transaction();
@@ -1167,17 +1167,17 @@ mod tests {
         let mut doc = Automerge::new();
         doc.set_actor("aaaa".try_into().unwrap());
         let mut tx = doc.transaction();
-        tx.set(ROOT, "prop1", "val1")?;
+        tx.put(ROOT, "prop1", "val1")?;
         tx.commit();
         doc.get_heads();
         let heads1 = doc.get_heads();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "prop1", "val2")?;
+        tx.put(ROOT, "prop1", "val2")?;
         tx.commit();
         doc.get_heads();
         let heads2 = doc.get_heads();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "prop2", "val3")?;
+        tx.put(ROOT, "prop2", "val3")?;
         tx.commit();
         doc.get_heads();
         let heads3 = doc.get_heads();
@@ -1187,7 +1187,7 @@ mod tests {
         doc.get_heads();
         let heads4 = doc.get_heads();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "prop3", "val4")?;
+        tx.put(ROOT, "prop3", "val4")?;
         tx.commit();
         doc.get_heads();
         let heads5 = doc.get_heads();
@@ -1242,7 +1242,7 @@ mod tests {
         doc.set_actor("aaaa".try_into().unwrap());
 
         let mut tx = doc.transaction();
-        let list = tx.set_object(ROOT, "list", ObjType::List)?;
+        let list = tx.put_object(ROOT, "list", ObjType::List)?;
         tx.commit();
         let heads1 = doc.get_heads();
 
@@ -1252,13 +1252,13 @@ mod tests {
         let heads2 = doc.get_heads();
 
         let mut tx = doc.transaction();
-        tx.set(&list, 0, 20)?;
+        tx.put(&list, 0, 20)?;
         tx.insert(&list, 0, 30)?;
         tx.commit();
         let heads3 = doc.get_heads();
 
         let mut tx = doc.transaction();
-        tx.set(&list, 1, 40)?;
+        tx.put(&list, 1, 40)?;
         tx.insert(&list, 1, 50)?;
         tx.commit();
         let heads4 = doc.get_heads();
@@ -1305,17 +1305,17 @@ mod tests {
     fn keys_iter() {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "a", 3).unwrap();
-        tx.set(ROOT, "b", 4).unwrap();
-        tx.set(ROOT, "c", 5).unwrap();
-        tx.set(ROOT, "d", 6).unwrap();
+        tx.put(ROOT, "a", 3).unwrap();
+        tx.put(ROOT, "b", 4).unwrap();
+        tx.put(ROOT, "c", 5).unwrap();
+        tx.put(ROOT, "d", 6).unwrap();
         tx.commit();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "a", 7).unwrap();
+        tx.put(ROOT, "a", 7).unwrap();
         tx.commit();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "a", 8).unwrap();
-        tx.set(ROOT, "d", 9).unwrap();
+        tx.put(ROOT, "a", 8).unwrap();
+        tx.put(ROOT, "d", 9).unwrap();
         tx.commit();
         assert_eq!(doc.keys(ROOT).count(), 4);
 
@@ -1368,11 +1368,11 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
         // create a map
-        let map1 = tx.set_object(ROOT, "a", ObjType::Map).unwrap();
-        tx.set(&map1, "b", 1).unwrap();
+        let map1 = tx.put_object(ROOT, "a", ObjType::Map).unwrap();
+        tx.put(&map1, "b", 1).unwrap();
         // overwrite the first map with a new one
-        let map2 = tx.set_object(ROOT, "a", ObjType::Map).unwrap();
-        tx.set(&map2, "c", 2).unwrap();
+        let map2 = tx.put_object(ROOT, "a", ObjType::Map).unwrap();
+        tx.put(&map2, "c", 2).unwrap();
         tx.commit();
 
         // we can get the new map by traversing the tree
@@ -1388,7 +1388,7 @@ mod tests {
         assert_eq!(doc.value(&map1, "b").unwrap().unwrap().0, Value::int(1));
         // and even set new things in it!
         let mut tx = doc.transaction();
-        tx.set(&map1, "c", 3).unwrap();
+        tx.put(&map1, "c", 3).unwrap();
         tx.commit();
 
         assert_eq!(doc.value(&map1, "c").unwrap().unwrap().0, Value::int(3));
@@ -1408,7 +1408,7 @@ mod tests {
         assert!(Automerge::load(&bytes).is_ok());
 
         let mut tx = doc.transaction();
-        tx.set(ROOT, "a", 1).unwrap();
+        tx.put(ROOT, "a", 1).unwrap();
         tx.commit();
         let last_change = doc.get_last_local_change().unwrap();
         assert_eq!(last_change.len(), 1);
@@ -1435,7 +1435,7 @@ mod tests {
     fn loaded_doc_changes_have_hash() {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        tx.set(ROOT, "a", 1).unwrap();
+        tx.put(ROOT, "a", 1).unwrap();
         tx.commit();
         let hash = doc.get_last_local_change().unwrap().hash;
         let bytes = doc.save();
@@ -1516,7 +1516,7 @@ mod tests {
         ];
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        let list = tx.set_object(ROOT, "list", ObjType::List).unwrap();
+        let list = tx.put_object(ROOT, "list", ObjType::List).unwrap();
         for action in actions {
             match action {
                 Action::InsertText(index, c) => {
@@ -1569,7 +1569,7 @@ mod tests {
         ];
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
-        let list = tx.set_object(ROOT, "list", ObjType::List).unwrap();
+        let list = tx.put_object(ROOT, "list", ObjType::List).unwrap();
         for action in actions {
             match action {
                 Action::InsertText(index, c) => {
@@ -1608,14 +1608,14 @@ mod tests {
         let mut doc1 = AutoCommit::new().with_actor(actor1.clone());
         let actor2 = ActorId::from(b"bbbb");
         let mut doc2 = AutoCommit::new().with_actor(actor2.clone());
-        let list = doc1.set_object(ROOT, "list", ObjType::List).unwrap();
+        let list = doc1.put_object(ROOT, "list", ObjType::List).unwrap();
         doc1.insert(&list, 0, 0).unwrap();
         doc2.load_incremental(&doc1.save_incremental()).unwrap();
         for i in 1..=max {
-            doc1.set(&list, 0, i).unwrap()
+            doc1.put(&list, 0, i).unwrap()
         }
         for i in 1..=max {
-            doc2.set(&list, 0, i).unwrap()
+            doc2.put(&list, 0, i).unwrap()
         }
         let change1 = doc1.save_incremental();
         let change2 = doc2.save_incremental();

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -879,7 +879,7 @@ fn group_doc_change_and_doc_ops(
                 let del = DocOp {
                     actor: succ.1,
                     ctr: succ.0,
-                    action: OpType::Del,
+                    action: OpType::Delete,
                     obj: op.obj.clone(),
                     key,
                     succ: Vec::new(),

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -135,8 +135,8 @@ impl<'a> Iterator for OperationIterator<'a> {
             Action::MakeText => OpType::Make(ObjType::Text),
             Action::MakeMap => OpType::Make(ObjType::Map),
             Action::MakeTable => OpType::Make(ObjType::Table),
-            Action::Del => OpType::Del,
-            Action::Inc => OpType::Inc(value.to_i64()?),
+            Action::Del => OpType::Delete,
+            Action::Inc => OpType::Increment(value.to_i64()?),
         };
         Some(amp::Op {
             action,
@@ -176,8 +176,8 @@ impl<'a> Iterator for DocOpIterator<'a> {
             Action::MakeText => OpType::Make(ObjType::Text),
             Action::MakeMap => OpType::Make(ObjType::Map),
             Action::MakeTable => OpType::Make(ObjType::Table),
-            Action::Del => OpType::Del,
-            Action::Inc => OpType::Inc(value.to_i64()?),
+            Action::Del => OpType::Delete,
+            Action::Inc => OpType::Increment(value.to_i64()?),
         };
         Some(DocOp {
             actor,
@@ -1055,11 +1055,11 @@ impl DocOpEncoder {
                     self.val.append_value(value, actors);
                     Action::Set
                 }
-                amp::OpType::Inc(val) => {
+                amp::OpType::Increment(val) => {
                     self.val.append_value(&ScalarValue::Int(*val), actors);
                     Action::Inc
                 }
-                amp::OpType::Del => {
+                amp::OpType::Delete => {
                     self.val.append_null();
                     Action::Del
                 }
@@ -1161,11 +1161,11 @@ impl ColumnEncoder {
                 self.val.append_value2(value, actors);
                 Action::Set
             }
-            OpType::Inc(val) => {
+            OpType::Increment(val) => {
                 self.val.append_value2(&ScalarValue::Int(*val), actors);
                 Action::Inc
             }
-            OpType::Del => {
+            OpType::Delete => {
                 self.val.append_null();
                 Action::Del
             }

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -130,7 +130,7 @@ impl<'a> Iterator for OperationIterator<'a> {
         let pred = self.pred.next()?;
         let value = self.value.next()?;
         let action = match action {
-            Action::Set => OpType::Set(value),
+            Action::Set => OpType::Put(value),
             Action::MakeList => OpType::Make(ObjType::List),
             Action::MakeText => OpType::Make(ObjType::Text),
             Action::MakeMap => OpType::Make(ObjType::Map),
@@ -171,7 +171,7 @@ impl<'a> Iterator for DocOpIterator<'a> {
         let succ = self.succ.next()?;
         let value = self.value.next()?;
         let action = match action {
-            Action::Set => OpType::Set(value),
+            Action::Set => OpType::Put(value),
             Action::MakeList => OpType::Make(ObjType::List),
             Action::MakeText => OpType::Make(ObjType::Text),
             Action::MakeMap => OpType::Make(ObjType::Map),
@@ -1051,7 +1051,7 @@ impl DocOpEncoder {
             self.insert.append(op.insert);
             self.succ.append(&op.succ, actors);
             let action = match &op.action {
-                amp::OpType::Set(value) => {
+                amp::OpType::Put(value) => {
                     self.val.append_value(value, actors);
                     Action::Set
                 }
@@ -1157,7 +1157,7 @@ impl ColumnEncoder {
 
         self.pred.append(&op.pred, actors);
         let action = match &op.action {
-            OpType::Set(value) => {
+            OpType::Put(value) => {
                 self.val.append_value2(value, actors);
                 Action::Set
             }

--- a/automerge/src/legacy/mod.rs
+++ b/automerge/src/legacy/mod.rs
@@ -216,7 +216,7 @@ pub struct Op {
 impl Op {
     pub fn primitive_value(&self) -> Option<ScalarValue> {
         match &self.action {
-            OpType::Set(v) => Some(v.clone()),
+            OpType::Put(v) => Some(v.clone()),
             OpType::Increment(i) => Some(ScalarValue::Int(*i)),
             _ => None,
         }

--- a/automerge/src/legacy/mod.rs
+++ b/automerge/src/legacy/mod.rs
@@ -217,7 +217,7 @@ impl Op {
     pub fn primitive_value(&self) -> Option<ScalarValue> {
         match &self.action {
             OpType::Set(v) => Some(v.clone()),
-            OpType::Inc(i) => Some(ScalarValue::Int(*i)),
+            OpType::Increment(i) => Some(ScalarValue::Int(*i)),
             _ => None,
         }
     }

--- a/automerge/src/legacy/serde_impls/op.rs
+++ b/automerge/src/legacy/serde_impls/op.rs
@@ -19,7 +19,7 @@ impl Serialize for Op {
         }
 
         let numerical_datatype = match &self.action {
-            OpType::Set(value) => value.as_numerical_datatype(),
+            OpType::Put(value) => value.as_numerical_datatype(),
             _ => None,
         };
 
@@ -48,7 +48,7 @@ impl Serialize for Op {
         }
         match &self.action {
             OpType::Increment(n) => op.serialize_field("value", &n)?,
-            OpType::Set(value) => op.serialize_field("value", &value)?,
+            OpType::Put(value) => op.serialize_field("value", &value)?,
             _ => {}
         }
         op.serialize_field("pred", &self.pred)?;
@@ -204,7 +204,7 @@ impl<'de> Deserialize<'de> for Op {
                                 .ok_or_else(|| Error::missing_field("value"))?
                                 .unwrap_or(ScalarValue::Null)
                         };
-                        OpType::Set(value)
+                        OpType::Put(value)
                     }
                     RawOpType::Inc => match value.flatten() {
                         Some(ScalarValue::Int(n)) => Ok(OpType::Increment(n)),
@@ -266,7 +266,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::Uint(123)),
+                    action: OpType::Put(ScalarValue::Uint(123)),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -284,7 +284,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::Int(-123)),
+                    action: OpType::Put(ScalarValue::Int(-123)),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -302,7 +302,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::F64(-123.0)),
+                    action: OpType::Put(ScalarValue::F64(-123.0)),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -319,7 +319,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::Str("somestring".into())),
+                    action: OpType::Put(ScalarValue::Str("somestring".into())),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -336,7 +336,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::F64(1.23)),
+                    action: OpType::Put(ScalarValue::F64(1.23)),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -353,7 +353,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::Boolean(true)),
+                    action: OpType::Put(ScalarValue::Boolean(true)),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -382,7 +382,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::Counter(123.into())),
+                    action: OpType::Put(ScalarValue::Counter(123.into())),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -474,7 +474,7 @@ mod tests {
                     "pred": []
                 }),
                 expected: Ok(Op {
-                    action: OpType::Set(ScalarValue::Null),
+                    action: OpType::Put(ScalarValue::Null),
                     obj: ObjectId::Root,
                     key: "somekey".into(),
                     insert: false,
@@ -580,7 +580,7 @@ mod tests {
     fn test_round_trips() {
         let testcases = vec![
             Op {
-                action: OpType::Set(ScalarValue::Uint(12)),
+                action: OpType::Put(ScalarValue::Uint(12)),
                 obj: ObjectId::Root,
                 key: "somekey".into(),
                 insert: false,
@@ -594,7 +594,7 @@ mod tests {
                 pred: SortedVec::new(),
             },
             Op {
-                action: OpType::Set(ScalarValue::Uint(12)),
+                action: OpType::Put(ScalarValue::Uint(12)),
                 obj: ObjectId::from_str("1@7ef48769b04d47e9a88e98a134d62716").unwrap(),
                 key: "somekey".into(),
                 insert: false,
@@ -608,7 +608,7 @@ mod tests {
                 pred: SortedVec::new(),
             },
             Op {
-                action: OpType::Set("seomthing".into()),
+                action: OpType::Put("seomthing".into()),
                 obj: ObjectId::from_str("1@7ef48769b04d47e9a88e98a134d62716").unwrap(),
                 key: OpId::from_str("1@7ef48769b04d47e9a88e98a134d62716")
                     .unwrap()

--- a/automerge/src/legacy/serde_impls/op_type.rs
+++ b/automerge/src/legacy/serde_impls/op_type.rs
@@ -15,8 +15,8 @@ impl Serialize for OpType {
             OpType::Make(ObjType::Table) => RawOpType::MakeTable,
             OpType::Make(ObjType::List) => RawOpType::MakeList,
             OpType::Make(ObjType::Text) => RawOpType::MakeText,
-            OpType::Del => RawOpType::Del,
-            OpType::Inc(_) => RawOpType::Inc,
+            OpType::Delete => RawOpType::Del,
+            OpType::Increment(_) => RawOpType::Inc,
             OpType::Set(_) => RawOpType::Set,
         };
         raw_type.serialize(serializer)

--- a/automerge/src/legacy/serde_impls/op_type.rs
+++ b/automerge/src/legacy/serde_impls/op_type.rs
@@ -17,7 +17,7 @@ impl Serialize for OpType {
             OpType::Make(ObjType::Text) => RawOpType::MakeText,
             OpType::Delete => RawOpType::Del,
             OpType::Increment(_) => RawOpType::Inc,
-            OpType::Set(_) => RawOpType::Set,
+            OpType::Put(_) => RawOpType::Set,
         };
         raw_type.serialize(serializer)
     }

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -642,7 +642,7 @@ mod tests {
         let zero = OpId(0, 0);
         Op {
             id: zero,
-            action: amp::OpType::Set(0.into()),
+            action: amp::OpType::Put(0.into()),
             key: zero.into(),
             succ: vec![],
             pred: vec![],

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -191,7 +191,7 @@ impl VisWindow {
                     visible = true;
                 }
             }
-            OpType::Inc(inc_val) => {
+            OpType::Increment(inc_val) => {
                 for id in &op.pred {
                     // pred is always before op.id so we can see them
                     if let Some(mut entry) = self.counters.get_mut(id) {

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -177,7 +177,7 @@ impl VisWindow {
 
         let mut visible = false;
         match op.action {
-            OpType::Set(ScalarValue::Counter(Counter { start, .. })) => {
+            OpType::Put(ScalarValue::Counter(Counter { start, .. })) => {
                 self.counters.insert(
                     op.id,
                     CounterData {
@@ -197,7 +197,7 @@ impl VisWindow {
                     if let Some(mut entry) = self.counters.get_mut(id) {
                         entry.succ.remove(&op.id);
                         entry.val += inc_val;
-                        entry.op.action = OpType::Set(ScalarValue::counter(entry.val));
+                        entry.op.action = OpType::Put(ScalarValue::counter(entry.val));
                         if !entry.succ.iter().any(|i| clock.covers(i)) {
                             visible = true;
                         }

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -86,7 +86,7 @@ impl TransactionInner {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    pub fn set<P: Into<Prop>, V: Into<ScalarValue>>(
+    pub fn put<P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
@@ -112,7 +112,7 @@ impl TransactionInner {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    pub fn set_object<P: Into<Prop>>(
+    pub fn put_object<P: Into<Prop>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
@@ -361,8 +361,8 @@ mod tests {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();
 
-        let a = tx.set_object(ROOT, "a", ObjType::Map).unwrap();
-        tx.set(&a, "b", 1).unwrap();
+        let a = tx.put_object(ROOT, "a", ObjType::Map).unwrap();
+        tx.put(&a, "b", 1).unwrap();
         assert!(tx.value(&a, "b").unwrap().is_some());
     }
 }

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -142,7 +142,7 @@ impl TransactionInner {
             });
         }
 
-        if !op.is_del() {
+        if !op.is_delete() {
             doc.ops.insert(pos, &obj, op.clone());
         }
 
@@ -236,7 +236,7 @@ impl TransactionInner {
         let query = doc.ops.search(&obj, query::Prop::new(prop));
 
         // no key present to delete
-        if query.ops.is_empty() && action == OpType::Del {
+        if query.ops.is_empty() && action == OpType::Delete {
             return Ok(None);
         }
 
@@ -303,7 +303,7 @@ impl TransactionInner {
         }
     }
 
-    pub fn inc<P: Into<Prop>>(
+    pub fn increment<P: Into<Prop>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
@@ -311,18 +311,18 @@ impl TransactionInner {
         value: i64,
     ) -> Result<(), AutomergeError> {
         let obj = doc.exid_to_obj(obj)?;
-        self.local_op(doc, obj, prop.into(), OpType::Inc(value))?;
+        self.local_op(doc, obj, prop.into(), OpType::Increment(value))?;
         Ok(())
     }
 
-    pub fn del<P: Into<Prop>>(
+    pub fn delete<P: Into<Prop>>(
         &mut self,
         doc: &mut Automerge,
         obj: &ExId,
         prop: P,
     ) -> Result<(), AutomergeError> {
         let obj = doc.exid_to_obj(obj)?;
-        self.local_op(doc, obj, prop.into(), OpType::Del)?;
+        self.local_op(doc, obj, prop.into(), OpType::Delete)?;
         Ok(())
     }
 
@@ -339,7 +339,7 @@ impl TransactionInner {
         let obj = doc.exid_to_obj(obj)?;
         for _ in 0..del {
             // del()
-            self.local_op(doc, obj, pos.into(), OpType::Del)?;
+            self.local_op(doc, obj, pos.into(), OpType::Delete)?;
         }
         for v in vals {
             // insert()

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -142,7 +142,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.inner
             .as_mut()
             .unwrap()
-            .inc(self.doc, obj.as_ref(), prop, value)
+            .increment(self.doc, obj.as_ref(), prop, value)
     }
 
     fn delete<O: AsRef<ExId>, P: Into<Prop>>(
@@ -153,7 +153,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.inner
             .as_mut()
             .unwrap()
-            .del(self.doc, obj.as_ref(), prop)
+            .delete(self.doc, obj.as_ref(), prop)
     }
 
     /// Splice new elements into the given sequence. Returns a vector of the OpIds used to insert

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -47,7 +47,7 @@ impl<'a> Transaction<'a> {
     /// # use std::time::SystemTime;
     /// let mut doc = Automerge::new();
     /// let mut tx = doc.transaction();
-    /// tx.set_object(ROOT, "todos", ObjType::List).unwrap();
+    /// tx.put_object(ROOT, "todos", ObjType::List).unwrap();
     /// let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as
     /// i64;
     /// tx.commit_with(CommitOptions::default().with_message("Create todos list").with_time(now));
@@ -85,7 +85,7 @@ impl<'a> Transactable for Transaction<'a> {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
+    fn put<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         prop: P,
@@ -94,10 +94,10 @@ impl<'a> Transactable for Transaction<'a> {
         self.inner
             .as_mut()
             .unwrap()
-            .set(self.doc, obj.as_ref(), prop, value)
+            .put(self.doc, obj.as_ref(), prop, value)
     }
 
-    fn set_object<O: AsRef<ExId>, P: Into<Prop>>(
+    fn put_object<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
@@ -106,7 +106,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.inner
             .as_mut()
             .unwrap()
-            .set_object(self.doc, obj.as_ref(), prop, value)
+            .put_object(self.doc, obj.as_ref(), prop, value)
     }
 
     fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -133,7 +133,7 @@ impl<'a> Transactable for Transaction<'a> {
             .insert_object(self.doc, obj, index, value)
     }
 
-    fn inc<O: AsRef<ExId>, P: Into<Prop>>(
+    fn increment<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
@@ -145,7 +145,7 @@ impl<'a> Transactable for Transaction<'a> {
             .inc(self.doc, obj.as_ref(), prop, value)
     }
 
-    fn del<O: AsRef<ExId>, P: Into<Prop>>(
+    fn delete<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -15,7 +15,7 @@ pub trait Transactable {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
+    fn put<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
         &mut self,
         obj: O,
         prop: P,
@@ -34,7 +34,7 @@ pub trait Transactable {
     /// - The object does not exist
     /// - The key is the wrong type for the object
     /// - The key does not exist in the object
-    fn set_object<O: AsRef<ExId>, P: Into<Prop>>(
+    fn put_object<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -58,7 +58,7 @@ pub trait Transactable {
     ) -> Result<ExId, AutomergeError>;
 
     /// Increment the counter at the prop in the object by `value`.
-    fn inc<O: AsRef<ExId>, P: Into<Prop>>(
+    fn increment<O: AsRef<ExId>, P: Into<Prop>>(
         &mut self,
         obj: O,
         prop: P,
@@ -66,8 +66,11 @@ pub trait Transactable {
     ) -> Result<(), AutomergeError>;
 
     /// Delete the value at prop in the object.
-    fn del<O: AsRef<ExId>, P: Into<Prop>>(&mut self, obj: O, prop: P)
-        -> Result<(), AutomergeError>;
+    fn delete<O: AsRef<ExId>, P: Into<Prop>>(
+        &mut self,
+        obj: O,
+        prop: P,
+    ) -> Result<(), AutomergeError>;
 
     fn splice<O: AsRef<ExId>, V: IntoIterator<Item = ScalarValue>>(
         &mut self,

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -168,9 +168,8 @@ impl fmt::Display for ObjType {
 #[derive(PartialEq, Debug, Clone)]
 pub enum OpType {
     Make(ObjType),
-    /// Perform a deletion, expanding the operation to cover `n` deletions (multiOp).
-    Del,
-    Inc(i64),
+    Delete,
+    Increment(i64),
     Set(ScalarValue),
 }
 
@@ -374,7 +373,7 @@ impl Op {
             ..
         })) = &mut self.action
         {
-            if let OpType::Inc(n) = &op.action {
+            if let OpType::Increment(n) = &op.action {
                 *current += *n;
                 *increments += 1;
             }
@@ -389,7 +388,7 @@ impl Op {
             ..
         })) = &mut self.action
         {
-            if let OpType::Inc(n) = &op.action {
+            if let OpType::Increment(n) = &op.action {
                 *current -= *n;
                 *increments -= 1;
             }
@@ -414,12 +413,12 @@ impl Op {
         }
     }
 
-    pub fn is_del(&self) -> bool {
-        matches!(&self.action, OpType::Del)
+    pub fn is_delete(&self) -> bool {
+        matches!(&self.action, OpType::Delete)
     }
 
     pub fn is_inc(&self) -> bool {
-        matches!(&self.action, OpType::Inc(_))
+        matches!(&self.action, OpType::Increment(_))
     }
 
     pub fn is_counter(&self) -> bool {
@@ -460,8 +459,8 @@ impl Op {
             OpType::Set(value) if self.insert => format!("i:{}", value),
             OpType::Set(value) => format!("s:{}", value),
             OpType::Make(obj) => format!("make{}", obj),
-            OpType::Inc(val) => format!("inc:{}", val),
-            OpType::Del => "del".to_string(),
+            OpType::Increment(val) => format!("inc:{}", val),
+            OpType::Delete => "del".to_string(),
         }
     }
 }

--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -269,7 +269,7 @@ impl From<&Op> for (Value, OpId) {
     fn from(op: &Op) -> Self {
         match &op.action {
             OpType::Make(obj_type) => (Value::Object(*obj_type), op.id),
-            OpType::Set(scalar) => (Value::Scalar(scalar.clone()), op.id),
+            OpType::Put(scalar) => (Value::Scalar(scalar.clone()), op.id),
             _ => panic!("cant convert op into a value - {:?}", op),
         }
     }
@@ -279,7 +279,7 @@ impl From<Op> for (Value, OpId) {
     fn from(op: Op) -> Self {
         match &op.action {
             OpType::Make(obj_type) => (Value::Object(*obj_type), op.id),
-            OpType::Set(scalar) => (Value::Scalar(scalar.clone()), op.id),
+            OpType::Put(scalar) => (Value::Scalar(scalar.clone()), op.id),
             _ => panic!("cant convert op into a value - {:?}", op),
         }
     }
@@ -289,7 +289,7 @@ impl From<Value> for OpType {
     fn from(v: Value) -> Self {
         match v {
             Value::Object(o) => OpType::Make(o),
-            Value::Scalar(s) => OpType::Set(s),
+            Value::Scalar(s) => OpType::Put(s),
         }
     }
 }

--- a/automerge/src/visualisation.rs
+++ b/automerge/src/visualisation.rs
@@ -234,10 +234,10 @@ impl OpTableRow {
         actor_shorthands: &HashMap<usize, String>,
     ) -> Self {
         let op_description = match &op.action {
-            crate::OpType::Del => "del".to_string(),
+            crate::OpType::Delete => "del".to_string(),
             crate::OpType::Set(v) => format!("set {}", v),
             crate::OpType::Make(obj) => format!("make {}", obj),
-            crate::OpType::Inc(v) => format!("inc {}", v),
+            crate::OpType::Increment(v) => format!("inc {}", v),
         };
         let prop = match op.key {
             crate::types::Key::Map(k) => metadata.props[k].clone(),

--- a/automerge/src/visualisation.rs
+++ b/automerge/src/visualisation.rs
@@ -235,7 +235,7 @@ impl OpTableRow {
     ) -> Self {
         let op_description = match &op.action {
             crate::OpType::Delete => "del".to_string(),
-            crate::OpType::Set(v) => format!("set {}", v),
+            crate::OpType::Put(v) => format!("set {}", v),
             crate::OpType::Make(obj) => format!("make {}", obj),
             crate::OpType::Increment(v) => format!("inc {}", v),
         };

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -10,8 +10,8 @@ use helpers::{
 #[test]
 fn no_conflict_on_repeated_assignment() {
     let mut doc = AutoCommit::new();
-    doc.set(&automerge::ROOT, "foo", 1).unwrap();
-    doc.set(&automerge::ROOT, "foo", 2).unwrap();
+    doc.put(&automerge::ROOT, "foo", 1).unwrap();
+    doc.put(&automerge::ROOT, "foo", 2).unwrap();
     assert_doc!(
         doc.document(),
         map! {
@@ -24,14 +24,14 @@ fn no_conflict_on_repeated_assignment() {
 fn repeated_map_assignment_which_resolves_conflict_not_ignored() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(&automerge::ROOT, "field", 123).unwrap();
+    doc1.put(&automerge::ROOT, "field", 123).unwrap();
     doc2.merge(&mut doc1).unwrap();
-    doc2.set(&automerge::ROOT, "field", 456).unwrap();
-    doc1.set(&automerge::ROOT, "field", 789).unwrap();
+    doc2.put(&automerge::ROOT, "field", 456).unwrap();
+    doc1.put(&automerge::ROOT, "field", 789).unwrap();
     doc1.merge(&mut doc2).unwrap();
     assert_eq!(doc1.values(&automerge::ROOT, "field").unwrap().len(), 2);
 
-    doc1.set(&automerge::ROOT, "field", 123).unwrap();
+    doc1.put(&automerge::ROOT, "field", 123).unwrap();
     assert_doc!(
         doc1.document(),
         map! {
@@ -45,13 +45,13 @@ fn repeated_list_assignment_which_resolves_conflict_not_ignored() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
     doc1.insert(&list_id, 0, 123).unwrap();
     doc2.merge(&mut doc1).unwrap();
-    doc2.set(&list_id, 0, 456).unwrap();
+    doc2.put(&list_id, 0, 456).unwrap();
     doc1.merge(&mut doc2).unwrap();
-    doc1.set(&list_id, 0, 789).unwrap();
+    doc1.put(&list_id, 0, 789).unwrap();
 
     assert_doc!(
         doc1.document(),
@@ -69,7 +69,7 @@ fn repeated_list_assignment_which_resolves_conflict_not_ignored() {
 fn list_deletion() {
     let mut doc = new_doc();
     let list_id = doc
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
     doc.insert(&list_id, 0, 123).unwrap();
     doc.insert(&list_id, 1, 456).unwrap();
@@ -90,8 +90,8 @@ fn list_deletion() {
 fn merge_concurrent_map_prop_updates() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(&automerge::ROOT, "foo", "bar").unwrap();
-    doc2.set(&automerge::ROOT, "hello", "world").unwrap();
+    doc1.put(&automerge::ROOT, "foo", "bar").unwrap();
+    doc2.put(&automerge::ROOT, "hello", "world").unwrap();
     doc1.merge(&mut doc2).unwrap();
     assert_eq!(
         doc1.value(&automerge::ROOT, "foo").unwrap().unwrap().0,
@@ -119,7 +119,7 @@ fn merge_concurrent_map_prop_updates() {
 fn add_concurrent_increments_of_same_property() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(&automerge::ROOT, "counter", mk_counter(0))
+    doc1.put(&automerge::ROOT, "counter", mk_counter(0))
         .unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc1.increment(&automerge::ROOT, "counter", 1).unwrap();
@@ -140,12 +140,12 @@ fn add_increments_only_to_preceeded_values() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
 
-    doc1.set(&automerge::ROOT, "counter", mk_counter(0))
+    doc1.put(&automerge::ROOT, "counter", mk_counter(0))
         .unwrap();
     doc1.increment(&automerge::ROOT, "counter", 1).unwrap();
 
     // create a counter in doc2
-    doc2.set(&automerge::ROOT, "counter", mk_counter(0))
+    doc2.put(&automerge::ROOT, "counter", mk_counter(0))
         .unwrap();
     doc2.increment(&automerge::ROOT, "counter", 3).unwrap();
 
@@ -167,8 +167,8 @@ fn add_increments_only_to_preceeded_values() {
 fn concurrent_updates_of_same_field() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(&automerge::ROOT, "field", "one").unwrap();
-    doc2.set(&automerge::ROOT, "field", "two").unwrap();
+    doc1.put(&automerge::ROOT, "field", "one").unwrap();
+    doc2.put(&automerge::ROOT, "field", "two").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -188,12 +188,12 @@ fn concurrent_updates_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .put_object(&automerge::ROOT, "birds", ObjType::List)
         .unwrap();
     doc1.insert(&list_id, 0, "finch").unwrap();
     doc2.merge(&mut doc1).unwrap();
-    doc1.set(&list_id, 0, "greenfinch").unwrap();
-    doc2.set(&list_id, 0, "goldfinch").unwrap();
+    doc1.put(&list_id, 0, "greenfinch").unwrap();
+    doc2.put(&list_id, 0, "goldfinch").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -215,10 +215,10 @@ fn assignment_conflicts_of_different_types() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let mut doc3 = new_doc();
-    doc1.set(&automerge::ROOT, "field", "string").unwrap();
-    doc2.set_object(&automerge::ROOT, "field", ObjType::List)
+    doc1.put(&automerge::ROOT, "field", "string").unwrap();
+    doc2.put_object(&automerge::ROOT, "field", ObjType::List)
         .unwrap();
-    doc3.set_object(&automerge::ROOT, "field", ObjType::Map)
+    doc3.put_object(&automerge::ROOT, "field", ObjType::Map)
         .unwrap();
     doc1.merge(&mut doc2).unwrap();
     doc1.merge(&mut doc3).unwrap();
@@ -239,11 +239,11 @@ fn assignment_conflicts_of_different_types() {
 fn changes_within_conflicting_map_field() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(&automerge::ROOT, "field", "string").unwrap();
+    doc1.put(&automerge::ROOT, "field", "string").unwrap();
     let map_id = doc2
-        .set_object(&automerge::ROOT, "field", ObjType::Map)
+        .put_object(&automerge::ROOT, "field", ObjType::Map)
         .unwrap();
-    doc2.set(&map_id, "innerKey", 42).unwrap();
+    doc2.put(&map_id, "innerKey", 42).unwrap();
     doc1.merge(&mut doc2).unwrap();
 
     assert_doc!(
@@ -267,19 +267,19 @@ fn changes_within_conflicting_list_element() {
     let mut doc1 = new_doc_with_actor(actor1);
     let mut doc2 = new_doc_with_actor(actor2);
     let list_id = doc1
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
     doc1.insert(&list_id, 0, "hello").unwrap();
     doc2.merge(&mut doc1).unwrap();
 
-    let map_in_doc1 = doc1.set_object(&list_id, 0, ObjType::Map).unwrap();
-    doc1.set(&map_in_doc1, "map1", true).unwrap();
-    doc1.set(&map_in_doc1, "key", 1).unwrap();
+    let map_in_doc1 = doc1.put_object(&list_id, 0, ObjType::Map).unwrap();
+    doc1.put(&map_in_doc1, "map1", true).unwrap();
+    doc1.put(&map_in_doc1, "key", 1).unwrap();
 
-    let map_in_doc2 = doc2.set_object(&list_id, 0, ObjType::Map).unwrap();
+    let map_in_doc2 = doc2.put_object(&list_id, 0, ObjType::Map).unwrap();
     doc1.merge(&mut doc2).unwrap();
-    doc2.set(&map_in_doc2, "map2", true).unwrap();
-    doc2.set(&map_in_doc2, "key", 2).unwrap();
+    doc2.put(&map_in_doc2, "map2", true).unwrap();
+    doc2.put(&map_in_doc2, "key", 2).unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -310,14 +310,14 @@ fn concurrently_assigned_nested_maps_should_not_merge() {
     let mut doc2 = new_doc();
 
     let doc1_map_id = doc1
-        .set_object(&automerge::ROOT, "config", ObjType::Map)
+        .put_object(&automerge::ROOT, "config", ObjType::Map)
         .unwrap();
-    doc1.set(&doc1_map_id, "background", "blue").unwrap();
+    doc1.put(&doc1_map_id, "background", "blue").unwrap();
 
     let doc2_map_id = doc2
-        .set_object(&automerge::ROOT, "config", ObjType::Map)
+        .put_object(&automerge::ROOT, "config", ObjType::Map)
         .unwrap();
-    doc2.set(&doc2_map_id, "logo_url", "logo.png").unwrap();
+    doc2.put(&doc2_map_id, "logo_url", "logo.png").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -344,7 +344,7 @@ fn concurrent_insertions_at_different_list_positions() {
     assert!(doc1.get_actor() < doc2.get_actor());
 
     let list_id = doc1
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
 
     doc1.insert(&list_id, 0, "one").unwrap();
@@ -378,7 +378,7 @@ fn concurrent_insertions_at_same_list_position() {
     assert!(doc1.get_actor() < doc2.get_actor());
 
     let list_id = doc1
-        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .put_object(&automerge::ROOT, "birds", ObjType::List)
         .unwrap();
     doc1.insert(&list_id, 0, "parakeet").unwrap();
 
@@ -411,10 +411,10 @@ fn concurrent_insertions_at_same_list_position() {
 fn concurrent_assignment_and_deletion_of_a_map_entry() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
-    doc1.set(&automerge::ROOT, "bestBird", "robin").unwrap();
+    doc1.put(&automerge::ROOT, "bestBird", "robin").unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc1.delete(&automerge::ROOT, "bestBird").unwrap();
-    doc2.set(&automerge::ROOT, "bestBird", "magpie").unwrap();
+    doc2.put(&automerge::ROOT, "bestBird", "magpie").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -433,13 +433,13 @@ fn concurrent_assignment_and_deletion_of_list_entry() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .put_object(&automerge::ROOT, "birds", ObjType::List)
         .unwrap();
     doc1.insert(&list_id, 0, "blackbird").unwrap();
     doc1.insert(&list_id, 1, "thrush").unwrap();
     doc1.insert(&list_id, 2, "goldfinch").unwrap();
     doc2.merge(&mut doc1).unwrap();
-    doc1.set(&list_id, 1, "starling").unwrap();
+    doc1.put(&list_id, 1, "starling").unwrap();
     doc2.delete(&list_id, 1).unwrap();
 
     assert_doc!(
@@ -482,7 +482,7 @@ fn insertion_after_a_deleted_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .put_object(&automerge::ROOT, "birds", ObjType::List)
         .unwrap();
 
     doc1.insert(&list_id, 0, "blackbird").unwrap();
@@ -525,7 +525,7 @@ fn concurrent_deletion_of_same_list_element() {
     let mut doc1 = new_doc();
     let mut doc2 = new_doc();
     let list_id = doc1
-        .set_object(&automerge::ROOT, "birds", ObjType::List)
+        .put_object(&automerge::ROOT, "birds", ObjType::List)
         .unwrap();
 
     doc1.insert(&list_id, 0, "albatross").unwrap();
@@ -568,18 +568,18 @@ fn concurrent_updates_at_different_levels() {
     let mut doc2 = new_doc();
 
     let animals = doc1
-        .set_object(&automerge::ROOT, "animals", ObjType::Map)
+        .put_object(&automerge::ROOT, "animals", ObjType::Map)
         .unwrap();
-    let birds = doc1.set_object(&animals, "birds", ObjType::Map).unwrap();
-    doc1.set(&birds, "pink", "flamingo").unwrap();
-    doc1.set(&birds, "black", "starling").unwrap();
+    let birds = doc1.put_object(&animals, "birds", ObjType::Map).unwrap();
+    doc1.put(&birds, "pink", "flamingo").unwrap();
+    doc1.put(&birds, "black", "starling").unwrap();
 
-    let mammals = doc1.set_object(&animals, "mammals", ObjType::List).unwrap();
+    let mammals = doc1.put_object(&animals, "mammals", ObjType::List).unwrap();
     doc1.insert(&mammals, 0, "badger").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
 
-    doc1.set(&birds, "brown", "sparrow").unwrap();
+    doc1.put(&birds, "brown", "sparrow").unwrap();
 
     doc2.delete(&animals, "birds").unwrap();
     doc1.merge(&mut doc2).unwrap();
@@ -613,16 +613,16 @@ fn concurrent_updates_of_concurrently_deleted_objects() {
     let mut doc2 = new_doc();
 
     let birds = doc1
-        .set_object(&automerge::ROOT, "birds", ObjType::Map)
+        .put_object(&automerge::ROOT, "birds", ObjType::Map)
         .unwrap();
-    let blackbird = doc1.set_object(&birds, "blackbird", ObjType::Map).unwrap();
-    doc1.set(&blackbird, "feathers", "black").unwrap();
+    let blackbird = doc1.put_object(&birds, "blackbird", ObjType::Map).unwrap();
+    doc1.put(&blackbird, "feathers", "black").unwrap();
 
     doc2.merge(&mut doc1).unwrap();
 
     doc1.delete(&birds, "blackbird").unwrap();
 
-    doc2.set(&blackbird, "beak", "orange").unwrap();
+    doc2.put(&blackbird, "beak", "orange").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -643,7 +643,7 @@ fn does_not_interleave_sequence_insertions_at_same_position() {
     let mut doc2 = new_doc_with_actor(actor2);
 
     let wisdom = doc1
-        .set_object(&automerge::ROOT, "wisdom", ObjType::List)
+        .put_object(&automerge::ROOT, "wisdom", ObjType::List)
         .unwrap();
     doc2.merge(&mut doc1).unwrap();
 
@@ -704,7 +704,7 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_greater_actor_id(
     let mut doc2 = new_doc_with_actor(actor2);
 
     let list = doc1
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
     doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1).unwrap();
@@ -729,7 +729,7 @@ fn mutliple_insertions_at_same_list_position_with_insertion_by_lesser_actor_id()
     let mut doc2 = new_doc_with_actor(actor2);
 
     let list = doc1
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
     doc1.insert(&list, 0, "two").unwrap();
     doc2.merge(&mut doc1).unwrap();
@@ -752,7 +752,7 @@ fn insertion_consistent_with_causality() {
     let mut doc2 = new_doc();
 
     let list = doc1
-        .set_object(&automerge::ROOT, "list", ObjType::List)
+        .put_object(&automerge::ROOT, "list", ObjType::List)
         .unwrap();
     doc1.insert(&list, 0, "four").unwrap();
     doc2.merge(&mut doc1).unwrap();
@@ -787,18 +787,18 @@ fn save_and_restore_empty() {
 fn save_restore_complex() {
     let mut doc1 = new_doc();
     let todos = doc1
-        .set_object(&automerge::ROOT, "todos", ObjType::List)
+        .put_object(&automerge::ROOT, "todos", ObjType::List)
         .unwrap();
 
     let first_todo = doc1.insert_object(&todos, 0, ObjType::Map).unwrap();
-    doc1.set(&first_todo, "title", "water plants").unwrap();
-    doc1.set(&first_todo, "done", false).unwrap();
+    doc1.put(&first_todo, "title", "water plants").unwrap();
+    doc1.put(&first_todo, "done", false).unwrap();
 
     let mut doc2 = new_doc();
     doc2.merge(&mut doc1).unwrap();
-    doc2.set(&first_todo, "title", "weed plants").unwrap();
+    doc2.put(&first_todo, "title", "weed plants").unwrap();
 
-    doc1.set(&first_todo, "title", "kill plants").unwrap();
+    doc1.put(&first_todo, "title", "kill plants").unwrap();
     doc1.merge(&mut doc2).unwrap();
 
     let reloaded = Automerge::load(&doc1.save()).unwrap();
@@ -830,7 +830,7 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     let mut doc1 = new_doc_with_actor(actor1);
 
-    let list = doc1.set_object(ROOT, "list", ObjType::List)?;
+    let list = doc1.put_object(ROOT, "list", ObjType::List)?;
     doc1.insert(&list, 0, "a")?;
     doc1.insert(&list, 1, "b")?;
     doc1.insert(&list, 2, "c")?;
@@ -841,13 +841,13 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
     let mut doc3 = AutoCommit::load(&doc1.save())?;
     doc3.set_actor(actor3);
 
-    doc1.set(&list, 1, ScalarValue::counter(0))?;
-    doc2.set(&list, 1, ScalarValue::counter(10))?;
-    doc3.set(&list, 1, ScalarValue::counter(100))?;
+    doc1.put(&list, 1, ScalarValue::counter(0))?;
+    doc2.put(&list, 1, ScalarValue::counter(10))?;
+    doc3.put(&list, 1, ScalarValue::counter(100))?;
 
-    doc1.set(&list, 2, ScalarValue::counter(0))?;
-    doc2.set(&list, 2, ScalarValue::counter(10))?;
-    doc3.set(&list, 2, 100)?;
+    doc1.put(&list, 2, ScalarValue::counter(0))?;
+    doc2.put(&list, 2, ScalarValue::counter(10))?;
+    doc3.put(&list, 2, 100)?;
 
     doc1.increment(&list, 1, 1)?;
     doc1.increment(&list, 2, 1)?;

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -74,7 +74,7 @@ fn list_deletion() {
     doc.insert(&list_id, 0, 123).unwrap();
     doc.insert(&list_id, 1, 456).unwrap();
     doc.insert(&list_id, 2, 789).unwrap();
-    doc.del(&list_id, 1).unwrap();
+    doc.delete(&list_id, 1).unwrap();
     assert_doc!(
         doc.document(),
         map! {
@@ -122,8 +122,8 @@ fn add_concurrent_increments_of_same_property() {
     doc1.set(&automerge::ROOT, "counter", mk_counter(0))
         .unwrap();
     doc2.merge(&mut doc1).unwrap();
-    doc1.inc(&automerge::ROOT, "counter", 1).unwrap();
-    doc2.inc(&automerge::ROOT, "counter", 2).unwrap();
+    doc1.increment(&automerge::ROOT, "counter", 1).unwrap();
+    doc2.increment(&automerge::ROOT, "counter", 2).unwrap();
     doc1.merge(&mut doc2).unwrap();
     assert_doc!(
         doc1.document(),
@@ -142,12 +142,12 @@ fn add_increments_only_to_preceeded_values() {
 
     doc1.set(&automerge::ROOT, "counter", mk_counter(0))
         .unwrap();
-    doc1.inc(&automerge::ROOT, "counter", 1).unwrap();
+    doc1.increment(&automerge::ROOT, "counter", 1).unwrap();
 
     // create a counter in doc2
     doc2.set(&automerge::ROOT, "counter", mk_counter(0))
         .unwrap();
-    doc2.inc(&automerge::ROOT, "counter", 3).unwrap();
+    doc2.increment(&automerge::ROOT, "counter", 3).unwrap();
 
     // The two values should be conflicting rather than added
     doc1.merge(&mut doc2).unwrap();
@@ -413,7 +413,7 @@ fn concurrent_assignment_and_deletion_of_a_map_entry() {
     let mut doc2 = new_doc();
     doc1.set(&automerge::ROOT, "bestBird", "robin").unwrap();
     doc2.merge(&mut doc1).unwrap();
-    doc1.del(&automerge::ROOT, "bestBird").unwrap();
+    doc1.delete(&automerge::ROOT, "bestBird").unwrap();
     doc2.set(&automerge::ROOT, "bestBird", "magpie").unwrap();
 
     doc1.merge(&mut doc2).unwrap();
@@ -440,7 +440,7 @@ fn concurrent_assignment_and_deletion_of_list_entry() {
     doc1.insert(&list_id, 2, "goldfinch").unwrap();
     doc2.merge(&mut doc1).unwrap();
     doc1.set(&list_id, 1, "starling").unwrap();
-    doc2.del(&list_id, 1).unwrap();
+    doc2.delete(&list_id, 1).unwrap();
 
     assert_doc!(
         doc2.document(),
@@ -534,9 +534,9 @@ fn concurrent_deletion_of_same_list_element() {
 
     doc2.merge(&mut doc1).unwrap();
 
-    doc1.del(&list_id, 1).unwrap();
+    doc1.delete(&list_id, 1).unwrap();
 
-    doc2.del(&list_id, 1).unwrap();
+    doc2.delete(&list_id, 1).unwrap();
 
     doc1.merge(&mut doc2).unwrap();
 
@@ -581,7 +581,7 @@ fn concurrent_updates_at_different_levels() {
 
     doc1.set(&birds, "brown", "sparrow").unwrap();
 
-    doc2.del(&animals, "birds").unwrap();
+    doc2.delete(&animals, "birds").unwrap();
     doc1.merge(&mut doc2).unwrap();
 
     assert_obj!(
@@ -620,7 +620,7 @@ fn concurrent_updates_of_concurrently_deleted_objects() {
 
     doc2.merge(&mut doc1).unwrap();
 
-    doc1.del(&birds, "blackbird").unwrap();
+    doc1.delete(&birds, "blackbird").unwrap();
 
     doc2.set(&blackbird, "beak", "orange").unwrap();
 
@@ -849,8 +849,8 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
     doc2.set(&list, 2, ScalarValue::counter(10))?;
     doc3.set(&list, 2, 100)?;
 
-    doc1.inc(&list, 1, 1)?;
-    doc1.inc(&list, 2, 1)?;
+    doc1.increment(&list, 1, 1)?;
+    doc1.increment(&list, 2, 1)?;
 
     doc1.merge(&mut doc2).unwrap();
     doc1.merge(&mut doc3).unwrap();
@@ -867,8 +867,8 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
     assert_eq!(&values[1].0, &Value::counter(10));
     assert_eq!(&values[2].0, &Value::int(100));
 
-    doc1.inc(&list, 1, 1)?;
-    doc1.inc(&list, 2, 1)?;
+    doc1.increment(&list, 1, 1)?;
+    doc1.increment(&list, 2, 1)?;
 
     let values = doc1.values(&list, 1)?;
     assert_eq!(values.len(), 3);
@@ -883,7 +883,7 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     assert_eq!(doc1.length(&list), 3);
 
-    doc1.del(&list, 2)?;
+    doc1.delete(&list, 2)?;
 
     assert_eq!(doc1.length(&list), 2);
 
@@ -891,7 +891,7 @@ fn list_counter_del() -> Result<(), automerge::AutomergeError> {
 
     assert_eq!(doc4.length(&list), 2);
 
-    doc1.del(&list, 1)?;
+    doc1.delete(&list, 1)?;
 
     assert_eq!(doc1.length(&list), 1);
 

--- a/edit-trace/automerge-wasm.js
+++ b/edit-trace/automerge-wasm.js
@@ -1,5 +1,5 @@
 
-// make sure to 
+// make sure to
 
 // # cd ../automerge-wasm
 // # yarn release
@@ -11,7 +11,7 @@ const Automerge = require('../automerge-wasm')
 const start = new Date()
 
 let doc = Automerge.create();
-let text = doc.set("_root", "text", "", "text")
+let text = doc.put("_root", "text", "", "text")
 
 for (let i = 0; i < edits.length; i++) {
   let edit = edits[i]

--- a/edit-trace/benches/main.rs
+++ b/edit-trace/benches/main.rs
@@ -5,7 +5,7 @@ use std::fs;
 fn replay_trace_tx(commands: Vec<(usize, usize, Vec<ScalarValue>)>) -> Automerge {
     let mut doc = Automerge::new();
     let mut tx = doc.transaction();
-    let text = tx.set_object(ROOT, "text", ObjType::Text).unwrap();
+    let text = tx.put_object(ROOT, "text", ObjType::Text).unwrap();
     for (pos, del, vals) in commands {
         tx.splice(&text, pos, del, vals).unwrap();
     }
@@ -15,7 +15,7 @@ fn replay_trace_tx(commands: Vec<(usize, usize, Vec<ScalarValue>)>) -> Automerge
 
 fn replay_trace_autotx(commands: Vec<(usize, usize, Vec<ScalarValue>)>) -> AutoCommit {
     let mut doc = AutoCommit::new();
-    let text = doc.set_object(ROOT, "text", ObjType::Text).unwrap();
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
     for (pos, del, vals) in commands {
         doc.splice(&text, pos, del, vals).unwrap();
     }

--- a/edit-trace/src/main.rs
+++ b/edit-trace/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), AutomergeError> {
 
     let now = Instant::now();
     let mut tx = doc.transaction();
-    let text = tx.set_object(ROOT, "text", ObjType::Text).unwrap();
+    let text = tx.put_object(ROOT, "text", ObjType::Text).unwrap();
     for (i, (pos, del, vals)) in commands.into_iter().enumerate() {
         if i % 1000 == 0 {
             println!("Processed {} edits in {} ms", i, now.elapsed().as_millis());


### PR DESCRIPTION
Rename `del` and `inc` to `delete` and `increment`.

I've also changed them in js/wasm but if that causes a conflict with js internals then we can revert the delete one.