### PR TITLE
Have queries be able to return references to scalars

### DIFF
--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -347,7 +347,7 @@ pub(crate) fn map_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
                 Reflect::set(&map, &k.into(), &doc.text(&exid).unwrap().into()).unwrap();
             }
             Ok(Some((Value::Scalar(v), _))) => {
-                Reflect::set(&map, &k.into(), &ScalarValue(v).into()).unwrap();
+                Reflect::set(&map, &k.into(), &ScalarValue(v.into_owned()).into()).unwrap();
             }
             _ => (),
         };
@@ -370,7 +370,7 @@ pub(crate) fn list_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
                 array.push(&list_to_js(doc, &exid));
             }
             Ok(Some((Value::Scalar(v), _))) => {
-                array.push(&ScalarValue(v).into());
+                array.push(&ScalarValue(v.into_owned()).into());
             }
             _ => (),
         };

--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -347,7 +347,7 @@ pub(crate) fn map_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
                 Reflect::set(&map, &k.into(), &doc.text(&exid).unwrap().into()).unwrap();
             }
             Ok(Some((Value::Scalar(v), _))) => {
-                Reflect::set(&map, &k.into(), &ScalarValue(v.into_owned()).into()).unwrap();
+                Reflect::set(&map, &k.into(), &ScalarValue(v).into()).unwrap();
             }
             _ => (),
         };
@@ -370,7 +370,7 @@ pub(crate) fn list_to_js(doc: &am::AutoCommit, obj: &ObjId) -> JsValue {
                 array.push(&list_to_js(doc, &exid));
             }
             Ok(Some((Value::Scalar(v), _))) => {
-                array.push(&ScalarValue(v.into_owned()).into());
+                array.push(&ScalarValue(v).into());
             }
             _ => (),
         };

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -242,14 +242,14 @@ impl Automerge {
             let opid = match (p, value) {
                 (Prop::Map(s), Value::Object(objtype)) => Some(self.0.put_object(obj, s, objtype)?),
                 (Prop::Map(s), Value::Scalar(scalar)) => {
-                    self.0.put(obj, s, scalar)?;
+                    self.0.put(obj, s, scalar.into_owned())?;
                     None
                 }
                 (Prop::Seq(i), Value::Object(objtype)) => {
                     Some(self.0.insert_object(obj, i, objtype)?)
                 }
                 (Prop::Seq(i), Value::Scalar(scalar)) => {
-                    self.0.insert(obj, i, scalar)?;
+                    self.0.insert(obj, i, scalar.into_owned())?;
                     None
                 }
             };
@@ -299,7 +299,7 @@ impl Automerge {
                 }
                 Some((Value::Scalar(value), _)) => {
                     result.push(&datatype(&value).into());
-                    result.push(&ScalarValue(value).into());
+                    result.push(&ScalarValue(value.into_owned()).into());
                     Ok(Some(result))
                 }
                 None => Ok(None),
@@ -336,7 +336,7 @@ impl Automerge {
                     (Value::Scalar(value), id) => {
                         let sub = Array::new();
                         sub.push(&datatype(&value).into());
-                        sub.push(&ScalarValue(value).into());
+                        sub.push(&ScalarValue(value.into_owned()).into());
                         sub.push(&id.to_string().into());
                         result.push(&sub.into());
                     }
@@ -378,7 +378,7 @@ impl Automerge {
                         }
                         (Value::Scalar(value), _) => {
                             js_set(&patch, "datatype", datatype(&value))?;
-                            js_set(&patch, "value", ScalarValue(value))?;
+                            js_set(&patch, "value", ScalarValue(value.into_owned()))?;
                         }
                     };
                     js_set(&patch, "conflict", conflict)?;
@@ -395,7 +395,7 @@ impl Automerge {
                         }
                         (Value::Scalar(value), _) => {
                             js_set(&patch, "datatype", datatype(&value))?;
-                            js_set(&patch, "value", ScalarValue(value))?;
+                            js_set(&patch, "value", ScalarValue(value.into_owned()))?;
                         }
                     };
                 }
@@ -658,7 +658,7 @@ impl Automerge {
         &mut self,
         value: &JsValue,
         datatype: Option<String>,
-    ) -> Result<(Value, Vec<(Prop, JsValue)>), JsValue> {
+    ) -> Result<(Value<'static>, Vec<(Prop, JsValue)>), JsValue> {
         match self.import_scalar(value, &datatype) {
             Some(val) => Ok((val.into(), vec![])),
             None => {

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -299,7 +299,7 @@ impl Automerge {
                 }
                 Some((Value::Scalar(value), _)) => {
                     result.push(&datatype(&value).into());
-                    result.push(&ScalarValue(value.into_owned()).into());
+                    result.push(&ScalarValue(value).into());
                     Ok(Some(result))
                 }
                 None => Ok(None),
@@ -336,7 +336,7 @@ impl Automerge {
                     (Value::Scalar(value), id) => {
                         let sub = Array::new();
                         sub.push(&datatype(&value).into());
-                        sub.push(&ScalarValue(value.into_owned()).into());
+                        sub.push(&ScalarValue(value).into());
                         sub.push(&id.to_string().into());
                         result.push(&sub.into());
                     }
@@ -378,7 +378,7 @@ impl Automerge {
                         }
                         (Value::Scalar(value), _) => {
                             js_set(&patch, "datatype", datatype(&value))?;
-                            js_set(&patch, "value", ScalarValue(value.into_owned()))?;
+                            js_set(&patch, "value", ScalarValue(value))?;
                         }
                     };
                     js_set(&patch, "conflict", conflict)?;
@@ -395,7 +395,7 @@ impl Automerge {
                         }
                         (Value::Scalar(value), _) => {
                             js_set(&patch, "datatype", datatype(&value))?;
-                            js_set(&patch, "value", ScalarValue(value.into_owned()))?;
+                            js_set(&patch, "value", ScalarValue(value))?;
                         }
                     };
                 }

--- a/automerge-wasm/src/value.rs
+++ b/automerge-wasm/src/value.rs
@@ -1,13 +1,15 @@
+use std::borrow::Cow;
+
 use automerge as am;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug)]
