### PR TITLE
Add patches support to transactions

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -239,8 +239,8 @@ impl Automerge {
         }
     }
 
-    fn insert_op_with_patch(&mut self, obj: &ObjId, op: Op) {
-        let q = self.ops.search(obj, query::SeekOpWithPatch::new(&op));
+    pub(crate) fn insert_patch(&mut self, obj: &ObjId, op: &Op) -> (usize, Vec<usize>) {
+        let q = self.ops.search(obj, query::SeekOpWithPatch::new(op));
 
         let query::SeekOpWithPatch {
             pos,
@@ -299,6 +299,12 @@ impl Automerge {
         if let Some(patches) = &mut self.patches {
             patches.push(patch);
         }
+
+        (pos, succ)
+    }
+
+    fn insert_op_with_patch(&mut self, obj: &ObjId, op: Op) {
+        let (pos, succ) = self.insert_patch(obj, &op);
 
         for i in succ {
             self.ops.replace(obj, i, |old_op| old_op.add_succ(&op));

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -506,7 +506,7 @@ pub(crate) fn export_change(
         operations: change
             .operations
             .iter()
-            .map(|(obj, op)| export_op(op, obj, actors, props))
+            .map(|(obj, op, _)| export_op(op, obj, actors, props))
             .collect(),
         extra_bytes: change.extra_bytes,
     }

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -42,8 +42,10 @@ impl TransactionInner {
         }
 
         let num_ops = self.pending_ops();
-        for (obj, op) in self.operations.iter() {
-            doc.insert_patch(obj, op);
+        if doc.patches.is_some() {
+            for (obj, op) in self.operations.iter() {
+                doc.insert_patch(obj, op);
+            }
         }
         let change = export_change(self, &doc.ops.m.actors, &doc.ops.m.props);
         let hash = change.hash;

--- a/automerge/src/transaction/inner.rs
+++ b/automerge/src/transaction/inner.rs
@@ -42,6 +42,9 @@ impl TransactionInner {
         }
 
         let num_ops = self.pending_ops();
+        for (obj, op) in self.operations.iter() {
+            doc.insert_patch(obj, op);
+        }
         let change = export_change(self, &doc.ops.m.actors, &doc.ops.m.props);
         let hash = change.hash;
         doc.update_history(change, num_ops);


### PR DESCRIPTION
This adds previously-unsupported patches tracking to transactions. Patches only worked for `apply_changes` in the past.