### PR TITLE
Remove grapheme splitting internally

### DIFF
--- a/automerge-cli/src/import.rs
+++ b/automerge-cli/src/import.rs
@@ -28,7 +28,7 @@ fn import_map(
                 doc.put(obj, key, *b)?;
             }
             serde_json::Value::String(s) => {
-                doc.put(obj, key, s.as_ref())?;
+                doc.put(obj, key, s)?;
             }
             serde_json::Value::Array(vec) => {
                 let id = doc.put_object(obj, key, am::ObjType::List)?;
@@ -68,7 +68,7 @@ fn import_list(
                 doc.insert(obj, i, *b)?;
             }
             serde_json::Value::String(s) => {
-                doc.insert(obj, i, s.as_ref())?;
+                doc.insert(obj, i, s)?;
             }
             serde_json::Value::Array(vec) => {
                 let id = doc.insert_object(obj, i, am::ObjType::List)?;

--- a/automerge-wasm/Cargo.toml
+++ b/automerge-wasm/Cargo.toml
@@ -30,7 +30,6 @@ getrandom = { version = "^0.2.2", features=["js"] }
 uuid = { version = "^0.8.2", features=["v4", "wasm-bindgen", "serde"] }
 serde-wasm-bindgen = "0.1.3"
 serde_bytes = "0.11.5"
-unicode-segmentation = "1.7.1"
 hex = "^0.4.3"
 regex = "^1.5"
 

--- a/automerge-wasm/src/interop.rs
+++ b/automerge-wasm/src/interop.rs
@@ -4,7 +4,6 @@ use automerge::{Change, ChangeHash, Prop};
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use std::collections::HashSet;
 use std::fmt::Display;
-use unicode_segmentation::UnicodeSegmentation;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -286,9 +285,9 @@ pub(crate) fn to_objtype(
         Some("text") => {
             let text = value.as_string()?;
             let text = text
-                .graphemes(true)
+                .chars()
                 .enumerate()
-                .map(|(i, ch)| (i.into(), ch.into()))
+                .map(|(i, ch)| (i.into(), ch.to_string().into()))
                 .collect();
             Some((am::ObjType::Text, text))
         }
@@ -311,9 +310,9 @@ pub(crate) fn to_objtype(
                 Some((am::ObjType::Map, map))
             } else if let Some(text) = value.as_string() {
                 let text = text
-                    .graphemes(true)
+                    .chars()
                     .enumerate()
-                    .map(|(i, ch)| (i.into(), ch.into()))
+                    .map(|(i, ch)| (i.into(), ch.to_string().into()))
                     .collect();
                 Some((am::ObjType::Text, text))
             } else {

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -24,7 +24,6 @@ smol_str = "^0.1.21"
 tracing = { version = "^0.1.29", features = ["log"] }
 fxhash = "^0.2.1"
 tinyvec = { version = "^1.5.1", features = ["alloc"] }
-unicode-segmentation = "1.7.1"
 serde = { version = "^1.0", features=["derive"] }
 dot = { version = "0.1.4", optional = true }
 js-sys = { version = "^0.3", optional = true }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1749,6 +1749,21 @@ mod tests {
     }
 
     #[test]
+    fn can_insert_long_string_into_text() {
+        let mut doc = Automerge::new();
+        let mut tx = doc.transaction();
+        let text = tx.put_object(ROOT, "text", ObjType::Text).unwrap();
+        let polar_bear = "🐻‍❄️";
+        let polar_bear_army = polar_bear.repeat(100);
+        tx.insert(&text, 0, &polar_bear_army).unwrap();
+        tx.commit();
+        let s = doc.text(&text).unwrap();
+        assert_eq!(s, polar_bear_army);
+        let len = doc.length(&text);
+        assert_eq!(len, 1); // many graphemes
+    }
+
+    #[test]
     fn splice_text_uses_unicode_scalars() {
         let mut doc = Automerge::new();
         let mut tx = doc.transaction();

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1733,4 +1733,32 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn can_insert_a_grapheme_into_text() {
+        let mut doc = Automerge::new();
+        let mut tx = doc.transaction();
+        let text = tx.put_object(ROOT, "text", ObjType::Text).unwrap();
+        let polar_bear = "🐻‍❄️";
+        tx.insert(&text, 0, polar_bear).unwrap();
+        tx.commit();
+        let s = doc.text(&text).unwrap();
+        assert_eq!(s, polar_bear);
+        let len = doc.length(&text);
+        assert_eq!(len, 1); // just one grapheme
+    }
+
+    #[test]
+    fn splice_text_uses_unicode_scalars() {
+        let mut doc = Automerge::new();
+        let mut tx = doc.transaction();
+        let text = tx.put_object(ROOT, "text", ObjType::Text).unwrap();
+        let polar_bear = "🐻‍❄️";
+        tx.splice_text(&text, 0, 0, polar_bear).unwrap();
+        tx.commit();
+        let s = doc.text(&text).unwrap();
+        assert_eq!(s, polar_bear);
+        let len = doc.length(&text);
+        assert_eq!(len, 4); // 4 chars
+    }
 }

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -1,6 +1,5 @@
 use crate::exid::ExId;
 use crate::{AutomergeError, ChangeHash, Keys, KeysAt, ObjType, Prop, ScalarValue, Value};
-use unicode_segmentation::UnicodeSegmentation;
 
 /// A way of mutating a document within a single change.
 pub trait Transactable {
@@ -88,8 +87,7 @@ pub trait Transactable {
         del: usize,
         text: &str,
     ) -> Result<(), AutomergeError> {
-        let text = text.to_owned();
-        let vals = text.graphemes(true).map(|c| c.into());
+        let vals = text.chars().map(|c| c.into());
         self.splice(obj, pos, del, vals)
     }
 

--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -246,6 +246,12 @@ impl<'a> From<&str> for Value<'a> {
     }
 }
 
+impl<'a> From<&String> for Value<'a> {
+    fn from(s: &String) -> Self {
+        Value::Scalar(Cow::Owned(ScalarValue::Str(s.into())))
+    }
+}
+
 impl<'a> From<String> for Value<'a> {
     fn from(s: String) -> Self {
         Value::Scalar(Cow::Owned(ScalarValue::Str(s.into())))
@@ -622,6 +628,12 @@ impl ScalarValue {
 
 impl From<&str> for ScalarValue {
     fn from(s: &str) -> Self {
+        ScalarValue::Str(s.into())
+    }
+}
+
+impl From<&String> for ScalarValue {
+    fn from(s: &String) -> Self {
         ScalarValue::Str(s.into())
     }
 }


### PR DESCRIPTION
Currently, we do an automatic split of strings into grapheme clusters on some calls but users can still insert normal strings into text. Since grapheme clusters and the algorithm behind splitting them is able to change with different revisions of the unicode spec I think we should leave this to users, as they require.

When we need to split things (`splice_text` and from js) we can just use the chars that make up the rust string, these are unicode scalars.