-pub struct ScalarValue(pub(crate) am::ScalarValue);
+pub struct ScalarValue<'a>(pub(crate) Cow<'a, am::ScalarValue>);
 
-impl From<ScalarValue> for JsValue {
+impl<'a> From<ScalarValue<'a>> for JsValue {
     fn from(val: ScalarValue) -> Self {
-        match &val.0 {
+        match &*val.0 {
             am::ScalarValue::Bytes(v) => Uint8Array::from(v.as_slice()).into(),
             am::ScalarValue::Str(v) => v.to_string().into(),
             am::ScalarValue::Int(v) => (*v as f64).into(),

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -198,17 +198,18 @@ impl Automerge {
         f
     }
 
-    fn insert_op(&mut self, obj: &ObjId, op: Op) -> Op {
+    fn insert_op(&mut self, obj: &ObjId, op: Op) {
         let q = self.ops.search(obj, query::SeekOp::new(&op));
 
-        for i in q.succ {
+        let succ = q.succ;
+        let pos = q.pos;
+        for i in succ {
             self.ops.replace(obj, i, |old_op| old_op.add_succ(&op));
         }
 
         if !op.is_delete() {
-            self.ops.insert(q.pos, obj, op.clone());
+            self.ops.insert(pos, obj, op);
         }
-        op
     }
 
     fn insert_op_with_patch(&mut self, obj: &ObjId, op: Op) -> Op {

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -488,7 +488,7 @@ impl Automerge {
                         .search(&obj, query::PropAt::new(p, clock))
                         .ops
                         .into_iter()
-                        .map(|o| (o.value(), self.id_to_exid(o.id)))
+                        .map(|o| (o.clone_value(), self.id_to_exid(o.id)))
                         .collect()
                 } else {
                     vec![]
@@ -499,7 +499,7 @@ impl Automerge {
                 .search(&obj, query::NthAt::new(n, clock))
                 .ops
                 .into_iter()
-                .map(|o| (o.value(), self.id_to_exid(o.id)))
+                .map(|o| (o.clone_value(), self.id_to_exid(o.id)))
                 .collect(),
         };
         Ok(result)

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -61,9 +61,9 @@ impl OpSetInternal {
         }
     }
 
-    pub fn search<Q>(&self, obj: &ObjId, query: Q) -> Q
+    pub fn search<'a, 'b: 'a, Q>(&'b self, obj: &ObjId, query: Q) -> Q
     where
-        Q: TreeQuery,
+        Q: TreeQuery<'a>,
     {
         if let Some((_typ, tree)) = self.trees.get(obj) {
             tree.search(query, &self.m)

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -51,9 +51,9 @@ impl OpTreeInternal {
             .map(|root| query::KeysAt::new(root, clock))
     }
 
-    pub fn search<Q>(&self, mut query: Q, m: &OpSetMetadata) -> Q
+    pub fn search<'a, 'b: 'a, Q>(&'b self, mut query: Q, m: &OpSetMetadata) -> Q
     where
-        Q: TreeQuery,
+        Q: TreeQuery<'a>,
     {
         self.root_node
             .as_ref()
@@ -172,9 +172,9 @@ impl OpTreeNode {
         }
     }
 
-    pub fn search<Q>(&self, query: &mut Q, m: &OpSetMetadata) -> bool
+    pub fn search<'a, 'b: 'a, Q>(&'b self, query: &mut Q, m: &OpSetMetadata) -> bool
     where
-        Q: TreeQuery,
+        Q: TreeQuery<'a>,
     {
         if self.is_leaf() {
             for e in &self.elements {

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -43,22 +43,26 @@ pub(crate) struct CounterData {
     op: Op,
 }
 
-pub(crate) trait TreeQuery {
+pub(crate) trait TreeQuery<'a> {
     #[inline(always)]
-    fn query_node_with_metadata(&mut self, child: &OpTreeNode, _m: &OpSetMetadata) -> QueryResult {
+    fn query_node_with_metadata(
+        &mut self,
+        child: &'a OpTreeNode,
+        _m: &OpSetMetadata,
+    ) -> QueryResult {
         self.query_node(child)
     }
 
-    fn query_node(&mut self, _child: &OpTreeNode) -> QueryResult {
+    fn query_node(&mut self, _child: &'a OpTreeNode) -> QueryResult {
         QueryResult::Descend
     }
 
     #[inline(always)]
-    fn query_element_with_metadata(&mut self, element: &Op, _m: &OpSetMetadata) -> QueryResult {
+    fn query_element_with_metadata(&mut self, element: &'a Op, _m: &OpSetMetadata) -> QueryResult {
         self.query_element(element)
     }
 
-    fn query_element(&mut self, _element: &Op) -> QueryResult {
+    fn query_element(&mut self, _element: &'a Op) -> QueryResult {
         panic!("invalid element query")
     }
 }

--- a/automerge/src/query/insert.rs
+++ b/automerge/src/query/insert.rs
@@ -61,7 +61,7 @@ impl InsertNth {
     }
 }
 
-impl TreeQuery for InsertNth {
+impl<'a> TreeQuery<'a> for InsertNth {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         // if this node has some visible elements then we may find our target within
         let mut num_vis = child.index.visible_len();

--- a/automerge/src/query/keys_at.rs
+++ b/automerge/src/query/keys_at.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub(crate) struct KeysAt<'a> {
     clock: Clock,
-    window: VisWindow,
+    window: VisWindow<'a>,
     index: usize,
     last_key: Option<Key>,
     index_back: usize,

--- a/automerge/src/query/keys_at.rs
+++ b/automerge/src/query/keys_at.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub(crate) struct KeysAt<'a> {
     clock: Clock,
-    window: VisWindow<'a>,
+    window: VisWindow,
     index: usize,
     last_key: Option<Key>,
     index_back: usize,

--- a/automerge/src/query/len.rs
+++ b/automerge/src/query/len.rs
@@ -13,7 +13,7 @@ impl Len {
     }
 }
 
-impl TreeQuery for Len {
+impl<'a> TreeQuery<'a> for Len {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         self.len = child.index.visible_len();
         QueryResult::Finish

--- a/automerge/src/query/len_at.rs
+++ b/automerge/src/query/len_at.rs
@@ -23,7 +23,7 @@ impl LenAt {
     }
 }
 
-impl TreeQuery for LenAt {
+impl<'a> TreeQuery<'a> for LenAt {
     fn query_element(&mut self, op: &Op) -> QueryResult {
         if op.insert {
             self.last = None;

--- a/automerge/src/query/len_at.rs
+++ b/automerge/src/query/len_at.rs
@@ -3,15 +3,15 @@ use crate::types::{Clock, ElemId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct LenAt {
+pub(crate) struct LenAt<'a> {
     pub len: usize,
     clock: Clock,
     pos: usize,
     last: Option<ElemId>,
-    window: VisWindow,
+    window: VisWindow<'a>,
 }
 
-impl LenAt {
+impl<'a> LenAt<'a> {
     pub fn new(clock: Clock) -> Self {
         LenAt {
             clock,
@@ -23,8 +23,8 @@ impl LenAt {
     }
 }
 
-impl<'a> TreeQuery<'a> for LenAt {
-    fn query_element(&mut self, op: &Op) -> QueryResult {
+impl<'a> TreeQuery<'a> for LenAt<'a> {
+    fn query_element(&mut self, op: &'a Op) -> QueryResult {
         if op.insert {
             self.last = None;
         }

--- a/automerge/src/query/len_at.rs
+++ b/automerge/src/query/len_at.rs
@@ -3,15 +3,15 @@ use crate::types::{Clock, ElemId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct LenAt<'a> {
+pub(crate) struct LenAt {
     pub len: usize,
     clock: Clock,
     pos: usize,
     last: Option<ElemId>,
-    window: VisWindow<'a>,
+    window: VisWindow,
 }
 
-impl<'a> LenAt<'a> {
+impl LenAt {
     pub fn new(clock: Clock) -> Self {
         LenAt {
             clock,
@@ -23,7 +23,7 @@ impl<'a> LenAt<'a> {
     }
 }
 
-impl<'a> TreeQuery<'a> for LenAt<'a> {
+impl<'a> TreeQuery<'a> for LenAt {
     fn query_element(&mut self, op: &'a Op) -> QueryResult {
         if op.insert {
             self.last = None;

--- a/automerge/src/query/list_vals.rs
+++ b/automerge/src/query/list_vals.rs
@@ -18,7 +18,7 @@ impl ListVals {
     }
 }
 
-impl TreeQuery for ListVals {
+impl<'a> TreeQuery<'a> for ListVals {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         let start = 0;
         for pos in start..child.len() {

--- a/automerge/src/query/list_vals_at.rs
+++ b/automerge/src/query/list_vals_at.rs
@@ -3,15 +3,15 @@ use crate::types::{Clock, ElemId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ListValsAt {
+pub(crate) struct ListValsAt<'a> {
     clock: Clock,
     last_elem: Option<ElemId>,
-    pub ops: Vec<Op>,
-    window: VisWindow,
+    pub ops: Vec<&'a Op>,
+    window: VisWindow<'a>,
     pos: usize,
 }
 
-impl ListValsAt {
+impl<'a> ListValsAt<'a> {
     pub fn new(clock: Clock) -> Self {
         ListValsAt {
             clock,
@@ -23,8 +23,8 @@ impl ListValsAt {
     }
 }
 
-impl<'a> TreeQuery<'a> for ListValsAt {
-    fn query_element_with_metadata(&mut self, op: &Op, m: &OpSetMetadata) -> QueryResult {
+impl<'a> TreeQuery<'a> for ListValsAt<'a> {
+    fn query_element_with_metadata(&mut self, op: &'a Op, m: &OpSetMetadata) -> QueryResult {
         if op.insert {
             self.last_elem = None;
         }

--- a/automerge/src/query/list_vals_at.rs
+++ b/automerge/src/query/list_vals_at.rs
@@ -23,7 +23,7 @@ impl ListValsAt {
     }
 }
 
-impl TreeQuery for ListValsAt {
+impl<'a> TreeQuery<'a> for ListValsAt {
     fn query_element_with_metadata(&mut self, op: &Op, m: &OpSetMetadata) -> QueryResult {
         if op.insert {
             self.last_elem = None;

--- a/automerge/src/query/list_vals_at.rs
+++ b/automerge/src/query/list_vals_at.rs
@@ -3,15 +3,15 @@ use crate::types::{Clock, ElemId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct ListValsAt<'a> {
+pub(crate) struct ListValsAt {
     clock: Clock,
     last_elem: Option<ElemId>,
-    pub ops: Vec<&'a Op>,
-    window: VisWindow<'a>,
+    pub ops: Vec<Op>,
+    window: VisWindow,
     pos: usize,
 }
 
-impl<'a> ListValsAt<'a> {
+impl ListValsAt {
     pub fn new(clock: Clock) -> Self {
         ListValsAt {
             clock,
@@ -23,7 +23,7 @@ impl<'a> ListValsAt<'a> {
     }
 }
 
-impl<'a> TreeQuery<'a> for ListValsAt<'a> {
+impl<'a> TreeQuery<'a> for ListValsAt {
     fn query_element_with_metadata(&mut self, op: &'a Op, m: &OpSetMetadata) -> QueryResult {
         if op.insert {
             self.last_elem = None;

--- a/automerge/src/query/nth.rs
+++ b/automerge/src/query/nth.rs
@@ -5,18 +5,18 @@ use crate::types::{ElemId, Key, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Nth {
+pub(crate) struct Nth<'a> {
     target: usize,
     seen: usize,
     /// last_seen is the target elemid of the last `seen` operation.
     /// It is used to avoid double counting visible elements (which arise through conflicts) that are split across nodes.
     last_seen: Option<ElemId>,
-    pub ops: Vec<Op>,
+    pub ops: Vec<&'a Op>,
     pub ops_pos: Vec<usize>,
     pub pos: usize,
 }
 
-impl Nth {
+impl<'a> Nth<'a> {
     pub fn new(target: usize) -> Self {
         Nth {
             target,
@@ -39,7 +39,7 @@ impl Nth {
     }
 }
 
-impl TreeQuery for Nth {
+impl<'a> TreeQuery<'a> for Nth<'a> {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         let mut num_vis = child.index.visible_len();
         if child.index.has_visible(&self.last_seen) {
@@ -67,7 +67,7 @@ impl TreeQuery for Nth {
         }
     }
 
-    fn query_element(&mut self, element: &Op) -> QueryResult {
+    fn query_element(&mut self, element: &'a Op) -> QueryResult {
         if element.insert {
             if self.seen > self.target {
                 return QueryResult::Finish;
@@ -82,7 +82,7 @@ impl TreeQuery for Nth {
             self.last_seen = element.elemid()
         }
         if self.seen == self.target + 1 && visible {
-            self.ops.push(element.clone());
+            self.ops.push(element);
             self.ops_pos.push(self.pos);
         }
         self.pos += 1;

--- a/automerge/src/query/nth_at.rs
+++ b/automerge/src/query/nth_at.rs
@@ -3,18 +3,18 @@ use crate::types::{Clock, ElemId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct NthAt<'a> {
+pub(crate) struct NthAt {
     clock: Clock,
     target: usize,
     seen: usize,
     last_seen: Option<ElemId>,
-    window: VisWindow<'a>,
-    pub ops: Vec<&'a Op>,
+    window: VisWindow,
+    pub ops: Vec<Op>,
     pub ops_pos: Vec<usize>,
     pub pos: usize,
 }
 
-impl<'a> NthAt<'a> {
+impl NthAt {
     pub fn new(target: usize, clock: Clock) -> Self {
         NthAt {
             clock,
@@ -29,7 +29,7 @@ impl<'a> NthAt<'a> {
     }
 }
 
-impl<'a> TreeQuery<'a> for NthAt<'a> {
+impl<'a> TreeQuery<'a> for NthAt {
     fn query_element(&mut self, element: &'a Op) -> QueryResult {
         if element.insert {
             if self.seen > self.target {

--- a/automerge/src/query/nth_at.rs
+++ b/automerge/src/query/nth_at.rs
@@ -3,18 +3,18 @@ use crate::types::{Clock, ElemId, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct NthAt {
+pub(crate) struct NthAt<'a> {
     clock: Clock,
     target: usize,
     seen: usize,
     last_seen: Option<ElemId>,
-    window: VisWindow,
-    pub ops: Vec<Op>,
+    window: VisWindow<'a>,
+    pub ops: Vec<&'a Op>,
     pub ops_pos: Vec<usize>,
     pub pos: usize,
 }
 
-impl NthAt {
+impl<'a> NthAt<'a> {
     pub fn new(target: usize, clock: Clock) -> Self {
         NthAt {
             clock,
@@ -29,8 +29,8 @@ impl NthAt {
     }
 }
 
-impl<'a> TreeQuery<'a> for NthAt {
-    fn query_element(&mut self, element: &Op) -> QueryResult {
+impl<'a> TreeQuery<'a> for NthAt<'a> {
+    fn query_element(&mut self, element: &'a Op) -> QueryResult {
         if element.insert {
             if self.seen > self.target {
                 return QueryResult::Finish;

--- a/automerge/src/query/nth_at.rs
+++ b/automerge/src/query/nth_at.rs
@@ -29,7 +29,7 @@ impl NthAt {
     }
 }
 
-impl TreeQuery for NthAt {
+impl<'a> TreeQuery<'a> for NthAt {
     fn query_element(&mut self, element: &Op) -> QueryResult {
         if element.insert {
             if self.seen > self.target {

--- a/automerge/src/query/opid.rs
+++ b/automerge/src/query/opid.rs
@@ -30,7 +30,7 @@ impl OpIdSearch {
     }
 }
 
-impl TreeQuery for OpIdSearch {
+impl<'a> TreeQuery<'a> for OpIdSearch {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         if child.index.ops.contains(&self.target) {
             QueryResult::Descend

--- a/automerge/src/query/prop.rs
+++ b/automerge/src/query/prop.rs
@@ -4,14 +4,14 @@ use crate::types::{Key, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Prop {
+pub(crate) struct Prop<'a> {
     key: Key,
-    pub ops: Vec<Op>,
+    pub ops: Vec<&'a Op>,
     pub ops_pos: Vec<usize>,
     pub pos: usize,
 }
 
-impl Prop {
+impl<'a> Prop<'a> {
     pub fn new(prop: usize) -> Self {
         Prop {
             key: Key::Map(prop),
@@ -22,8 +22,12 @@ impl Prop {
     }
 }
 
-impl TreeQuery for Prop {
-    fn query_node_with_metadata(&mut self, child: &OpTreeNode, m: &OpSetMetadata) -> QueryResult {
+impl<'a> TreeQuery<'a> for Prop<'a> {
+    fn query_node_with_metadata(
+        &mut self,
+        child: &'a OpTreeNode,
+        m: &OpSetMetadata,
+    ) -> QueryResult {
         let start = binary_search_by(child, |op| m.key_cmp(&op.key, &self.key));
         self.pos = start;
         for pos in start..child.len() {
@@ -32,7 +36,7 @@ impl TreeQuery for Prop {
                 break;
             }
             if op.visible() {
-                self.ops.push(op.clone());
+                self.ops.push(op);
                 self.ops_pos.push(pos);
             }
             self.pos += 1;

--- a/automerge/src/query/prop_at.rs
+++ b/automerge/src/query/prop_at.rs
@@ -4,15 +4,15 @@ use crate::types::{Clock, Key, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct PropAt {
+pub(crate) struct PropAt<'a> {
     clock: Clock,
     key: Key,
-    pub ops: Vec<Op>,
+    pub ops: Vec<&'a Op>,
     pub ops_pos: Vec<usize>,
     pub pos: usize,
 }
 
-impl PropAt {
+impl<'a> PropAt<'a> {
     pub fn new(prop: usize, clock: Clock) -> Self {
         PropAt {
             clock,
@@ -24,8 +24,12 @@ impl PropAt {
     }
 }
 
-impl<'a> TreeQuery<'a> for PropAt {
-    fn query_node_with_metadata(&mut self, child: &OpTreeNode, m: &OpSetMetadata) -> QueryResult {
+impl<'a> TreeQuery<'a> for PropAt<'a> {
+    fn query_node_with_metadata(
+        &mut self,
+        child: &'a OpTreeNode,
+        m: &OpSetMetadata,
+    ) -> QueryResult {
         let start = binary_search_by(child, |op| m.key_cmp(&op.key, &self.key));
         let mut window: VisWindow = Default::default();
         self.pos = start;

--- a/automerge/src/query/prop_at.rs
+++ b/automerge/src/query/prop_at.rs
@@ -24,7 +24,7 @@ impl PropAt {
     }
 }
 
-impl TreeQuery for PropAt {
+impl<'a> TreeQuery<'a> for PropAt {
     fn query_node_with_metadata(&mut self, child: &OpTreeNode, m: &OpSetMetadata) -> QueryResult {
         let start = binary_search_by(child, |op| m.key_cmp(&op.key, &self.key));
         let mut window: VisWindow = Default::default();

--- a/automerge/src/query/prop_at.rs
+++ b/automerge/src/query/prop_at.rs
@@ -4,15 +4,15 @@ use crate::types::{Clock, Key, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct PropAt<'a> {
+pub(crate) struct PropAt {
     clock: Clock,
     key: Key,
-    pub ops: Vec<&'a Op>,
+    pub ops: Vec<Op>,
     pub ops_pos: Vec<usize>,
     pub pos: usize,
 }
 
-impl<'a> PropAt<'a> {
+impl PropAt {
     pub fn new(prop: usize, clock: Clock) -> Self {
         PropAt {
             clock,
@@ -24,7 +24,7 @@ impl<'a> PropAt<'a> {
     }
 }
 
-impl<'a> TreeQuery<'a> for PropAt<'a> {
+impl<'a> TreeQuery<'a> for PropAt {
     fn query_node_with_metadata(
         &mut self,
         child: &'a OpTreeNode,

--- a/automerge/src/query/seek_op.rs
+++ b/automerge/src/query/seek_op.rs
@@ -5,9 +5,9 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct SeekOp {
+pub(crate) struct SeekOp<'a> {
     /// the op we are looking for
-    op: Op,
+    op: &'a Op,
     /// The position to insert at
     pub pos: usize,
     /// The indices of ops that this op overwrites
@@ -16,10 +16,10 @@ pub(crate) struct SeekOp {
     found: bool,
 }
 
-impl SeekOp {
-    pub fn new(op: &Op) -> Self {
+impl<'a> SeekOp<'a> {
+    pub fn new(op: &'a Op) -> Self {
         SeekOp {
-            op: op.clone(),
+            op,
             succ: vec![],
             pos: 0,
             found: false,
@@ -39,7 +39,7 @@ impl SeekOp {
     }
 }
 
-impl<'a> TreeQuery<'a> for SeekOp {
+impl<'a> TreeQuery<'a> for SeekOp<'a> {
     fn query_node_with_metadata(&mut self, child: &OpTreeNode, m: &OpSetMetadata) -> QueryResult {
         if self.found {
             return QueryResult::Descend;

--- a/automerge/src/query/seek_op.rs
+++ b/automerge/src/query/seek_op.rs
@@ -39,7 +39,7 @@ impl SeekOp {
     }
 }
 
-impl TreeQuery for SeekOp {
+impl<'a> TreeQuery<'a> for SeekOp {
     fn query_node_with_metadata(&mut self, child: &OpTreeNode, m: &OpSetMetadata) -> QueryResult {
         if self.found {
             return QueryResult::Descend;

--- a/automerge/src/query/seek_op_with_patch.rs
+++ b/automerge/src/query/seek_op_with_patch.rs
@@ -60,7 +60,7 @@ impl SeekOpWithPatch {
     }
 }
 
-impl TreeQuery for SeekOpWithPatch {
+impl<'a> TreeQuery<'a> for SeekOpWithPatch {
     fn query_node_with_metadata(&mut self, child: &OpTreeNode, m: &OpSetMetadata) -> QueryResult {
         if self.found {
             return QueryResult::Descend;

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -257,7 +257,9 @@ impl TransactionInner {
             insert: false,
         };
 
-        self.insert_local_op(doc, op, query.pos, obj, &query.ops_pos);
+        let pos = query.pos;
+        let ops_pos = query.ops_pos;
+        self.insert_local_op(doc, op, pos, obj, &ops_pos);
 
         if is_make {
             Ok(Some(id))
@@ -294,7 +296,9 @@ impl TransactionInner {
             insert: false,
         };
 
-        self.insert_local_op(doc, op, query.pos, obj, &query.ops_pos);
+        let pos = query.pos;
+        let ops_pos = query.ops_pos;
+        self.insert_local_op(doc, op, pos, obj, &ops_pos);
 
         if is_make {
             Ok(Some(id))

--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -159,6 +159,14 @@ impl<'a> Value<'a> {
         }
     }
 
+    pub fn to_owned(&self) -> Value<'static> {
+        match self {
+            Value::Object(o) => Value::Object(*o),
+            Value::Scalar(Cow::Owned(s)) => Value::Scalar(Cow::Owned(s.clone())),
+            Value::Scalar(Cow::Borrowed(s)) => Value::Scalar(Cow::Owned((*s).clone())),
+        }
+    }
+
     pub fn into_bytes(self) -> Result<Vec<u8>, Self> {
         match self {
             Value::Scalar(s) => s

--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -1,58 +1,61 @@
 use crate::error;
-use crate::types::{ObjType, Op, OpId, OpType};
+use crate::types::ObjType;
 use serde::{Deserialize, Serialize, Serializer};
 use smol_str::SmolStr;
+use std::borrow::Cow;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Value {
+pub enum Value<'a> {
     Object(ObjType),
-    Scalar(ScalarValue),
+    // TODO: if we don't have to store this in patches any more then it might be able to be just a
+    // &'a ScalarValue rather than a Cow
+    Scalar(Cow<'a, ScalarValue>),
 }
 
-impl Value {
-    pub fn map() -> Value {
+impl<'a> Value<'a> {
+    pub fn map() -> Value<'a> {
         Value::Object(ObjType::Map)
     }
 
-    pub fn list() -> Value {
+    pub fn list() -> Value<'a> {
         Value::Object(ObjType::List)
     }
 
-    pub fn text() -> Value {
+    pub fn text() -> Value<'a> {
         Value::Object(ObjType::Text)
     }
 
-    pub fn table() -> Value {
+    pub fn table() -> Value<'a> {
         Value::Object(ObjType::Table)
     }
 
-    pub fn str(s: &str) -> Value {
-        Value::Scalar(ScalarValue::Str(s.into()))
+    pub fn str(s: &str) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::Str(s.into())))
     }
 
-    pub fn int(n: i64) -> Value {
-        Value::Scalar(ScalarValue::Int(n))
+    pub fn int(n: i64) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::Int(n)))
     }
 
-    pub fn uint(n: u64) -> Value {
-        Value::Scalar(ScalarValue::Uint(n))
+    pub fn uint(n: u64) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::Uint(n)))
     }
 
-    pub fn counter(n: i64) -> Value {
-        Value::Scalar(ScalarValue::counter(n))
+    pub fn counter(n: i64) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::counter(n)))
     }
 
-    pub fn timestamp(n: i64) -> Value {
-        Value::Scalar(ScalarValue::Timestamp(n))
+    pub fn timestamp(n: i64) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::Timestamp(n)))
     }
 
-    pub fn f64(n: f64) -> Value {
-        Value::Scalar(ScalarValue::F64(n))
+    pub fn f64(n: f64) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::F64(n)))
     }
 
-    pub fn bytes(b: Vec<u8>) -> Value {
-        Value::Scalar(ScalarValue::Bytes(b))
+    pub fn bytes(b: Vec<u8>) -> Value<'a> {
+        Value::Scalar(Cow::Owned(ScalarValue::Bytes(b)))
     }
 
     pub fn is_object(&self) -> bool {
@@ -64,44 +67,80 @@ impl Value {
     }
 
     pub fn is_bytes(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Bytes(_)))
+        if let Self::Scalar(s) = self {
+            s.is_bytes()
+        } else {
+            false
+        }
     }
 
     pub fn is_str(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Str(_)))
+        if let Self::Scalar(s) = self {
+            s.is_str()
+        } else {
+            false
+        }
     }
 
     pub fn is_int(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Int(_)))
+        if let Self::Scalar(s) = self {
+            s.is_int()
+        } else {
+            false
+        }
     }
 
     pub fn is_uint(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Uint(_)))
+        if let Self::Scalar(s) = self {
+            s.is_uint()
+        } else {
+            false
+        }
     }
 
     pub fn is_f64(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::F64(_)))
+        if let Self::Scalar(s) = self {
+            s.is_f64()
+        } else {
+            false
+        }
     }
 
     pub fn is_counter(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Counter(_)))
+        if let Self::Scalar(s) = self {
+            s.is_counter()
+        } else {
+            false
+        }
     }
 
     pub fn is_timestamp(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Timestamp(_)))
+        if let Self::Scalar(s) = self {
+            s.is_timestamp()
+        } else {
+            false
+        }
     }
 
     pub fn is_boolean(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Boolean(_)))
+        if let Self::Scalar(s) = self {
+            s.is_boolean()
+        } else {
+            false
+        }
     }
 
     pub fn is_null(&self) -> bool {
-        matches!(self, Self::Scalar(ScalarValue::Null))
+        if let Self::Scalar(s) = self {
+            s.is_null()
+        } else {
+            false
+        }
     }
 
     pub fn into_scalar(self) -> Result<ScalarValue, Self> {
         match self {
-            Self::Scalar(s) => Ok(s),
+            Self::Scalar(s) => Ok(s.into_owned()),
             _ => Err(self),
         }
     }
@@ -122,7 +161,10 @@ impl Value {
 
     pub fn into_bytes(self) -> Result<Vec<u8>, Self> {
         match self {
-            Value::Scalar(s) => s.into_bytes().map_err(Value::Scalar),
+            Value::Scalar(s) => s
+                .into_owned()
+                .into_bytes()
+                .map_err(|v| Value::Scalar(Cow::Owned(v))),
             _ => Err(self),
         }
     }
@@ -136,7 +178,10 @@ impl Value {
 
     pub fn into_string(self) -> Result<String, Self> {
         match self {
-            Value::Scalar(s) => s.into_string().map_err(Value::Scalar),
+            Value::Scalar(s) => s
+                .into_owned()
+                .into_string()
+                .map_err(|v| Value::Scalar(Cow::Owned(v))),
             _ => Err(self),
         }
     }
@@ -178,7 +223,7 @@ impl Value {
     }
 }
 
-impl fmt::Display for Value {
+impl<'a> fmt::Display for Value<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::Object(o) => write!(f, "Object: {}", o),
@@ -187,110 +232,81 @@ impl fmt::Display for Value {
     }
 }
 
-impl From<&str> for Value {
+impl<'a> From<&str> for Value<'a> {
     fn from(s: &str) -> Self {
-        Value::Scalar(ScalarValue::Str(s.into()))
+        Value::Scalar(Cow::Owned(ScalarValue::Str(s.into())))
     }
 }
 
-impl From<String> for Value {
+impl<'a> From<String> for Value<'a> {
     fn from(s: String) -> Self {
-        Value::Scalar(ScalarValue::Str(s.into()))
+        Value::Scalar(Cow::Owned(ScalarValue::Str(s.into())))
     }
 }
 
-impl From<char> for Value {
+impl<'a> From<char> for Value<'a> {
     fn from(c: char) -> Self {
-        Value::Scalar(ScalarValue::Str(SmolStr::new(c.to_string())))
+        Value::Scalar(Cow::Owned(ScalarValue::Str(SmolStr::new(c.to_string()))))
     }
 }
 
-impl From<Vec<u8>> for Value {
+impl<'a> From<Vec<u8>> for Value<'a> {
     fn from(v: Vec<u8>) -> Self {
-        Value::Scalar(ScalarValue::Bytes(v))
+        Value::Scalar(Cow::Owned(ScalarValue::Bytes(v)))
     }
 }
 
-impl From<f64> for Value {
+impl<'a> From<f64> for Value<'a> {
     fn from(n: f64) -> Self {
-        Value::Scalar(ScalarValue::F64(n))
+        Value::Scalar(Cow::Owned(ScalarValue::F64(n)))
     }
 }
 
-impl From<i64> for Value {
+impl<'a> From<i64> for Value<'a> {
     fn from(n: i64) -> Self {
-        Value::Scalar(ScalarValue::Int(n))
+        Value::Scalar(Cow::Owned(ScalarValue::Int(n)))
     }
 }
 
-impl From<i32> for Value {
+impl<'a> From<i32> for Value<'a> {
     fn from(n: i32) -> Self {
-        Value::Scalar(ScalarValue::Int(n.into()))
+        Value::Scalar(Cow::Owned(ScalarValue::Int(n.into())))
     }
 }
 
-impl From<u32> for Value {
+impl<'a> From<u32> for Value<'a> {
     fn from(n: u32) -> Self {
-        Value::Scalar(ScalarValue::Uint(n.into()))
+        Value::Scalar(Cow::Owned(ScalarValue::Uint(n.into())))
     }
 }
 
-impl From<u64> for Value {
+impl<'a> From<u64> for Value<'a> {
     fn from(n: u64) -> Self {
-        Value::Scalar(ScalarValue::Uint(n))
+        Value::Scalar(Cow::Owned(ScalarValue::Uint(n)))
     }
 }
 
-impl From<bool> for Value {
+impl<'a> From<bool> for Value<'a> {
     fn from(v: bool) -> Self {
-        Value::Scalar(ScalarValue::Boolean(v))
+        Value::Scalar(Cow::Owned(ScalarValue::Boolean(v)))
     }
 }
 
-impl From<()> for Value {
+impl<'a> From<()> for Value<'a> {
     fn from(_: ()) -> Self {
-        Value::Scalar(ScalarValue::Null)
+        Value::Scalar(Cow::Owned(ScalarValue::Null))
     }
 }
 
-impl From<ObjType> for Value {
+impl<'a> From<ObjType> for Value<'a> {
     fn from(o: ObjType) -> Self {
         Value::Object(o)
     }
 }
 
-impl From<ScalarValue> for Value {
+impl<'a> From<ScalarValue> for Value<'a> {
     fn from(v: ScalarValue) -> Self {
-        Value::Scalar(v)
-    }
-}
-
-impl From<&Op> for (Value, OpId) {
-    fn from(op: &Op) -> Self {
-        match &op.action {
-            OpType::Make(obj_type) => (Value::Object(*obj_type), op.id),
-            OpType::Put(scalar) => (Value::Scalar(scalar.clone()), op.id),
-            _ => panic!("cant convert op into a value - {:?}", op),
-        }
-    }
-}
-
-impl From<Op> for (Value, OpId) {
-    fn from(op: Op) -> Self {
-        match &op.action {
-            OpType::Make(obj_type) => (Value::Object(*obj_type), op.id),
-            OpType::Put(scalar) => (Value::Scalar(scalar.clone()), op.id),
-            _ => panic!("cant convert op into a value - {:?}", op),
-        }
-    }
-}
-
-impl From<Value> for OpType {
-    fn from(v: Value) -> Self {
-        match v {
-            Value::Object(o) => OpType::Make(o),
-            Value::Scalar(s) => OpType::Put(s),
-        }
+        Value::Scalar(Cow::Owned(v))
     }
 }
 

--- a/automerge/tests/helpers/mod.rs
+++ b/automerge/tests/helpers/mod.rs
@@ -319,7 +319,7 @@ pub fn realize_prop<P: Into<automerge::Prop>>(
     let (val, obj_id) = doc.value(obj_id, prop).unwrap().unwrap();
     match val {
         automerge::Value::Object(obj_type) => realize_obj(doc, &obj_id, obj_type),
-        automerge::Value::Scalar(v) => RealizedObject::Value(OrdScalarValue::from(v)),
+        automerge::Value::Scalar(v) => RealizedObject::Value(OrdScalarValue::from(v.into_owned())),
     }
 }
 
@@ -356,7 +356,9 @@ fn realize_values<K: Into<automerge::Prop>>(
     for (value, objid) in doc.values(obj_id, key).unwrap() {
         let realized = match value {
             automerge::Value::Object(objtype) => realize_obj(doc, &objid, objtype),
-            automerge::Value::Scalar(v) => RealizedObject::Value(OrdScalarValue::from(v)),
+            automerge::Value::Scalar(v) => {
+                RealizedObject::Value(OrdScalarValue::from(v.into_owned()))
+            }
         };
         values.insert(realized);
     }


### PR DESCRIPTION
Lots of the queries were cloning operations that they were going to return. This allows them to keep just the reference to the op that exists in the tree.

Additionally, rather than returning owned values of scalars that live in the ops we should just return a reference to them to make calls to `value` cheaper, and future iteration methods.