### PR TITLE
Wasm readme

### DIFF
--- a/automerge-js/package.json
+++ b/automerge-js/package.json
@@ -10,7 +10,7 @@
     "mocha": "^9.1.1"
   },
   "dependencies": {
-    "automerge-wasm": "file:../automerge-wasm/dev",
+    "automerge-wasm": "file:../automerge-wasm",
     "fast-sha256": "^1.3.0",
     "pako": "^2.0.4",
     "uuid": "^8.3"

--- a/automerge-js/src/index.js
+++ b/automerge-js/src/index.js
@@ -99,7 +99,7 @@ function emptyChange(doc, options) {
 }
 
 function load(data, actor) {
-  const state = AutomergeWASM.loadDoc(data, actor)
+  const state = AutomergeWASM.load(data, actor)
   return rootProxy(state, true);
 }
 

--- a/automerge-js/src/proxies.js
+++ b/automerge-js/src/proxies.js
@@ -574,7 +574,7 @@ function listMethods(target) {
 }
 
 function textMethods(target) {
-  const {context, objectId, path, readonly, frozen} = target
+  const {context, objectId, path, readonly, frozen, heads } = target
   const methods = {
     set (index, value) {
       return this[index] = value
@@ -583,13 +583,7 @@ function textMethods(target) {
       return this[index]
     },
     toString () {
-      let str = ''
-      let length = this.length
-      for (let i = 0; i < length; i++) {
-        const value = this.get(i)
-        if (typeof value === 'string') str += value
-      }
-      return str
+      return context.text(objectId, heads).replace(/￼/g,'')
     },
     toSpans () {
       let spans = []

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -236,7 +236,7 @@ When querying maps use the `value()` method with the object in question and the 
 
 ### Counters
 
-Counters are 64 bit ints that support the increment operation.  Frequently different actords will want to increment or decrement a number and have all these coalesse into a merged value.
+Counters are 64 bit ints that support the increment operation.  Frequently different actors will want to increment or decrement a number and have all these coalesse into a merged value.
 
 ```
     let doc1 = create("aaaaaa")
@@ -259,7 +259,7 @@ Counters are 64 bit ints that support the increment operation.  Frequently diffe
 
 ### Transactions
 
-Generally speaking you don't need to think about transaction when using automerge.  Normal edits queue up into an in progress trasnaction.  You can query the number of ops in the current transaction with `pendingOps()`.  The transaction will commit automatically on certains calls such as `save()`, `saveIncremental()`, `fork()`, `merge()`, `getHeads()`, `applyChanges()`, `generateSyncMessage()`, and `receiveSyncMessage()`.  When the transaction commits the heads of the document change.  If you want to roll back all the in progress ops you can call `doc.rollback()`.  If you want to manually commit a transaction in progress you can call`doc.commit()` with an optional commit message and timestamp.
+Generally speaking you don't need to think about transactions when using Automerge.  Normal edits queue up into an in-progress transaction.  You can query the number of ops in the current transaction with `pendingOps()`.  The transaction will commit automatically on certains calls such as `save()`, `saveIncremental()`, `fork()`, `merge()`, `getHeads()`, `applyChanges()`, `generateSyncMessage()`, and `receiveSyncMessage()`.  When the transaction commits the heads of the document change.  If you want to roll back all the in progress ops you can call `doc.rollback()`.  If you want to manually commit a transaction in progress you can call `doc.commit()` with an optional commit message and timestamp.
 
 ```javascript
     let doc = create()
@@ -288,7 +288,7 @@ Generally speaking you don't need to think about transaction when using automerg
 
 ### Viewing Old Versions of the Document
 
-All query functions can take an optional argument of `heads` which allow you to query a prior document state. Heads are a set of change hashes that uniquly identify a point in the document history.  The `getHeads()` method can retrieve these at any point.
+All query functions can take an optional argument of `heads` which allow you to query a prior document state. Heads are a set of change hashes that uniquely identify a point in the document history.  The `getHeads()` method can retrieve these at any point.
 
 ```javascript
     let doc = create()
@@ -315,9 +315,9 @@ Queries of old document states are not indexed internally and will be slower tha
 
 ### Forking and Merging
 
-You can `fork()` a document which makes an exact copy of it.  This assigns a new actor so changes made to the fork can be merged back in with the origional.  The `forkAt()` takes a heads allowing you to fork off a document from a previous point in its history.  These documents allocate new memory in WASM and need to be freed.
+You can `fork()` a document which makes an exact copy of it.  This assigns a new actor so changes made to the fork can be merged back in with the original.  The `forkAt()` takes a Heads, allowing you to fork off a document from a previous point in its history.  These documents allocate new memory in WASM and need to be freed.
 
-The `merge()` command applys all changes in the argument doc into the calling doc.  Therefore if doc a has 1000 changes that doc b lacks and doc b has only 10 changes that doc a lacks, `a.merge(b)` will be much faster than `b.merge(a)`.
+The `merge()` command applies all changes in the argument doc into the calling doc.  Therefore if doc a has 1000 changes that doc b lacks and doc b has only 10 changes that doc a lacks, `a.merge(b)` will be much faster than `b.merge(a)`.
 
 ```javascript
     let doc1 = create()
@@ -340,11 +340,11 @@ Note that calling `a.merge(a)` will produce an unrecoverable error from the wasm
 
 ### Saving and Loading
 
-Calling `save()` converts the document to a compressed `Uint8Array()` that can be saved to durable storage.  This format uses a columnar storage format that compresses away most of the automerge metadata needed to manage the CRDT state, but does include all of the change history.
+Calling `save()` converts the document to a compressed `Uint8Array()` that can be saved to durable storage.  This format uses a columnar storage format that compresses away most of the Automerge metadata needed to manage the CRDT state, but does include all of the change history.
 
-If you wish to incrementally update a saved automerge doc you can call `saveIncremental()` to get a `Uint8Array()` of bytes that can be appended to the file with all the new changes(). Note that the `saveIncremental()` bytes are not as compressed the whole document save as each chunk has metadata information needed to parse it.  It may make sense to periodically perform a new `save()` to get the smallest possible file footprint.
+If you wish to incrementally update a saved Automerge doc you can call `saveIncremental()` to get a `Uint8Array()` of bytes that can be appended to the file with all the new changes(). Note that the `saveIncremental()` bytes are not as compressed as the whole document save as each chunk has metadata information needed to parse it.  It may make sense to periodically perform a new `save()` to get the smallest possible file footprint.
 
-The `load()` function takes a `Uint8Array()` of bytes produced in this way and constitutes a new document.  The `loadIncremental()` method is availble if you wish to consume the result of a `saveIncremental()` with a already instanciated document.
+The `load()` function takes a `Uint8Array()` of bytes produced in this way and constitutes a new document.  The `loadIncremental()` method is available if you wish to consume the result of a `saveIncremental()` with an already instanciated document.
 
 ```javascript
   import { create, load } from "automerge-wasm"
@@ -454,7 +454,7 @@ Methods that create new documents will generate random actors automatically - if
 
 ### Glossary: Object Id's
 
-Object Id's uniquly identify an object within a document.  They are represented as strings in the format of `{counter}@{actor}`.  The root object is a special case and can be referred to as `_root`.  The counter in an ever increasing integer, starting at 1, that is always one higher than the highest counter seen in the document thus far.  Object Id's do not change when the object is modified but they do if it is overwritten with a new object.
+Object Ids uniquely identify an object within a document.  They are represented as strings in the format of `{counter}@{actor}`.  The root object is a special case and can be referred to as `_root`.  The counter is an ever increasing integer, starting at 1, that is always one higher than the highest counter seen in the document thus far.  Object Id's do not change when the object is modified but they do if it is overwritten with a new object.
 
 ```
   let doc = create("aabbcc")

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -1,10 +1,10 @@
 ## Automerge WASM Low Level Interface
 
-This package is a low level interface to the [automerge rust](https://github.com/automerge/automerge-rs/tree/experiment) CRDT.  The api is intended to be a "close to the metal" as possible only a few ease of use accomodations.  This library is used as the underpinnings for the [Automerge JS wrapper](https://github.com/automerge/automerge-rs/tree/experiment/automerge-js) and can be used as is or as a basis for another higher level expression of a CRDT.
+This package is a low level interface to the [automerge rust](https://github.com/automerge/automerge-rs/tree/experiment) CRDT.  The api is intended to be as "close to the metal" as possible with only a few ease of use accommodations.  This library is used as the underpinnings for the [Automerge JS wrapper](https://github.com/automerge/automerge-rs/tree/experiment/automerge-js) and can be used as is or as a basis for another higher level expression of a CRDT.
 
 ### Why CRDT?
 
-CRDT stands for Conflict Free Replicated Datatype.  It is a datastructure that offers eventual consistency where multiple actors can write to the document independantly and then these edits can be automatically merged together into a coherent document that, as much as possible, preserves the inten of the different writers.  This allows for novel masterless application design where different components need not have a central coordinating server when altering application state.
+CRDT stands for Conflict Free Replicated Data Type.  It is a data structure that offers eventual consistency where multiple actors can write to the document independently and then these edits can be automatically merged together into a coherent document that, as much as possible, preserves the intent of the different writers.  This allows for novel masterless application design where different components need not have a central coordinating server when altering application state.
 
 ### Terminology
 
@@ -12,13 +12,13 @@ The term Actor, Object Id and Heads are used through this documentation.  Detail
 
 An Actor is a unique id that distinguishes a single writer to a document.  It can be any hex string.
 
-An Object id uniquely identifies a Map, List or Text object within a document.  This id comes as a string in the form on `{number}@{actor}` - so `"10@aabbcc"` for example.  The string `"_root"` or `"/"` can also be used to refer to the document root.  These strings are durable and can be used on any decendant or copy of the document that generated them.
+An Object id uniquely identifies a Map, List or Text object within a document.  This id comes as a string in the form of `{number}@{actor}` - so `"10@aabbcc"` for example.  The string `"_root"` or `"/"` can also be used to refer to the document root.  These strings are durable and can be used on any descendant or copy of the document that generated them.
 
-Heads refers to a set of hashes that uniquly identifies a point in time in a documents history.  Heads are useful for comparing documents state or retrieving past states from the document.
+Heads refers to a set of hashes that uniquely identifies a point in time in a document's history.  Heads are useful for comparing documents state or retrieving past states from the document.
 
 ### Using the Library and Creating a Document
 
-This is a rust/wasm package and will work in a node or web environment.  Node is able to load wasm syncronously but a web environment is not.  The default import of the package is a function that returns a promise that resolves once the wasm is loaded.
+This is a rust/wasm package and will work in a node or web environment.  Node is able to load wasm synchronously but a web environment is not.  The default import of the package is a function that returns a promise that resolves once the wasm is loaded.
 
 This creates a document in node.  The memory allocated is handled by wasm and isn't managed by the javascript garbage collector and thus needs to be manually freed.
 
@@ -46,9 +46,9 @@ The examples below will assume a node context for brevity.
 
 ### Automerge Scalar Types
 
-Automerge has many scalar types.  Methods like `set()` and `insert()` take an optional datatype parameter.  Normally the type can be inferred but in some cases, such as telling the difference between int, uint and a counter, it cannot.
+Automerge has many scalar types.  Methods like `set()` and `insert()` take an optional data type parameter.  Normally the type can be inferred but in some cases, such as telling the difference between int, uint and a counter, it cannot.
 
-These are sets without a datatype
+These are sets without a data type
 
 ```javascript
   import { create } from "automerge-wasm"
@@ -64,7 +64,7 @@ These are sets without a datatype
   doc.free()
 ```
 
-Sets with a datatype and examples of all the supported datatypes.
+Sets with a data type and examples of all the supported data types.
 
 While int vs uint vs f64 matters little in javascript, Automerge is a cross platform library where these distinctions matter.
 
@@ -86,7 +86,7 @@ While int vs uint vs f64 matters little in javascript, Automerge is a cross plat
 
 ### Automerge Object Types
 
-Automerge WASM supports 3 object types.  Maps, lists, and text.  Maps are key value stores where the values can be any scalar type or any object type.  Lists are numerically indexed set of data that can hold any scalar or any object type.  Text is numerically indexed sets of graphmeme clusters.
+Automerge WASM supports 3 object types.  Maps, lists, and text.  Maps are key value stores where the values can be any scalar type or any object type.  Lists are numerically indexed sets of data that can hold any scalar or any object type.  Text is numerically indexed sets of grapheme clusters.
 
 ```javascript
   import { create } from "automerge-wasm"
@@ -124,7 +124,7 @@ You can access objects by passing the object id as the first parameter for a cal
   doc.set(config, "align", "right")
 ```
 
-Anywhere Object Id's are being used a path can also be used.  The following two statements are equivelent:
+Anywhere Object Ids are being used a path can also be used.  The following two statements are equivalent:
 
 ```javascript
   // get the id then use it
@@ -141,7 +141,7 @@ Using the id directly is always faster (as it prevents the path to id conversion
 
 ### Maps
 
-Maps are key/value store.  The root object is always a map.  The keys are always strings.  The values can be any scalar type or any object.
+Maps are key/value stores.  The root object is always a map.  The keys are always strings.  The values can be any scalar type or any object.
 
 ```javascript
     let doc = create()
@@ -161,7 +161,7 @@ Maps are key/value store.  The root object is always a map.  The keys are always
 
 ### Lists
 
-Lists are index addressable sets of values.  These values can be any scalar or object type.  You can manipulate lists with with `insert()`, `set()`, `push()`, `splice()`, and `del()`.
+Lists are index addressable sets of values.  These values can be any scalar or object type.  You can manipulate lists with `insert()`, `set()`, `push()`, `splice()`, and `del()`.
 
 ```javascript
     let doc = create()
@@ -204,7 +204,7 @@ Automerge's Table type is currently not implemented.
 
 ### Querying Data
 
-When querying maps use the `value()` method with the object in question and the property to query.  This method returns a tuple with the datatype and the data.  The `keys()` method will return all the keys on the object.  If you are interested in conflicted values from a merge use `values()` instead which returns an array of values instead of just the winner.
+When querying maps use the `value()` method with the object in question and the property to query.  This method returns a tuple with the data type and the data.  The `keys()` method will return all the keys on the object.  If you are interested in conflicted values from a merge use `values()` instead which returns an array of values instead of just the winner.
 
 ```javascript
     let doc1 = create("aabbcc")
@@ -238,7 +238,7 @@ When querying maps use the `value()` method with the object in question and the 
 
 ### Viewing Old Versions of the Document
 
-All query functions can take a optional argument of `heads` in which case you are query the document state.  Heads is a set of change hashes that uniquly identifies a point in the document history.  The `getHeads()` method can retrieve these at any point.
+All query functions can take an optional argument of `heads` which allow you to query a prior document state. Heads are a set of change hashes that uniquly identify a point in the document history.  The `getHeads()` method can retrieve these at any point.
 
 ```javascript
     let doc = create() 
@@ -262,7 +262,7 @@ This works for `value()`, `values()`, `keys()`, `length()`, `text()`, and `mater
 
 ### Syncing
 
-### Glossery: Actors
+### Glossary: Actors
 
 Some basic concepts you will need to know to better understand the api are Actors and Object Ids.
 
@@ -285,7 +285,7 @@ Methods that create new documents will generate random actors automatically - if
   doc1.free(); doc2.free(); doc3.free(); doc4.free(); doc5.free(); doc6.free()
 ```
 
-### Glossery: Object Id's
+### Glossary: Object Id's
 
 Object Id's uniquly identify an object within a document.  They are represented as strings in the format of `{counter}@{actor}`.  The root object is a special case and can be referred to as `_root`.  The counter in an ever increasing integer, starting at 1, that is always one higher than the highest counter seen in the document thus far.  Object Id's do not change when the object is modified but they do if it is overwritten with a new object.
 
@@ -308,7 +308,7 @@ Object Id's uniquly identify an object within a document.  They are represented 
 
 ```
 
-### Glossery: Heads
+### Glossary: Heads
 
 // FIXME
 loadDoc()

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -1,696 +1,185 @@
 ## Automerge WASM Low Level Interface
 
-This is a low level automerge library written in rust exporting a javascript API via WASM. This low level api is the underpinning to the `automerge-js` library that reimplements the Automerge API via these low level functions.
+This package is a low level interface to the [automerge rust](https://github.com/automerge/automerge-rs/tree/experiment) CRDT.  The api is intended to be a "close to the metal" as possible only a few ease of use accomodations.  This library is used as the underpinnings for the [Automerge JS wrapper](https://github.com/automerge/automerge-rs/tree/experiment/automerge-js) and can be used as is or as a basis for another higher level expression of a CRDT.
 
-### Static Functions
+### Why CRDT?
 
-### Methods
+// TODO
 
-`doc.clone(actor?: string)` : Make a complete
+### Terminology
 
-`doc.free()` : deallocate WASM memory associated with a document
+The term Actor, Object Id and Heads are used through this documentation.  Detailed explanations are in the glossary at the end of this readme.  But the most basic definition would be...
 
-```rust
-    #[wasm_bindgen]
-    pub fn free(self) {}
+An Actor is a unique id that distinguishes a single writer to a document.  It can be any hex string.
 
-    #[wasm_bindgen(js_name = pendingOps)]
-    pub fn pending_ops(&self) -> JsValue {
-        (self.0.pending_ops() as u32).into()
-    }
+An Object id uniquely identifies a Map, List or Text object within a document.  This id comes as a string in the form on `{number}@{actor}` - so `"10@aabbcc"` for example.  The string `"_root"` or `"/"` can also be used to refer to the document root.  These strings are durable and can be used on any decendant or copy of the document that generated them.
 
-    pub fn commit(&mut self, message: Option<String>, time: Option<f64>) -> Array {
-        let heads = self.0.commit(message, time.map(|n| n as i64));
-        let heads: Array = heads
-            .iter()
-            .map(|h| JsValue::from_str(&hex::encode(&h.0)))
-            .collect();
-        heads
-    }
+Heads refers to a set of hashes that uniquly identifies a point in time in a documents history.  Heads are useful for comparing documents state or retrieving past states from the document.
 
-    pub fn rollback(&mut self) -> f64 {
-        self.0.rollback() as f64
-    }
+### Using the Library and Creating a Document
 
-    pub fn keys(&mut self, obj: String, heads: Option<Array>) -> Result<Array, JsValue> {
-        let obj = self.import(obj)?;
-        let result = if let Some(heads) = get_heads(heads) {
-            self.0.keys_at(&obj, &heads)
-        } else {
-            self.0.keys(&obj)
-        }
-        .iter()
-        .map(|s| JsValue::from_str(s))
-        .collect();
-        Ok(result)
-    }
+This is a rust/wasm package and will work in a node or web environment.  Node is able to load wasm syncronously but a web environment is not.  The default import of the package is a function that returns a promise that resolves once the wasm is loaded.
 
-    pub fn text(&mut self, obj: String, heads: Option<Array>) -> Result<String, JsValue> {
-        let obj = self.import(obj)?;
-        if let Some(heads) = get_heads(heads) {
-            self.0.text_at(&obj, &heads)
-        } else {
-            self.0.text(&obj)
-        }
-        .map_err(to_js_err)
-    }
+This creates a document in node.  The memory allocated is handled by wasm and isn't managed by the javascript garbage collector and thus needs to be manually freed.
 
-    pub fn splice(
-        &mut self,
-        obj: String,
-        start: f64,
-        delete_count: f64,
-        text: JsValue,
-    ) -> Result<Option<Array>, JsValue> {
-        let obj = self.import(obj)?;
-        let start = start as usize;
-        let delete_count = delete_count as usize;
-        let mut vals = vec![];
-        if let Some(t) = text.as_string() {
-            self.0
-                .splice_text(&obj, start, delete_count, &t)
-                .map_err(to_js_err)?;
-            Ok(None)
-        } else {
-            if let Ok(array) = text.dyn_into::<Array>() {
-                for i in array.iter() {
-                    if let Ok(array) = i.clone().dyn_into::<Array>() {
-                        let value = array.get(1);
-                        let datatype = array.get(2);
-                        let value = self.import_value(value, datatype.as_string())?;
-                        vals.push(value);
-                    } else {
-                        let value = self.import_value(i, None)?;
-                        vals.push(value);
-                    }
-                }
-            }
-            let result = self
-                .0
-                .splice(&obj, start, delete_count, vals)
-                .map_err(to_js_err)?;
-            if result.is_empty() {
-                Ok(None)
-            } else {
-                let result: Array = result
-                    .iter()
-                    .map(|r| JsValue::from(r.to_string()))
-                    .collect();
-                Ok(result.into())
-            }
-        }
-    }
-
-    pub fn push(
-        &mut self,
-        obj: String,
-        value: JsValue,
-        datatype: Option<String>,
-    ) -> Result<Option<String>, JsValue> {
-        let obj = self.import(obj)?;
-        let value = self.import_value(value, datatype)?;
-        let index = self.0.length(&obj);
-        let opid = self.0.insert(&obj, index, value).map_err(to_js_err)?;
-        Ok(opid.map(|id| id.to_string()))
-    }
-
-    pub fn insert(
-        &mut self,
-        obj: String,
-        index: f64,
-        value: JsValue,
-        datatype: Option<String>,
-    ) -> Result<Option<String>, JsValue> {
-        let obj = self.import(obj)?;
-        let index = index as f64;
-        let value = self.import_value(value, datatype)?;
-        let opid = self
-            .0
-            .insert(&obj, index as usize, value)
-            .map_err(to_js_err)?;
-        Ok(opid.map(|id| id.to_string()))
-    }
-
-    pub fn set(
-        &mut self,
-        obj: String,
-        prop: JsValue,
-        value: JsValue,
-        datatype: Option<String>,
-    ) -> Result<Option<String>, JsValue> {
-        let obj = self.import(obj)?;
-        let prop = self.import_prop(prop)?;
-        let value = self.import_value(value, datatype)?;
-        let opid = self.0.set(&obj, prop, value).map_err(to_js_err)?;
-        Ok(opid.map(|id| id.to_string()))
-    }
-
-    pub fn make(
-        &mut self,
-        obj: String,
-        prop: JsValue,
-        value: JsValue,
-    ) -> Result<String, JsValue> {
-        let obj = self.import(obj)?;
-        let prop = self.import_prop(prop)?;
-        let value = self.import_value(value, None)?;
-        if value.is_object() {
-          let opid = self.0.set(&obj, prop, value).map_err(to_js_err)?;
-          Ok(opid.unwrap().to_string())
-        } else {
-          Err("invalid object type".into())
-        }
-    }
-
-    pub fn inc(&mut self, obj: String, prop: JsValue, value: JsValue) -> Result<(), JsValue> {
-        let obj = self.import(obj)?;
-        let prop = self.import_prop(prop)?;
-        let value: f64 = value
-            .as_f64()
-            .ok_or("inc needs a numberic value")
-            .map_err(to_js_err)?;
-        self.0.inc(&obj, prop, value as i64).map_err(to_js_err)?;
-        Ok(())
-    }
-
-    pub fn value(
-        &mut self,
-        obj: String,
-        prop: JsValue,
-        heads: Option<Array>,
-    ) -> Result<Array, JsValue> {
-        let obj = self.import(obj)?;
-        let result = Array::new();
-        let prop = to_prop(prop);
-        let heads = get_heads(heads);
-        if let Ok(prop) = prop {
-            let value = if let Some(h) = heads {
-                self.0.value_at(&obj, prop, &h)
-            } else {
-                self.0.value(&obj, prop)
-            }
-            .map_err(to_js_err)?;
-            match value {
-                Some((Value::Object(obj_type), obj_id)) => {
-                    result.push(&obj_type.to_string().into());
-                    result.push(&obj_id.to_string().into());
-                }
-                Some((Value::Scalar(value), _)) => {
-                    result.push(&datatype(&value).into());
-                    result.push(&ScalarValue(value).into());
-                }
-                None => {}
-            }
-        }
-        Ok(result)
-    }
-
-    pub fn values(
-        &mut self,
-        obj: String,
-        arg: JsValue,
-        heads: Option<Array>,
-    ) -> Result<Array, JsValue> {
-        let obj = self.import(obj)?;
-        let result = Array::new();
-        let prop = to_prop(arg);
-        if let Ok(prop) = prop {
-            let values = if let Some(heads) = get_heads(heads) {
-                self.0.values_at(&obj, prop, &heads)
-            } else {
-                self.0.values(&obj, prop)
-            }
-            .map_err(to_js_err)?;
-            for value in values {
-                match value {
-                    (Value::Object(obj_type), obj_id) => {
-                        let sub = Array::new();
-                        sub.push(&obj_type.to_string().into());
-                        sub.push(&obj_id.to_string().into());
-                        result.push(&sub.into());
-                    }
-                    (Value::Scalar(value), id) => {
-                        let sub = Array::new();
-                        sub.push(&datatype(&value).into());
-                        sub.push(&ScalarValue(value).into());
-                        sub.push(&id.to_string().into());
-                        result.push(&sub.into());
-                    }
-                }
-            }
-        }
-        Ok(result)
-    }
-
-    pub fn length(&mut self, obj: String, heads: Option<Array>) -> Result<f64, JsValue> {
-        let obj = self.import(obj)?;
-        if let Some(heads) = get_heads(heads) {
-            Ok(self.0.length_at(&obj, &heads) as f64)
-        } else {
-            Ok(self.0.length(&obj) as f64)
-        }
-    }
-
-    pub fn del(&mut self, obj: String, prop: JsValue) -> Result<(), JsValue> {
-        let obj = self.import(obj)?;
-        let prop = to_prop(prop)?;
-        self.0.del(&obj, prop).map_err(to_js_err)?;
-        Ok(())
-    }
-
-    pub fn mark(
-        &mut self,
-        obj: JsValue,
-        range: JsValue,
-        name: JsValue,
-        value: JsValue,
-        datatype: JsValue,
-    ) -> Result<(), JsValue> {
-        let obj = self.import(obj)?;
-        let re = Regex::new(r"([\[\(])(\d+)\.\.(\d+)([\)\]])").unwrap();
-        let range = range.as_string().ok_or("range must be a string")?;
-        let cap = re.captures_iter(&range).next().ok_or("range must be in the form of (start..end] or [start..end) etc... () for sticky, [] for normal")?;
-        let start: usize = cap[2].parse().map_err(|_| to_js_err("invalid start"))?;
-        let end: usize = cap[3].parse().map_err(|_| to_js_err("invalid end"))?;
-        let start_sticky = &cap[1] == "(";
-        let end_sticky = &cap[4] == ")";
-        let name = name
-            .as_string()
-            .ok_or("invalid mark name")
-            .map_err(to_js_err)?;
-        let value = self.import_scalar(&value, datatype.as_string())?;
-        self.0
-            .mark(&obj, start, start_sticky, end, end_sticky, &name, value)
-            .map_err(to_js_err)?;
-        Ok(())
-    }
-
-    pub fn spans(&mut self, obj: JsValue) -> Result<JsValue, JsValue> {
-        let obj = self.import(obj)?;
-        let text = self.0.text(&obj).map_err(to_js_err)?;
-        let spans = self.0.spans(&obj).map_err(to_js_err)?;
-        let mut last_pos = 0;
-        let result = Array::new();
-        for s in spans {
-            let marks = Array::new();
-            for m in s.marks {
-                let mark = Array::new();
-                mark.push(&m.0.into());
-                mark.push(&datatype(&m.1).into());
-                mark.push(&ScalarValue(m.1).into());
-                marks.push(&mark.into());
-            }
-            let text_span = &text[last_pos..s.pos]; //.slice(last_pos, s.pos);
-            if text_span.len() > 0 {
-                result.push(&text_span.into());
-            }
-            result.push(&marks);
-            last_pos = s.pos;
-            //let obj = Object::new().into();
-            //js_set(&obj, "pos", s.pos as i32)?;
-            //js_set(&obj, "marks", marks)?;
-            //result.push(&obj.into());
-        }
-        let text_span = &text[last_pos..];
-        if text_span.len() > 0 {
-            result.push(&text_span.into());
-        }
-        Ok(result.into())
-    }
-
-    pub fn save(&mut self) -> Result<Uint8Array, JsValue> {
-        self.0
-            .save()
-            .map(|v| Uint8Array::from(v.as_slice()))
-            .map_err(to_js_err)
-    }
-
-    #[wasm_bindgen(js_name = saveIncremental)]
-    pub fn save_incremental(&mut self) -> Uint8Array {
-        let bytes = self.0.save_incremental();
-        Uint8Array::from(bytes.as_slice())
-    }
-
-    #[wasm_bindgen(js_name = loadIncremental)]
-    pub fn load_incremental(&mut self, data: Uint8Array) -> Result<f64, JsValue> {
-        let data = data.to_vec();
-        let len = self.0.load_incremental(&data).map_err(to_js_err)?;
-        Ok(len as f64)
-    }
-
-    #[wasm_bindgen(js_name = applyChanges)]
-    pub fn apply_changes(&mut self, changes: JsValue) -> Result<(), JsValue> {
-        let changes: Vec<_> = JS(changes).try_into()?;
-        self.0.apply_changes(&changes).map_err(to_js_err)?;
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = getChanges)]
-    pub fn get_changes(&mut self, have_deps: JsValue) -> Result<Array, JsValue> {
-        let deps: Vec<_> = JS(have_deps).try_into()?;
-        let changes = self.0.get_changes(&deps);
-        let changes: Array = changes
-            .iter()
-            .map(|c| Uint8Array::from(c.raw_bytes()))
-            .collect();
-        Ok(changes)
-    }
-
-    #[wasm_bindgen(js_name = getChangesAdded)]
-    pub fn get_changes_added(&mut self, other: &Automerge) -> Result<Array, JsValue> {
-        let changes = self.0.get_changes_added(&other.0);
-        let changes: Array = changes
-            .iter()
-            .map(|c| Uint8Array::from(c.raw_bytes()))
-            .collect();
-        Ok(changes)
-    }
-
-    #[wasm_bindgen(js_name = getHeads)]
-    pub fn get_heads(&mut self) -> Array {
-        let heads = self.0.get_heads();
-        let heads: Array = heads
-            .iter()
-            .map(|h| JsValue::from_str(&hex::encode(&h.0)))
-            .collect();
-        heads
-    }
-
-    #[wasm_bindgen(js_name = getActorId)]
-    pub fn get_actor_id(&mut self) -> String {
-        let actor = self.0.get_actor();
-        actor.to_string()
-    }
-
-    #[wasm_bindgen(js_name = getLastLocalChange)]
-    pub fn get_last_local_change(&mut self) -> Result<Option<Uint8Array>, JsValue> {
-        if let Some(change) = self.0.get_last_local_change() {
-            Ok(Some(Uint8Array::from(change.raw_bytes())))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub fn dump(&self) {
-        self.0.dump()
-    }
-
-    #[wasm_bindgen(js_name = getMissingDeps)]
-    pub fn get_missing_deps(&mut self, heads: Option<Array>) -> Result<Array, JsValue> {
-        let heads = get_heads(heads).unwrap_or_default();
-        let deps = self.0.get_missing_deps(&heads);
-        let deps: Array = deps
-            .iter()
-            .map(|h| JsValue::from_str(&hex::encode(&h.0)))
-            .collect();
-        Ok(deps)
-    }
-
-    #[wasm_bindgen(js_name = receiveSyncMessage)]
-    pub fn receive_sync_message(
-        &mut self,
-        state: &mut SyncState,
-        message: Uint8Array,
-    ) -> Result<(), JsValue> {
-        let message = message.to_vec();
-        let message = am::SyncMessage::decode(message.as_slice()).map_err(to_js_err)?;
-        self.0
-            .receive_sync_message(&mut state.0, message)
-            .map_err(to_js_err)?;
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = generateSyncMessage)]
-    pub fn generate_sync_message(&mut self, state: &mut SyncState) -> Result<JsValue, JsValue> {
-        if let Some(message) = self.0.generate_sync_message(&mut state.0) {
-            Ok(Uint8Array::from(message.encode().map_err(to_js_err)?.as_slice()).into())
-        } else {
-            Ok(JsValue::null())
-        }
-    }
-
-    #[wasm_bindgen(js_name = toJS)]
-    pub fn to_js(&self) -> JsValue {
-        map_to_js(&self.0, ROOT)
-    }
-
-    fn import(&self, id: String) -> Result<ObjId, JsValue> {
-        self.0.import(&id).map_err(to_js_err)
-    }
-
-    fn import_prop(&mut self, prop: JsValue) -> Result<Prop, JsValue> {
-        if let Some(s) = prop.as_string() {
-            Ok(s.into())
-        } else if let Some(n) = prop.as_f64() {
-            Ok((n as usize).into())
-        } else {
-            Err(format!("invalid prop {:?}", prop).into())
-        }
-    }
-
-    fn import_scalar(
-        &mut self,
-        value: &JsValue,
-        datatype: Option<String>,
-    ) -> Result<am::ScalarValue, JsValue> {
-        match datatype.as_deref() {
-            Some("boolean") => value
-                .as_bool()
-                .ok_or_else(|| "value must be a bool".into())
-                .map(am::ScalarValue::Boolean),
-            Some("int") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::Int(v as i64)),
-            Some("uint") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::Uint(v as u64)),
-            Some("f64") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(am::ScalarValue::F64),
-            Some("bytes") => Ok(am::ScalarValue::Bytes(
-                value.clone().dyn_into::<Uint8Array>().unwrap().to_vec(),
-            )),
-            Some("counter") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::counter(v as i64)),
-            Some("timestamp") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::Timestamp(v as i64)),
-            /*
-            Some("bytes") => unimplemented!(),
-            Some("cursor") => unimplemented!(),
-            */
-            Some("null") => Ok(am::ScalarValue::Null),
-            Some(_) => Err(format!("unknown datatype {:?}", datatype).into()),
-            None => {
-                if value.is_null() {
-                    Ok(am::ScalarValue::Null)
-                } else if let Some(b) = value.as_bool() {
-                    Ok(am::ScalarValue::Boolean(b))
-                } else if let Some(s) = value.as_string() {
-                    // FIXME - we need to detect str vs int vs float vs bool here :/
-                    Ok(am::ScalarValue::Str(s.into()))
-                } else if let Some(n) = value.as_f64() {
-                    if (n.round() - n).abs() < f64::EPSILON {
-                        Ok(am::ScalarValue::Int(n as i64))
-                    } else {
-                        Ok(am::ScalarValue::F64(n))
-                    }
-                //                } else if let Some(o) = to_objtype(&value) {
-                //                    Ok(o.into())
-                } else if let Ok(d) = value.clone().dyn_into::<js_sys::Date>() {
-                    Ok(am::ScalarValue::Timestamp(d.get_time() as i64))
-                } else if let Ok(o) = &value.clone().dyn_into::<Uint8Array>() {
-                    Ok(am::ScalarValue::Bytes(o.to_vec()))
-                } else {
-                    Err("value is invalid".into())
-                }
-            }
-        }
-    }
-
-    fn import_value(&mut self, value: JsValue, datatype: Option<String>) -> Result<Value, JsValue> {
-        match self.import_scalar(&value, datatype) {
-            Ok(val) => Ok(val.into()),
-            Err(err) => {
-                if let Some(o) = to_objtype(&value) {
-                    Ok(o.into())
-                } else {
-                    Err(err)
-                }
-            }
-        }
-        /*
-        match datatype.as_deref() {
-            Some("boolean") => value
-                .as_bool()
-                .ok_or_else(|| "value must be a bool".into())
-                .map(|v| am::ScalarValue::Boolean(v).into()),
-            Some("int") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::Int(v as i64).into()),
-            Some("uint") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::Uint(v as u64).into()),
-            Some("f64") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|n| am::ScalarValue::F64(n).into()),
-            Some("bytes") => {
-                Ok(am::ScalarValue::Bytes(value.dyn_into::<Uint8Array>().unwrap().to_vec()).into())
-            }
-            Some("counter") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::counter(v as i64).into()),
-            Some("timestamp") => value
-                .as_f64()
-                .ok_or_else(|| "value must be a number".into())
-                .map(|v| am::ScalarValue::Timestamp(v as i64).into()),
-            Some("null") => Ok(am::ScalarValue::Null.into()),
-            Some(_) => Err(format!("unknown datatype {:?}", datatype).into()),
-            None => {
-                if value.is_null() {
-                    Ok(am::ScalarValue::Null.into())
-                } else if let Some(b) = value.as_bool() {
-                    Ok(am::ScalarValue::Boolean(b).into())
-                } else if let Some(s) = value.as_string() {
-                    // FIXME - we need to detect str vs int vs float vs bool here :/
-                    Ok(am::ScalarValue::Str(s.into()).into())
-                } else if let Some(n) = value.as_f64() {
-                    if (n.round() - n).abs() < f64::EPSILON {
-                        Ok(am::ScalarValue::Int(n as i64).into())
-                    } else {
-                        Ok(am::ScalarValue::F64(n).into())
-                    }
-                } else if let Some(o) = to_objtype(&value) {
-                    Ok(o.into())
-                } else if let Ok(d) = value.clone().dyn_into::<js_sys::Date>() {
-                    Ok(am::ScalarValue::Timestamp(d.get_time() as i64).into())
-                } else if let Ok(o) = &value.dyn_into::<Uint8Array>() {
-                    Ok(am::ScalarValue::Bytes(o.to_vec()).into())
-                } else {
-                    Err("value is invalid".into())
-                }
-            }
-        }
-        */
-    }
-
-}
-
-#[wasm_bindgen(js_name = create)]
-pub fn init(actor: Option<String>) -> Result<Automerge, JsValue> {
-    console_error_panic_hook::set_once();
-    Automerge::new(actor)
-}
-
-#[wasm_bindgen(js_name = loadDoc)]
-pub fn load(data: Uint8Array, actor: Option<String>) -> Result<Automerge, JsValue> {
-    let data = data.to_vec();
-    let mut automerge = am::Automerge::load(&data).map_err(to_js_err)?;
-    if let Some(s) = actor {
-        let actor = automerge::ActorId::from(hex::decode(s).map_err(to_js_err)?.to_vec());
-        automerge.set_actor(actor)
-    }
-    Ok(Automerge(automerge))
-}
-
-#[wasm_bindgen(js_name = encodeChange)]
-pub fn encode_change(change: JsValue) -> Result<Uint8Array, JsValue> {
-    let change: am::ExpandedChange = change.into_serde().map_err(to_js_err)?;
-    let change: Change = change.into();
-    Ok(Uint8Array::from(change.raw_bytes()))
-}
-
-#[wasm_bindgen(js_name = decodeChange)]
-pub fn decode_change(change: Uint8Array) -> Result<JsValue, JsValue> {
-    let change = Change::from_bytes(change.to_vec()).map_err(to_js_err)?;
-    let change: am::ExpandedChange = change.decode();
-    JsValue::from_serde(&change).map_err(to_js_err)
-}
-
-#[wasm_bindgen(js_name = initSyncState)]
-pub fn init_sync_state() -> SyncState {
-    SyncState(am::SyncState::new())
-}
-
-// this is needed to be compatible with the automerge-js api
-#[wasm_bindgen(js_name = importSyncState)]
-pub fn import_sync_state(state: JsValue) -> Result<SyncState, JsValue> {
-    Ok(SyncState(JS(state).try_into()?))
-}
-
-// this is needed to be compatible with the automerge-js api
-#[wasm_bindgen(js_name = exportSyncState)]
-pub fn export_sync_state(state: SyncState) -> JsValue {
-    JS::from(state.0).into()
-}
-
-#[wasm_bindgen(js_name = encodeSyncMessage)]
-pub fn encode_sync_message(message: JsValue) -> Result<Uint8Array, JsValue> {
-    let heads = js_get(&message, "heads")?.try_into()?;
-    let need = js_get(&message, "need")?.try_into()?;
-    let changes = js_get(&message, "changes")?.try_into()?;
-    let have = js_get(&message, "have")?.try_into()?;
-    Ok(Uint8Array::from(
-        am::SyncMessage {
-            heads,
-            need,
-            have,
-            changes,
-        }
-        .encode()
-        .unwrap()
-        .as_slice(),
-    ))
-}
-
-#[wasm_bindgen(js_name = decodeSyncMessage)]
-pub fn decode_sync_message(msg: Uint8Array) -> Result<JsValue, JsValue> {
-    let data = msg.to_vec();
-    let msg = am::SyncMessage::decode(&data).map_err(to_js_err)?;
-    let heads = AR::from(msg.heads.as_slice());
-    let need = AR::from(msg.need.as_slice());
-    let changes = AR::from(msg.changes.as_slice());
-    let have = AR::from(msg.have.as_slice());
-    let obj = Object::new().into();
-    js_set(&obj, "heads", heads)?;
-    js_set(&obj, "need", need)?;
-    js_set(&obj, "have", have)?;
-    js_set(&obj, "changes", changes)?;
-    Ok(obj)
-}
-
-#[wasm_bindgen(js_name = encodeSyncState)]
-pub fn encode_sync_state(state: SyncState) -> Result<Uint8Array, JsValue> {
-    let state = state.0;
-    Ok(Uint8Array::from(
-        state.encode().map_err(to_js_err)?.as_slice(),
-    ))
-}
-
-#[wasm_bindgen(js_name = decodeSyncState)]
-pub fn decode_sync_state(data: Uint8Array) -> Result<SyncState, JsValue> {
-    SyncState::decode(data)
-}
-
-#[wasm_bindgen(js_name = MAP)]
-pub struct Map {}
-
-#[wasm_bindgen(js_name = LIST)]
-pub struct List {}
-
-#[wasm_bindgen(js_name = TEXT)]
-pub struct Text {}
-
-#[wasm_bindgen(js_name = TABLE)]
-pub struct Table {}
 ```
+  import { create } from "automerge-wasm"
+
+  let doc = create()
+
+  doc.free()
+
+```
+
+While this will work in both node and in a web context
+
+```
+  import init, { create } from "automerge-wasm"
+
+  init().then(_ => {
+    let doc = create()
+    doc.free()
+  })
+
+```
+
+The examples below will assume a node context for brevity.
+
+### Automerge Scalar Types
+
+Automerge has many scalar types.  Methods like `set()` and `insert()` take an optional datatype parameter.  Normally the type can be inferred but in some cases, such as telling the difference between int, uint and a counter, it cannot.
+
+These are sets without a datatype
+
+```
+  import { create } from "automerge-wasm"
+
+  let doc = create()
+  doc.set("/", "prop1", 100) // int
+  doc.set("/", "prop2", 3.14)
+  doc.set("/", "prop3", "hello world")
+  doc.set("/", "prop4", new Date())
+  doc.set("/", "prop5", new Uint8Array([1,2,3]))
+  doc.set("/", "prop6", true)
+  doc.set("/", "prop7", null)
+  doc.free()
+```
+
+Sets with a datatype and examples of all the supported datatypes.
+
+While int vs uint vs f64 matters little in javascript, Automerge is a cross platform library where these distinctions matter.
+
+```
+  import { create } from "automerge-wasm"
+
+  let doc = create()
+  doc.set("/", "prop1", 100, "int")
+  doc.set("/", "prop2", 100, "uint")
+  doc.set("/", "prop3", 100.5, "f64")
+  doc.set("/", "prop4", 100, "counter")
+  doc.set("/", "prop5", new Date(), "timestamp")
+  doc.set("/", "prop6", "hello world", "str")
+  doc.set("/", "prop7", new Uint8Array([1,2,3]), "bytes")
+  doc.set("/", "prop8", true, "boolean")
+  doc.set("/", "prop9", null, "null")
+  doc.free()
+```
+
+### Automerge Object Types
+
+Automerge WASM supports 3 object types.  Maps, lists, and text.  Maps are key value stores where the values can be any scalar type or any object type.  Lists are numerically indexed set of data that can hold any scalar or any object type.  Text is numerically indexed sets of graphmeme clusters.
+
+```
+  import { create } from "automerge-wasm"
+
+  let doc = create()
+
+  // you can create an object by passing in the inital state - if blank pass in `{}`
+  // the return value is the Object Id
+  // these functions all return an object id
+
+  let config = doc.set_object("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
+  let token = doc.set_object("/", "tokens", {})
+
+  // lists can be made with javascript arrays
+
+  let birds = doc.set_object("/", "birds", ["bluejay", "penguin", "puffin"])
+  let bots = doc.set_object("/", "bots", [])
+
+  // text is initialized with a string
+
+  let notes = doc.set_object("/", "notes", "Hello world!")
+
+  doc.free()
+```
+
+You can access objects by passing the object id as the first parameter for a call.
+
+```
+  import { create } from "automerge-wasm"
+
+  let doc = create()
+
+  let config = doc.set_object("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
+
+  doc.set(config, "align", "right")
+```
+
+Anywhere Object Id's are being used a path can also be used.  The following two statements are equivelent:
+
+```
+  // get the id then use it
+
+  let id = doc.value("/", "config")[1]
+  doc.set(id, "align", "right")
+
+  // use a path instead
+
+  doc.set("/config", "align", "right")
+```
+
+Using the id directly is always faster (as it prevents the path to id conversion internally) so it is preferred for performance critical code.
+
+### Maps
+
+### Lists
+
+### Text
+
+### Tables
+
+Automerge's Table type is currently not implemented
+
+### Counters
+
+### Viewing Old Versions of the Document
+
+### Forking and Merging
+
+### Saving and Loading
+
+### Syncing
+
+### Glossery: Actors
+
+Some basic concepts you will need to know to better understand the api are Actors and Object Ids.
+
+Actors are ids that need to be unique to each process writing to a document.  This is normally one actor per device.  Or for a web app one actor per tab per browser would be needed.  It can be a uuid, or a public key, or a certificate, as your application demands.  All that matters is that its bytes are unique.  Actors are always expressed in this api as a hex string.
+
+Methods that create new documents will generate random actors automatically - if you wish to supply your own it is always taken as an optional argument.  This is true for the following functions.
+
+```
+  import { create, loadDoc } from "automerge-wasm"
+
+  let doc1 = create()  // random actorid
+  let doc2 = create("aabbccdd")
+  let doc3 = doc1.fork()  // random actorid
+  let doc4 = doc2.for("ccdd0011")
+  let doc5 = loadDoc(doc3.save()) // random actorid
+  let doc6 = loadDoc(doc4.save(), "00aabb11")
+
+  let actor = doc1.getActor()
+```
+
+### Glossery: Object Id's
+### Glossery: Heads

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -196,7 +196,7 @@ Text is a specialized list type intended for modifying a text document.  The pri
 
     doc.text(notes)      // returns "Hello everyone"
 
-    let obj = doc.insert_object(notes, 6, { hi: "there" })
+    let obj = doc.insertObject(notes, 6, { hi: "there" })
 
     doc.text(notes)       // returns "Hello \ufffceveryone"
     doc.value(notes, 6)   // returns ["map", obj]

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -238,7 +238,7 @@ When querying maps use the `value()` method with the object in question and the 
 
 Counters are 64 bit ints that support the increment operation.  Frequently different actors will want to increment or decrement a number and have all these coalesse into a merged value.
 
-```
+```javascript
     let doc1 = create("aaaaaa")
     doc1.put("_root", "number", 0)
     doc1.put("_root", "total", 0, "counter")
@@ -437,7 +437,7 @@ Actors are ids that need to be unique to each process writing to a document.  Th
 
 Methods that create new documents will generate random actors automatically - if you wish to supply your own it is always taken as an optional argument.  This is true for the following functions.
 
-```
+```javascript
   import { create, load } from "automerge-wasm"
 
   let doc1 = create()  // random actorid
@@ -456,7 +456,7 @@ Methods that create new documents will generate random actors automatically - if
 
 Object Ids uniquely identify an object within a document.  They are represented as strings in the format of `{counter}@{actor}`.  The root object is a special case and can be referred to as `_root`.  The counter is an ever increasing integer, starting at 1, that is always one higher than the highest counter seen in the document thus far.  Object Id's do not change when the object is modified but they do if it is overwritten with a new object.
 
-```
+```javascript
   let doc = create("aabbcc")
   let o1 = doc.putObject("_root", "o1", {})
   let o2 = doc.putObject("_root", "o2", {})
@@ -476,9 +476,10 @@ Object Ids uniquely identify an object within a document.  They are represented 
   doc.free()
 ```
 
+```
 // TODO:
 can I rename loadDoc() to load()???
 implement forkAt()
-port sync example to typescript
-what about a doc.equals()
-remove the opid from values
+port sync example to typescript - make sure its right
+remove the opid from values()
+```

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -2,6 +2,8 @@
 
 This package is a low level interface to the [automerge rust](https://github.com/automerge/automerge-rs/tree/experiment) CRDT.  The api is intended to be as "close to the metal" as possible with only a few ease of use accommodations.  This library is used as the underpinnings for the [Automerge JS wrapper](https://github.com/automerge/automerge-rs/tree/experiment/automerge-js) and can be used as is or as a basis for another higher level expression of a CRDT.
 
+All example code can be found in `test/readme.ts`
+
 ### Why CRDT?
 
 CRDT stands for Conflict Free Replicated Data Type.  It is a data structure that offers eventual consistency where multiple actors can write to the document independently and then these edits can be automatically merged together into a coherent document that, as much as possible, preserves the intent of the different writers.  This allows for novel masterless application design where different components need not have a central coordinating server when altering application state.
@@ -46,21 +48,21 @@ The examples below will assume a node context for brevity.
 
 ### Automerge Scalar Types
 
-Automerge has many scalar types.  Methods like `set()` and `insert()` take an optional data type parameter.  Normally the type can be inferred but in some cases, such as telling the difference between int, uint and a counter, it cannot.
+Automerge has many scalar types.  Methods like `put()` and `insert()` take an optional data type parameter.  Normally the type can be inferred but in some cases, such as telling the difference between int, uint and a counter, it cannot.
 
-These are sets without a data type
+These are puts without a data type
 
 ```javascript
   import { create } from "automerge-wasm"
 
   let doc = create()
-  doc.set("/", "prop1", 100)  // int
-  doc.set("/", "prop2", 3.14) // f64
-  doc.set("/", "prop3", "hello world")
-  doc.set("/", "prop4", new Date())
-  doc.set("/", "prop5", new Uint8Array([1,2,3]))
-  doc.set("/", "prop6", true)
-  doc.set("/", "prop7", null)
+  doc.put("/", "prop1", 100)  // int
+  doc.put("/", "prop2", 3.14) // f64
+  doc.put("/", "prop3", "hello world")
+  doc.put("/", "prop4", new Date())
+  doc.put("/", "prop5", new Uint8Array([1,2,3]))
+  doc.put("/", "prop6", true)
+  doc.put("/", "prop7", null)
   doc.free()
 ```
 
@@ -72,15 +74,16 @@ While int vs uint vs f64 matters little in javascript, Automerge is a cross plat
   import { create } from "automerge-wasm"
 
   let doc = create()
-  doc.set("/", "prop1", 100, "int")
-  doc.set("/", "prop2", 100, "uint")
-  doc.set("/", "prop3", 100.5, "f64")
-  doc.set("/", "prop4", 100, "counter")
-  doc.set("/", "prop5", new Date(), "timestamp")
-  doc.set("/", "prop6", "hello world", "str")
-  doc.set("/", "prop7", new Uint8Array([1,2,3]), "bytes")
-  doc.set("/", "prop8", true, "boolean")
-  doc.set("/", "prop9", null, "null")
+  doc.put("/", "prop1", 100, "int")
+  doc.put("/", "prop2", 100, "uint")
+  doc.put("/", "prop3", 100.5, "f64")
+  doc.put("/", "prop4", 100, "counter")
+  doc.put("/", "prop5", 1647531707301, "timestamp")
+  doc.put("/", "prop6", new Date(), "timestamp")
+  doc.put("/", "prop7", "hello world", "str")
+  doc.put("/", "prop8", new Uint8Array([1,2,3]), "bytes")
+  doc.put("/", "prop9", true, "boolean")
+  doc.put("/", "prop10", null, "null")
   doc.free()
 ```
 
@@ -97,17 +100,17 @@ Automerge WASM supports 3 object types.  Maps, lists, and text.  Maps are key va
   // the return value is the Object Id
   // these functions all return an object id
 
-  let config = doc.set_object("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
-  let token = doc.set_object("/", "tokens", {})
+  let config = doc.putObject("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
+  let token = doc.putObject("/", "tokens", {})
 
   // lists can be made with javascript arrays
 
-  let birds = doc.set_object("/", "birds", ["bluejay", "penguin", "puffin"])
-  let bots = doc.set_object("/", "bots", [])
+  let birds = doc.putObject("/", "birds", ["bluejay", "penguin", "puffin"])
+  let bots = doc.putObject("/", "bots", [])
 
   // text is initialized with a string
 
-  let notes = doc.set_object("/", "notes", "Hello world!")
+  let notes = doc.putObject("/", "notes", "Hello world!")
 
   doc.free()
 ```
@@ -119,22 +122,25 @@ You can access objects by passing the object id as the first parameter for a cal
 
   let doc = create()
 
-  let config = doc.set_object("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
+  let config = doc.putObject("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
 
-  doc.set(config, "align", "right")
-```
+  doc.put(config, "align", "right")
 
-Anywhere Object Ids are being used a path can also be used.  The following two statements are equivalent:
+  // Anywhere Object Ids are being used a path can also be used.
+  // The following two statements are equivalent:
 
-```javascript
   // get the id then use it
 
   let id = doc.value("/", "config")[1]
-  doc.set(id, "align", "right")
+  if (id && id[0] === 'map') {
+    doc.put(id[1], "align", "right")
+  }
 
   // use a path instead
 
-  doc.set("/config", "align", "right")
+  doc.put("/config", "align", "right")
+
+  doc.free()
 ```
 
 Using the id directly is always faster (as it prevents the path to id conversion internally) so it is preferred for performance critical code.
@@ -145,36 +151,37 @@ Maps are key/value stores.  The root object is always a map.  The keys are alway
 
 ```javascript
     let doc = create()
-    let mymap = doc.set_object("_root", "mymap", { foo: "bar"})
+    let mymap = doc.putObject("_root", "mymap", { foo: "bar"})
                               // make a new map with the foo key
 
-    doc.set(mymap, "bytes", new Uint8Array([1,2,3]))
+    doc.put(mymap, "bytes", new Uint8Array([1,2,3]))
                               // assign a byte array to key `bytes` of the mymap object
 
-    let submap = doc.set_object(mymap, "sub", {})
+    let submap = doc.putObject(mymap, "sub", {})
                               // make a new empty object and assign it to the key `sub` of mymap
 
     doc.keys(mymap)           // returns ["bytes","foo","sub"]
-    doc.materialize("_root")  // returns { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {} }
+    doc.materialize("_root")  // returns { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {}}}
     doc.free()
 ```
 
 ### Lists
 
-Lists are index addressable sets of values.  These values can be any scalar or object type.  You can manipulate lists with `insert()`, `set()`, `push()`, `splice()`, and `del()`.
+Lists are index addressable sets of values.  These values can be any scalar or object type.  You can manipulate lists with `insert()`, `put()`, `insertObject()`, `pubObject()`, `push()`, `pushObject()`, `splice()`, and `del()`.
 
 ```javascript
     let doc = create()
-    let items = doc.set_object("_root", "items", [10,"box"])
+    let items = doc.putObject("_root", "items", [10,"box"])
                                                   // init a new list with two elements
     doc.push(items, true)                         // push `true` to the end of the list
-    doc.set_object(items, 0, { hello: "world" })  // overwrite the value 10 with an object with a key and value
+    doc.putObject(items, 0, { hello: "world" })  // overwrite the value 10 with an object with a key and value
     doc.del(items, 1)                             // delete "box"
     doc.splice(items, 2, 0, ["bag", "brick"])     // splice in "bag" and "brick" at position 2
     doc.insert(items, 0, "bat")                   // insert "bat" to the beginning of the list
+    doc.insertObject(items, 1, [1,2])             // insert a list with 2 values at pos 1
 
-    doc.materialize(items)                        // returns [ "bat", { hello : "world" }, true, "bag", "brick"]
-    doc.length(items)                             // returns 5
+    doc.materialize(items)                        // returns [ "bat", [1,2], { hello : "world" }, true, "bag", "brick"]
+    doc.length(items)                             // returns 6
     doc.free()
 ```
 
@@ -184,19 +191,18 @@ Text is a specialized list type intended for modifying a text document.  The pri
 
 ```javascript
     let doc = create("aaaaaa")
-    let notes = doc.set_object("_root", "notes", "Hello world")
+    let notes = doc.putObject("_root", "notes", "Hello world")
     doc.splice(notes, 6, 5, "everyone")
 
     doc.text(notes)      // returns "Hello everyone"
 
-    let obj = doc.insert_object(text, 6, { hi: "there" });
+    let obj = doc.insert_object(notes, 6, { hi: "there" })
 
-    doc.text(text)       // returns "Hello \ufffceveryone"
-    doc.value(text, 6)   // returns ["map", obj]
+    doc.text(notes)       // returns "Hello \ufffceveryone"
+    doc.value(notes, 6)   // returns ["map", obj]
     doc.value(obj, "hi") // returns ["str", "there"]
     doc.free()
 ```
-
 
 ### Tables
 
@@ -208,59 +214,220 @@ When querying maps use the `value()` method with the object in question and the 
 
 ```javascript
     let doc1 = create("aabbcc")
-    doc1.set("_root", "key1", "val1")
-    let key2 = doc1.set_object("_root", "key2", [])
+    doc1.put("_root", "key1", "val1")
+    let key2 = doc1.putObject("_root", "key2", [])
 
     doc1.value("_root", "key1") // returns ["str", "val1"]
-    doc1.value("_root", "key1") // returns ["list", "2@aabbcc"]
+    doc1.value("_root", "key2") // returns ["list", "2@aabbcc"]
     doc1.keys("_root")          // returns ["key1", "key2"]
 
     let doc2 = doc1.fork("ffaaff")
-    
-    // set a value concurrently
-    doc1.set("_root","key3","doc1val")
-    doc2.set("_root","key3","doc2val")
+
+    // put a value concurrently
+    doc1.put("_root","key3","doc1val")
+    doc2.put("_root","key3","doc2val")
 
     doc1.merge(doc2)
 
     doc1.value("_root","key3")   // returns ["str", "doc2val"]
     doc1.values("_root","key3")  // returns [[ "str", "doc1val"], ["str", "doc2val"]]
-    doc1.free(); doc2.free() 
+    doc1.free(); doc2.free()
 ```
 
 ### Counters
 
-// TODO
+Counters are 64 bit ints that support the increment operation.  Frequently different actords will want to increment or decrement a number and have all these coalesse into a merged value.
+
+```
+    let doc1 = create("aaaaaa")
+    doc1.put("_root", "number", 0)
+    doc1.put("_root", "total", 0, "counter")
+
+    let doc2 = doc1.fork("bbbbbb")
+    doc2.put("_root", "number", 10)
+    doc2.inc("_root", "total", 11)
+
+    doc1.put("_root", "number", 20)
+    doc1.inc("_root", "total", 22)
+
+    doc1.merge(doc2)
+
+    doc1.materialize("_root")  // returns { number: 10, total: 33 }
+
+    doc1.free(); doc2.free()
+```
 
 ### Transactions
 
-// TODO
+Generally speaking you don't need to think about transaction when using automerge.  Normal edits queue up into an in progress trasnaction.  You can query the number of ops in the current transaction with `pendingOps()`.  The transaction will commit automatically on certains calls such as `save()`, `saveIncremental()`, `fork()`, `merge()`, `getHeads()`, `applyChanges()`, `generateSyncMessage()`, and `receiveSyncMessage()`.  When the transaction commits the heads of the document change.  If you want to roll back all the in progress ops you can call `doc.rollback()`.  If you want to manually commit a transaction in progress you can call`doc.commit()` with an optional commit message and timestamp.
+
+```javascript
+    let doc = create()
+
+    doc.put("_root", "key", "val1")
+
+    doc.value("_root", "key")        // returns ["str","val1"]
+    doc.pendingOps()                 // returns 1
+
+    doc.rollback()
+
+    doc.value("_root", "key")        // returns null
+    doc.pendingOps()                 // returns 0
+
+    doc.put("_root", "key", "val2")
+
+    doc.pendingOps()                 // returns 1
+
+    doc.commit("test commit 1")
+
+    doc.value("_root", "key")        // returns ["str","val2"]
+    doc.pendingOps()                 // returns 0
+
+    doc.free()
+```
 
 ### Viewing Old Versions of the Document
 
 All query functions can take an optional argument of `heads` which allow you to query a prior document state. Heads are a set of change hashes that uniquly identify a point in the document history.  The `getHeads()` method can retrieve these at any point.
 
 ```javascript
-    let doc = create() 
-    doc.set("_root", "key", "val1")
+    let doc = create()
+
+    doc.put("_root", "key", "val1")
     let heads1 = doc.getHeads()
-    doc.set("_root", "key", "val2")
+
+    doc.put("_root", "key", "val2")
     let heads2 = doc.getHeads()
-    doc.set("_root", "key", "val3")
+
+    doc.put("_root", "key", "val3")
 
     doc.value("_root","key")          // returns ["str","val3"]
     doc.value("_root","key",heads2)   // returns ["str","val2"]
     doc.value("_root","key",heads1)   // returns ["str","val1"]
     doc.value("_root","key",[])       // returns null
+
+    doc.free()
 ```
 
 This works for `value()`, `values()`, `keys()`, `length()`, `text()`, and `materialize()`
 
+Queries of old document states are not indexed internally and will be slower than normal access.  If you need a fast indexed version of a document at a previous point in time you can create one with `doc.forkAt(heads, actor?)`
+
 ### Forking and Merging
+
+You can `fork()` a document which makes an exact copy of it.  This assigns a new actor so changes made to the fork can be merged back in with the origional.  The `forkAt()` takes a heads allowing you to fork off a document from a previous point in its history.  These documents allocate new memory in WASM and need to be freed.
+
+The `merge()` command applys all changes in the argument doc into the calling doc.  Therefore if doc a has 1000 changes that doc b lacks and doc b has only 10 changes that doc a lacks, `a.merge(b)` will be much faster than `b.merge(a)`.
+
+```javascript
+    let doc1 = create()
+    doc1.put("_root", "key1", "val1")
+
+    let doc2 = doc1.fork()
+
+    doc1.put("_root", "key2", "val2")
+    doc2.put("_root", "key3", "val3")
+
+    doc1.merge(doc2)
+
+    doc1.materialize("_root")       // returns { key1: "val1", key2: "val2", key3: "val3" }
+    doc2.materialize("_root")       // returns { key1: "val1", key3: "val3" }
+
+    doc1.free(); doc2.free()
+```
+
+Note that calling `a.merge(a)` will produce an unrecoverable error from the wasm-bindgen layer which (as of this writing) there is no workaround for.
 
 ### Saving and Loading
 
+Calling `save()` converts the document to a compressed `Uint8Array()` that can be saved to durable storage.  This format uses a columnar storage format that compresses away most of the automerge metadata needed to manage the CRDT state, but does include all of the change history.
+
+If you wish to incrementally update a saved automerge doc you can call `saveIncremental()` to get a `Uint8Array()` of bytes that can be appended to the file with all the new changes(). Note that the `saveIncremental()` bytes are not as compressed the whole document save as each chunk has metadata information needed to parse it.  It may make sense to periodically perform a new `save()` to get the smallest possible file footprint.
+
+The `load()` function takes a `Uint8Array()` of bytes produced in this way and constitutes a new document.  The `loadIncremental()` method is availble if you wish to consume the result of a `saveIncremental()` with a already instanciated document.
+
+```javascript
+  import { create, load } from "automerge-wasm"
+
+  let doc1 = create()
+
+  doc1.put("_root", "key1", "value1")
+
+  let save1 = doc1.save()
+
+  let doc2 = load(save1)
+
+  doc2.materialize("_root")  // returns { key1: "value1" }
+
+  doc1.put("_root", "key2", "value2")
+
+  let saveIncremental = doc1.saveIncremental()
+
+  let save2 = doc1.save()
+
+  let save3 = new Uint8Array([... save1, ... saveIncremental])
+
+  // save2 has fewer bytes than save3 but contains the same ops
+
+  doc2.loadIncremental(saveIncremental)
+
+  let doc3 = load(save2)
+
+  let doc4 = load(save3)
+
+  doc1.materialize("_root")  // returns { key1: "value1", key2: "value2" }
+  doc2.materialize("_root")  // returns { key1: "value1", key2: "value2" }
+  doc3.materialize("_root")  // returns { key1: "value1", key2: "value2" }
+  doc4.materialize("_root")  // returns { key1: "value1", key2: "value2" }
+
+  doc1.free(); doc2.free(); doc3.free(); doc4.free()
+```
+
 ### Syncing
+
+When syncing a document the `generateSyncMessage()` and `receiveSyncMessage()` methods will produce and consume sync messages.  A sync state object will need to be managed for the duration of the connection (created by the function `initSyncState()` and can be serialized to a Uint8Array() to preserve sync state with the `encodeSyncState()` and `decodeSyncState()` functions.
+
+A very simple sync implementation might look like this.
+
+```javascript
+  import { encodeSyncState, decodeSyncState, initSyncState } from "automerge-wasm"
+
+  let states = {}
+
+  function receiveMessageFromPeer(doc, peer_id, message) {
+      let syncState = states[peer_id]
+      doc.receiveMessage(syncState, message)
+      let reply = doc.generateSyncMessage(syncState)
+      if (reply) {
+          sendMessage(peer_id, reply)
+      }
+  }
+
+  function notifyPeerAboutUpdates(doc, peer_id) {
+      let syncState = states[peer_id]
+      let message = doc.generateSyncMessage(syncState)
+      if (message) {
+          sendMessage(peer_id, message)
+      }
+  }
+
+  function onDisconnect(peer_id) {
+      let state = states[peer_id]
+      if (state) {
+        saveSyncToStorage(peer_id, encodeSyncState(state))
+      }
+      delete states[peer_id]
+  }
+
+  function onConnect(peer_id) {
+      let state = loadSyncFromStorage(peer_id)
+      if (state) {
+        states[peer_id] = decodeSyncState(state)
+      } else {
+        states[peer_id] = initSyncState()
+      }
+  }
+```
 
 ### Glossary: Actors
 
@@ -271,14 +438,14 @@ Actors are ids that need to be unique to each process writing to a document.  Th
 Methods that create new documents will generate random actors automatically - if you wish to supply your own it is always taken as an optional argument.  This is true for the following functions.
 
 ```
-  import { create, loadDoc } from "automerge-wasm"
+  import { create, load } from "automerge-wasm"
 
   let doc1 = create()  // random actorid
   let doc2 = create("aabbccdd")
   let doc3 = doc1.fork()  // random actorid
-  let doc4 = doc2.for("ccdd0011")
-  let doc5 = loadDoc(doc3.save()) // random actorid
-  let doc6 = loadDoc(doc4.save(), "00aabb11")
+  let doc4 = doc2.fork("ccdd0011")
+  let doc5 = load(doc3.save()) // random actorid
+  let doc6 = load(doc4.save(), "00aabb11")
 
   let actor = doc1.getActor()
 
@@ -291,27 +458,27 @@ Object Id's uniquly identify an object within a document.  They are represented 
 
 ```
   let doc = create("aabbcc")
-  let o1 = doc.set_object("_root", "o1", {})
-  let o2 = doc.set_object("_root", "o2", {})
-  doc.set(o1, "hello", "world")
+  let o1 = doc.putObject("_root", "o1", {})
+  let o2 = doc.putObject("_root", "o2", {})
+  doc.put(o1, "hello", "world")
 
   assert.deepEqual(doc.materialize("_root"), { "o1": { hello: "world" }, "o2": {} })
   assert.equal(o1, "1@aabbcc")
   assert.equal(o2, "2@aabbcc")
 
-  let o1v2 = doc.set_object("_root", "o1", {})
+  let o1v2 = doc.putObject("_root", "o1", {})
 
-  doc.set(o1, "a", "b")    // modifying an overwritten object - does nothing
-  doc.set(o1v2, "x", "y")  // modifying the new "o1" object
+  doc.put(o1, "a", "b")    // modifying an overwritten object - does nothing
+  doc.put(o1v2, "x", "y")  // modifying the new "o1" object
 
   assert.deepEqual(doc.materialize("_root"), { "o1": { x: "y" }, "o2": {} })
 
+  doc.free()
 ```
 
-### Glossary: Heads
-
-// FIXME
-loadDoc()
-forkAt()
-set_object() -> setObject()
-materialize(heads)
+// TODO:
+can I rename loadDoc() to load()???
+implement forkAt()
+port sync example to typescript
+what about a doc.equals()
+remove the opid from values

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -66,7 +66,7 @@ These are puts without a data type
   doc.free()
 ```
 
-Sets with a data type and examples of all the supported data types.
+Put's with a data type and examples of all the supported data types.
 
 While int vs uint vs f64 matters little in javascript, Automerge is a cross platform library where these distinctions matter.
 
@@ -131,7 +131,7 @@ You can access objects by passing the object id as the first parameter for a cal
 
   // get the id then use it
 
-  let id = doc.value("/", "config")[1]
+  let id = doc.value("/", "config")
   if (id && id[0] === 'map') {
     doc.put(id[1], "align", "right")
   }
@@ -167,7 +167,7 @@ Maps are key/value stores.  The root object is always a map.  The keys are alway
 
 ### Lists
 
-Lists are index addressable sets of values.  These values can be any scalar or object type.  You can manipulate lists with `insert()`, `put()`, `insertObject()`, `pubObject()`, `push()`, `pushObject()`, `splice()`, and `del()`.
+Lists are index addressable sets of values.  These values can be any scalar or object type.  You can manipulate lists with `insert()`, `put()`, `insertObject()`, `pubObject()`, `push()`, `pushObject()`, `splice()`, and `delete()`.
 
 ```javascript
     let doc = create()
@@ -175,7 +175,7 @@ Lists are index addressable sets of values.  These values can be any scalar or o
                                                   // init a new list with two elements
     doc.push(items, true)                         // push `true` to the end of the list
     doc.putObject(items, 0, { hello: "world" })  // overwrite the value 10 with an object with a key and value
-    doc.del(items, 1)                             // delete "box"
+    doc.delete(items, 1)                             // delete "box"
     doc.splice(items, 2, 0, ["bag", "brick"])     // splice in "bag" and "brick" at position 2
     doc.insert(items, 0, "bat")                   // insert "bat" to the beginning of the list
     doc.insertObject(items, 1, [1,2])             // insert a list with 2 values at pos 1
@@ -245,10 +245,10 @@ Counters are 64 bit ints that support the increment operation.  Frequently diffe
 
     let doc2 = doc1.fork("bbbbbb")
     doc2.put("_root", "number", 10)
-    doc2.inc("_root", "total", 11)
+    doc2.increment("_root", "total", 11)
 
     doc1.put("_root", "number", 20)
-    doc1.inc("_root", "total", 22)
+    doc1.increment("_root", "total", 22)
 
     doc1.merge(doc2)
 

--- a/automerge-wasm/README.md
+++ b/automerge-wasm/README.md
@@ -476,10 +476,3 @@ Object Ids uniquely identify an object within a document.  They are represented 
   doc.free()
 ```
 
-```
-// TODO:
-can I rename loadDoc() to load()???
-implement forkAt()
-port sync example to typescript - make sure its right
-remove the opid from values()
-```

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -112,7 +112,7 @@ export class Automerge {
   materialize(obj?: ObjID): any;
 
   // transactions
-  commit(message?: string, time?: number): Heads;
+  commit(message?: string, time?: number): Hash;
   merge(other: Automerge): Heads;
   getActorId(): Actor;
   pendingOps(): number;
@@ -142,7 +142,7 @@ export class Automerge {
 
   // memory management
   free(): void;
-  //clone(actor?: string): Automerge;
+  clone(actor?: string): Automerge;
   fork(actor?: string): Automerge;
 
   // dump internal state to console.log

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -109,7 +109,7 @@ export class Automerge {
   keys(obj: ObjID, heads?: Heads): string[];
   text(obj: ObjID, heads?: Heads): string;
   length(obj: ObjID, heads?: Heads): number;
-  materialize(obj?: ObjID): any;
+  materialize(obj?: ObjID, heas?: Heads): any;
 
   // transactions
   commit(message?: string, time?: number): Hash;

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -109,7 +109,7 @@ export class Automerge {
   keys(obj: ObjID, heads?: Heads): string[];
   text(obj: ObjID, heads?: Heads): string;
   length(obj: ObjID, heads?: Heads): number;
-  materialize(obj?: ObjID, heas?: Heads): any;
+  materialize(obj?: ObjID, heads?: Heads): any;
 
   // transactions
   commit(message?: string, time?: number): Hash;

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -142,7 +142,7 @@ export class Automerge {
 
   // memory management
   free(): void;
-  clone(actor?: string): Automerge;
+  //clone(actor?: string): Automerge;
   fork(actor?: string): Automerge;
 
   // dump internal state to console.log
@@ -160,77 +160,5 @@ export class SyncState {
   readonly sharedHeads: any;
 }
 
-export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
-
-export interface InitOutput {
-  readonly memory: WebAssembly.Memory;
-  readonly __wbg_automerge_free: (a: number) => void;
-  readonly automerge_new: (a: number, b: number, c: number) => void;
-  readonly automerge_clone: (a: number, b: number, c: number, d: number) => void;
-  readonly automerge_free: (a: number) => void;
-  readonly automerge_pendingOps: (a: number) => number;
-  readonly automerge_commit: (a: number, b: number, c: number, d: number, e: number) => number;
-  readonly automerge_rollback: (a: number) => number;
-  readonly automerge_keys: (a: number, b: number, c: number, d: number, e: number) => void;
-  readonly automerge_text: (a: number, b: number, c: number, d: number, e: number) => void;
-  readonly automerge_splice: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
-  readonly automerge_push: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
-  readonly automerge_insert: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => void;
-  readonly automerge_set: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => void;
-  readonly automerge_inc: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-  readonly automerge_value: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-  readonly automerge_values: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-  readonly automerge_length: (a: number, b: number, c: number, d: number, e: number) => void;
-  readonly automerge_del: (a: number, b: number, c: number, d: number, e: number) => void;
-  readonly automerge_save: (a: number, b: number) => void;
-  readonly automerge_saveIncremental: (a: number) => number;
-  readonly automerge_loadIncremental: (a: number, b: number, c: number) => void;
-  readonly automerge_applyChanges: (a: number, b: number, c: number) => void;
-  readonly automerge_getChanges: (a: number, b: number, c: number) => void;
-  readonly automerge_getChangesAdded: (a: number, b: number, c: number) => void;
-  readonly automerge_getHeads: (a: number) => number;
-  readonly automerge_getActorId: (a: number, b: number) => void;
-  readonly automerge_getLastLocalChange: (a: number, b: number) => void;
-  readonly automerge_dump: (a: number) => void;
-  readonly automerge_getMissingDeps: (a: number, b: number, c: number) => void;
-  readonly automerge_receiveSyncMessage: (a: number, b: number, c: number, d: number) => void;
-  readonly automerge_generateSyncMessage: (a: number, b: number, c: number) => void;
-  readonly automerge_toJS: (a: number) => number;
-  readonly create: (a: number, b: number, c: number) => void;
-  readonly loadDoc: (a: number, b: number, c: number, d: number) => void;
-  readonly encodeChange: (a: number, b: number) => void;
-  readonly decodeChange: (a: number, b: number) => void;
-  readonly initSyncState: () => number;
-  readonly importSyncState: (a: number, b: number) => void;
-  readonly exportSyncState: (a: number) => number;
-  readonly encodeSyncMessage: (a: number, b: number) => void;
-  readonly decodeSyncMessage: (a: number, b: number) => void;
-  readonly encodeSyncState: (a: number, b: number) => void;
-  readonly decodeSyncState: (a: number, b: number) => void;
-  readonly __wbg_list_free: (a: number) => void;
-  readonly __wbg_map_free: (a: number) => void;
-  readonly __wbg_text_free: (a: number) => void;
-  readonly __wbg_table_free: (a: number) => void;
-  readonly __wbg_syncstate_free: (a: number) => void;
-  readonly syncstate_sharedHeads: (a: number) => number;
-  readonly syncstate_lastSentHeads: (a: number) => number;
-  readonly syncstate_set_lastSentHeads: (a: number, b: number, c: number) => void;
-  readonly syncstate_set_sentHashes: (a: number, b: number, c: number) => void;
-  readonly syncstate_clone: (a: number) => number;
-  readonly __wbindgen_malloc: (a: number) => number;
-  readonly __wbindgen_realloc: (a: number, b: number, c: number) => number;
-  readonly __wbindgen_add_to_stack_pointer: (a: number) => number;
-  readonly __wbindgen_free: (a: number, b: number) => void;
-  readonly __wbindgen_exn_store: (a: number) => void;
-}
-
-/**
-* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
-* for everything else, calls `WebAssembly.instantiate` directly.
-*
-* @param {InitInput | Promise<InitInput>} module_or_path
-*
-* @returns {Promise<InitOutput>}
-*/
-
-export default function init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;
+//export default function init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;
+export default function init (): Promise<()>;

--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -81,7 +81,7 @@ export type Patch = {
 }
 
 export function create(actor?: Actor): Automerge;
-export function loadDoc(data: Uint8Array, actor?: Actor): Automerge;
+export function load(data: Uint8Array, actor?: Actor): Automerge;
 export function encodeChange(change: DecodedChange): Change;
 export function decodeChange(change: Change): DecodedChange;
 export function initSyncState(): SyncState;
@@ -144,6 +144,7 @@ export class Automerge {
   free(): void;
   clone(actor?: string): Automerge;
   fork(actor?: string): Automerge;
+  forkAt(heads: Heads, actor?: string): Automerge;
 
   // dump internal state to console.log
   dump(): void;

--- a/automerge-wasm/node-index.js
+++ b/automerge-wasm/node-index.js
@@ -1,5 +1,6 @@
 let wasm = require("./bindgen")
 module.exports = wasm
+module.exports.load = module.exports.loadDoc
+delete module.exports.loadDoc
 Object.defineProperty(module.exports, "__esModule", { value: true });
 module.exports.default = () => (new Promise((resolve,reject) => { resolve() }))
-

--- a/automerge-wasm/node-index.js
+++ b/automerge-wasm/node-index.js
@@ -1,0 +1,5 @@
+let wasm = require("./bindgen")
+module.exports = wasm
+Object.defineProperty(module.exports, "__esModule", { value: true });
+module.exports.default = () => (new Promise(() => {}))
+

--- a/automerge-wasm/node-index.js
+++ b/automerge-wasm/node-index.js
@@ -1,5 +1,5 @@
 let wasm = require("./bindgen")
 module.exports = wasm
 Object.defineProperty(module.exports, "__esModule", { value: true });
-module.exports.default = () => (new Promise(() => {}))
+module.exports.default = () => (new Promise((resolve,reject) => { resolve() }))
 

--- a/automerge-wasm/package.json
+++ b/automerge-wasm/package.json
@@ -6,7 +6,7 @@
   ],
   "name": "automerge-wasm",
   "description": "wasm-bindgen bindings to the automerge rust implementation",
-  "version": "0.0.24",
+  "version": "0.0.1",
   "license": "MIT",
   "files": [
     "README.md",

--- a/automerge-wasm/package.json
+++ b/automerge-wasm/package.json
@@ -6,23 +6,26 @@
   ],
   "name": "automerge-wasm",
   "description": "wasm-bindgen bindings to the automerge rust implementation",
-  "version": "0.0.1",
+  "version": "0.0.19",
   "license": "MIT",
   "files": [
     "README.md",
-    "LICENSE",
     "package.json",
-    "automerge_wasm_bg.wasm",
-    "automerge_wasm.js"
+    "index.d.ts",
+    "node/index.js",
+    "node/index_bg.wasm",
+    "web/index.js",
+    "web/index_bg.wasm"
   ],
-  "module": "./pkg/index.js",
-  "main": "./dev/index.js",
+  "types": "index.d.ts",
+  "module": "./web/index.js",
+  "main": "./node/index.js",
   "scripts": {
-    "build": "rimraf ./dev && wasm-pack build --target nodejs --dev --out-name index -d dev && cp index.d.ts dev",
-    "release": "rimraf ./dev && wasm-pack build --target nodejs --release --out-name index -d dev && cp index.d.ts dev",
-    "pkg": "rimraf ./pkg && wasm-pack build --target web --release --out-name index -d pkg && cp index.d.ts pkg && cd pkg && yarn pack && mv automerge-wasm*tgz ..",
-    "prof": "rimraf ./dev && wasm-pack build --target nodejs --profiling --out-name index -d dev",
-    "test": "yarn build && ts-mocha -p tsconfig.json --type-check --bail --full-trace test/*.ts"
+    "build": "rimraf ./node && wasm-pack build --target nodejs --dev --out-name bindgen -d node && cp node-index.js node/index.js",
+    "release-w": "rimraf ./web && wasm-pack build --target web --release --out-name index -d web",
+    "release-n": "rimraf ./node && wasm-pack build --target nodejs --release --out-name index -d node && cp node-index.js node/index.js",
+    "release": "yarn release-w && yarn release-n",
+    "test": "ts-mocha -p tsconfig.json --type-check --bail --full-trace test/*.ts"
   },
   "dependencies": {},
   "devDependencies": {

--- a/automerge-wasm/package.json
+++ b/automerge-wasm/package.json
@@ -6,24 +6,26 @@
   ],
   "name": "automerge-wasm",
   "description": "wasm-bindgen bindings to the automerge rust implementation",
-  "version": "0.0.19",
+  "version": "0.0.24",
   "license": "MIT",
   "files": [
     "README.md",
     "package.json",
     "index.d.ts",
     "node/index.js",
-    "node/index_bg.wasm",
+    "node/bindgen.js",
+    "node/bindgen_bg.wasm",
     "web/index.js",
-    "web/index_bg.wasm"
+    "web/bindgen.js",
+    "web/bindgen_bg.wasm"
   ],
   "types": "index.d.ts",
   "module": "./web/index.js",
   "main": "./node/index.js",
   "scripts": {
     "build": "rimraf ./node && wasm-pack build --target nodejs --dev --out-name bindgen -d node && cp node-index.js node/index.js",
-    "release-w": "rimraf ./web && wasm-pack build --target web --release --out-name index -d web",
-    "release-n": "rimraf ./node && wasm-pack build --target nodejs --release --out-name index -d node && cp node-index.js node/index.js",
+    "release-w": "rimraf ./web && wasm-pack build --target web --release --out-name bindgen -d web && cp web-index.js web/index.js",
+    "release-n": "rimraf ./node && wasm-pack build --target nodejs --release --out-name bindgen -d node && cp node-index.js node/index.js",
     "release": "yarn release-w && yarn release-n",
     "test": "ts-mocha -p tsconfig.json --type-check --bail --full-trace test/*.ts"
   },

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -67,6 +67,17 @@ impl Automerge {
         Ok(automerge)
     }
 
+    #[wasm_bindgen(js_name = forkAt)]
+    pub fn fork_at(&mut self, heads: JsValue, actor: Option<String>) -> Result<Automerge, JsValue> {
+        let deps: Vec<_> = JS(heads).try_into()?;
+        let mut automerge = Automerge(self.0.fork_at(&deps)?);
+        if let Some(s) = actor {
+            let actor = automerge::ActorId::from(hex::decode(s).map_err(to_js_err)?.to_vec());
+            automerge.0.set_actor(actor);
+        }
+        Ok(automerge)
+    }
+
     pub fn free(self) {}
 
     #[wasm_bindgen(js_name = pendingOps)]

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -83,9 +83,7 @@ impl Automerge {
             commit_opts.set_time(time as i64);
         }
         let hash = self.0.commit_with(commit_opts);
-        let result = Array::new();
-        result.push(&JsValue::from_str(&hex::encode(&hash.0)));
-        result.into()
+        JsValue::from_str(&hex::encode(&hash.0))
     }
 
     pub fn merge(&mut self, other: &mut Automerge) -> Result<Array, JsValue> {

--- a/automerge-wasm/test/readme.ts
+++ b/automerge-wasm/test/readme.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 //@ts-ignore
 import assert from 'assert'
 //@ts-ignore
-import init, { create, loadDoc } from '..'
+import init, { create, load } from '..'
 
 describe('Automerge', () => {
   describe('Readme Examples', () => {
@@ -11,7 +11,7 @@ describe('Automerge', () => {
       doc.free()
     })
     it('Using the Library and Creating a Document (2)', (done) => {
-      init().then(_ => {
+      init().then((_:any) => {
         let doc = create()
         doc.free()
         done()
@@ -249,7 +249,7 @@ describe('Automerge', () => {
 
       let save1 = doc1.save()
 
-      let doc2 = loadDoc(save1)
+      let doc2 = load(save1)
 
       doc2.materialize("_root")  // returns { key1: "value1" }
 
@@ -265,9 +265,9 @@ describe('Automerge', () => {
 
       doc2.loadIncremental(saveIncremental)
 
-      let doc3 = loadDoc(save2)
+      let doc3 = load(save2)
 
-      let doc4 = loadDoc(save3)
+      let doc4 = load(save3)
 
       assert.deepEqual(doc1.materialize("_root"), { key1: "value1", key2: "value2" })
       assert.deepEqual(doc2.materialize("_root"), { key1: "value1", key2: "value2" })

--- a/automerge-wasm/test/readme.ts
+++ b/automerge-wasm/test/readme.ts
@@ -1,0 +1,281 @@
+import { describe, it } from 'mocha';
+//@ts-ignore
+import assert from 'assert'
+//@ts-ignore
+import init, { create, loadDoc } from '..'
+
+describe('Automerge', () => {
+  describe('Readme Examples', () => {
+    it('Using the Library and Creating a Document (1)', () => {
+      let doc = create()
+      doc.free()
+    })
+    it('Using the Library and Creating a Document (2)', (done) => {
+      init().then(_ => {
+        let doc = create()
+        doc.free()
+        done()
+      })
+    })
+    it('Automerge Scalar Types (1)', () => {
+      let doc = create()
+      doc.put("/", "prop1", 100)  // int
+      doc.put("/", "prop2", 3.14) // f64
+      doc.put("/", "prop3", "hello world")
+      doc.put("/", "prop4", new Date(0))
+      doc.put("/", "prop5", new Uint8Array([1,2,3]))
+      doc.put("/", "prop6", true)
+      doc.put("/", "prop7", null)
+
+      assert.deepEqual(doc.materialize("/"), {
+        prop1: 100,
+        prop2: 3.14,
+        prop3: "hello world",
+        prop4: new Date(0),
+        prop5: new Uint8Array([1,2,3]),
+        prop6: true,
+        prop7: null
+      })
+
+      doc.free()
+    })
+    it('Automerge Scalar Types (2)', () => {
+      let doc = create()
+      doc.put("/", "prop1", 100, "int")
+      doc.put("/", "prop2", 100, "uint")
+      doc.put("/", "prop3", 100.5, "f64")
+      doc.put("/", "prop4", 100, "counter")
+      doc.put("/", "prop5", 1647531707301, "timestamp")
+      doc.put("/", "prop6", new Date(), "timestamp")
+      doc.put("/", "prop7", "hello world", "str")
+      doc.put("/", "prop8", new Uint8Array([1,2,3]), "bytes")
+      doc.put("/", "prop9", true, "boolean")
+      doc.put("/", "prop10", null, "null")
+      doc.free()
+    })
+    it('Automerge Object Types (1)', () => {
+      let doc = create()
+
+      // you can create an object by passing in the inital state - if blank pass in `{}`
+      // the return value is the Object Id
+      // these functions all return an object id
+
+      let config = doc.putObject("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
+      let token = doc.putObject("/", "tokens", {})
+
+      // lists can be made with javascript arrays
+
+      let birds = doc.putObject("/", "birds", ["bluejay", "penguin", "puffin"])
+      let bots = doc.putObject("/", "bots", [])
+
+      // text is initialized with a string
+
+      let notes = doc.putObject("/", "notes", "Hello world!")
+
+      doc.free()
+    })
+    it('Automerge Object Types (2)', () => {
+      let doc = create()
+
+      let config = doc.putObject("/", "config", { align: "left", archived: false, cycles: [10, 19, 21] })
+
+      doc.put(config, "align", "right")
+
+      // Anywhere Object Ids are being used a path can also be used.
+      // The following two statements are equivalent:
+
+      let id = doc.value("/", "config")
+      if (id && id[0] === 'map') {
+        doc.put(id[1], "align", "right")
+      }
+
+      doc.put("/config", "align", "right")
+
+      assert.deepEqual(doc.materialize("/"), {
+         config: { align: "right", archived: false, cycles: [ 10, 19, 21 ] }
+      })
+
+      doc.free()
+    })
+    it('Maps (1)', () => {
+      let doc = create()
+      let mymap = doc.putObject("_root", "mymap", { foo: "bar"})
+                                // make a new map with the foo key
+
+      doc.put(mymap, "bytes", new Uint8Array([1,2,3]))
+                                // assign a byte array to key `bytes` of the mymap object
+
+      let submap = doc.putObject(mymap, "sub", {})
+                                // make a new empty object and assign it to the key `sub` of mymap
+
+      assert.deepEqual(doc.keys(mymap),["bytes","foo","sub"])
+      assert.deepEqual(doc.materialize("_root"), { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {} }})
+
+      doc.free()
+    })
+    it('Lists (1)', () => {
+      let doc = create()
+      let items = doc.putObject("_root", "items", [10,"box"])
+                                                    // init a new list with two elements
+      doc.push(items, true)                         // push `true` to the end of the list
+      doc.putObject(items, 0, { hello: "world" })  // overwrite the value 10 with an object with a key and value
+      doc.delete(items, 1)                             // delete "box"
+      doc.splice(items, 2, 0, ["bag", "brick"])     // splice in "bag" and "brick" at position 2
+      doc.insert(items, 0, "bat")                   // insert "bat" to the beginning of the list
+      doc.insertObject(items, 1, [ 1, 2 ])             // insert a list with 2 values at pos 1
+
+      assert.deepEqual(doc.materialize(items),[ "bat", [ 1 ,2 ], { hello : "world" }, true, "bag", "brick" ])
+      assert.deepEqual(doc.length(items),6)
+
+      doc.free()
+    })
+    it('Text (1)', () => {
+      let doc = create("aaaaaa")
+      let notes = doc.putObject("_root", "notes", "Hello world")
+      doc.splice(notes, 6, 5, "everyone")
+
+      assert.deepEqual(doc.text(notes), "Hello everyone")
+
+      let obj = doc.insertObject(notes, 6, { hi: "there" })
+
+      assert.deepEqual(doc.text(notes), "Hello \ufffceveryone")
+      assert.deepEqual(doc.value(notes, 6), ["map", obj])
+      assert.deepEqual(doc.value(obj, "hi"), ["str", "there"])
+
+      doc.free()
+    })
+    it('Querying Data (1)', () => {
+      let doc1 = create("aabbcc")
+      doc1.put("_root", "key1", "val1")
+      let key2 = doc1.putObject("_root", "key2", [])
+
+      assert.deepEqual(doc1.value("_root", "key1"), ["str", "val1"])
+      assert.deepEqual(doc1.value("_root", "key2"), ["list", "2@aabbcc"])
+      assert.deepEqual(doc1.keys("_root"), ["key1", "key2"])
+
+      let doc2 = doc1.fork("ffaaff")
+
+      // set a value concurrently
+      doc1.put("_root","key3","doc1val")
+      doc2.put("_root","key3","doc2val")
+
+      doc1.merge(doc2)
+
+      assert.deepEqual(doc1.value("_root","key3"), ["str", "doc2val"])
+      assert.deepEqual(doc1.values("_root","key3"),[[ "str", "doc1val", "3@aabbcc"], ["str", "doc2val", "3@ffaaff"]])
+
+      doc1.free(); doc2.free()
+    })
+    it('Counters (1)', () => {
+      let doc1 = create("aaaaaa")
+      doc1.put("_root", "number", 0)
+      doc1.put("_root", "total", 0, "counter")
+
+      let doc2 = doc1.fork("bbbbbb")
+      doc2.put("_root", "number", 10)
+      doc2.increment("_root", "total", 11)
+
+      doc1.put("_root", "number", 20)
+      doc1.increment("_root", "total", 22)
+
+      doc1.merge(doc2)
+
+      assert.deepEqual(doc1.materialize("_root"), { number: 10, total: 33 })
+
+      doc1.free(); doc2.free()
+    })
+    it('Transactions (1)', () => {
+      let doc = create()
+
+      doc.put("_root", "key", "val1")
+
+      assert.deepEqual(doc.value("_root", "key"),["str","val1"])
+      assert.deepEqual(doc.pendingOps(),1)
+
+      doc.rollback()
+
+      assert.deepEqual(doc.value("_root", "key"),null)
+      assert.deepEqual(doc.pendingOps(),0)
+
+      doc.put("_root", "key", "val2")
+
+      assert.deepEqual(doc.pendingOps(),1)
+
+      doc.commit("test commit 1")
+
+      assert.deepEqual(doc.value("_root", "key"),["str","val2"])
+      assert.deepEqual(doc.pendingOps(),0)
+
+      doc.free()
+    })
+    it('Viewing Old Versions of the Document (1)', () => {
+      let doc = create()
+
+      doc.put("_root", "key", "val1")
+      let heads1 = doc.getHeads()
+
+      doc.put("_root", "key", "val2")
+      let heads2 = doc.getHeads()
+
+      doc.put("_root", "key", "val3")
+
+      assert.deepEqual(doc.value("_root","key"), ["str","val3"])
+      assert.deepEqual(doc.value("_root","key",heads2), ["str","val2"])
+      assert.deepEqual(doc.value("_root","key",heads1), ["str","val1"])
+      assert.deepEqual(doc.value("_root","key",[]), null)
+
+      doc.free()
+    })
+    it('Forking And Merging (1)', () => {
+      let doc1 = create()
+      doc1.put("_root", "key1", "val1")
+
+      let doc2 = doc1.fork()
+
+      doc1.put("_root", "key2", "val2")
+      doc2.put("_root", "key3", "val3")
+
+      doc1.merge(doc2)
+
+      assert.deepEqual(doc1.materialize("_root"), { key1: "val1", key2: "val2", key3: "val3" })
+      assert.deepEqual(doc2.materialize("_root"), { key1: "val1", key3: "val3" })
+
+      doc1.free(); doc2.free()
+    })
+    it('Saving And Loading (1)', () => {
+      let doc1 = create()
+
+      doc1.put("_root", "key1", "value1")
+
+      let save1 = doc1.save()
+
+      let doc2 = loadDoc(save1)
+
+      doc2.materialize("_root")  // returns { key1: "value1" }
+
+      doc1.put("_root", "key2", "value2")
+
+      let saveIncremental = doc1.saveIncremental()
+
+      let save2 = doc1.save()
+
+      let save3 = new Uint8Array([... save1, ... saveIncremental])
+
+      // save2 has fewer bytes than save3 but contains the same ops
+
+      doc2.loadIncremental(saveIncremental)
+
+      let doc3 = loadDoc(save2)
+
+      let doc4 = loadDoc(save3)
+
+      assert.deepEqual(doc1.materialize("_root"), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc2.materialize("_root"), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc3.materialize("_root"), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc4.materialize("_root"), { key1: "value1", key2: "value2" })
+
+      doc1.free(); doc2.free(); doc3.free(); doc4.free()
+    })
+    it.skip('Syncing (1)', () => { })
+  })
+})

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -3,9 +3,8 @@ import { describe, it } from 'mocha';
 import assert from 'assert'
 //@ts-ignore
 import { BloomFilter } from './helpers/sync'
-import { create, loadDoc, SyncState, Automerge, encodeChange, decodeChange, initSyncState, decodeSyncMessage, decodeSyncState, encodeSyncState, encodeSyncMessage } from '../dev/index'
-import { DecodedSyncMessage } from '../index';
-import { Hash } from '../dev/index';
+import init, { create, loadDoc, SyncState, Automerge, encodeChange, decodeChange, initSyncState, decodeSyncMessage, decodeSyncState, encodeSyncState, encodeSyncMessage } from '..'
+import { DecodedSyncMessage, Hash } from '..';
 
 function sync(a: Automerge, b: Automerge, aSyncState = initSyncState(), bSyncState = initSyncState()) {
   const MAX_ITER = 10
@@ -29,7 +28,11 @@ function sync(a: Automerge, b: Automerge, aSyncState = initSyncState(), bSyncSta
 
 describe('Automerge', () => {
   describe('basics', () => {
-    it('should init clone and free', () => {
+    it('default import init() should return a promise', () => {
+      assert(init() instanceof Promise)
+    })
+
+    it('should create, clone and free', () => {
       let doc1 = create()
       let doc2 = doc1.clone()
       doc1.free()

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -171,6 +171,7 @@ describe('Automerge', () => {
       doc.insert(submap, 0, "b");
       assert.deepEqual(doc.materialize(), { letters: ["b", "a" ] })
       doc.push(submap, "c");
+      let heads = doc.getHeads()
       assert.deepEqual(doc.materialize(), { letters: ["b", "a", "c" ] })
       doc.push(submap, 3, "timestamp");
       assert.deepEqual(doc.materialize(), { letters: ["b", "a", "c", new Date(3) ] })
@@ -180,6 +181,7 @@ describe('Automerge', () => {
       assert.deepEqual(doc.materialize(), { letters: ["z", "d", "e", "f", "c", new Date(3) ] })
       assert.deepEqual(doc.materialize(submap), ["z", "d", "e", "f", "c", new Date(3) ])
       assert.deepEqual(doc.length(submap),6)
+      assert.deepEqual(doc.materialize("/", heads), { letters: ["b", "a", "c" ] })
 
       doc.free()
     })

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -466,10 +466,8 @@ describe('Automerge', () => {
       A.merge(B)
       let heads2 = A.getHeads();
       A.put("/", "key5","val5");
-      let C = A.forkAt(heads1)
-      let D = A.forkAt(heads2)
-      assert.deepEqual(C.materialize("/"), A.materialize("/",heads1))
-      assert.deepEqual(D.materialize("/"), A.materialize("/",heads2))
+      assert.deepEqual(A.forkAt(heads1).materialize("/"), A.materialize("/",heads1))
+      assert.deepEqual(A.forkAt(heads2).materialize("/"), A.materialize("/",heads2))
     })
 
     it('should handle merging text conflicts then saving & loading', () => {

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -189,17 +189,17 @@ describe('Automerge', () => {
 
       doc.put("_root", "foo","bar")
       doc.put("_root", "bip","bap")
-      let heads1 = doc.commit()
+      let hash1 = doc.commit()
 
       assert.deepEqual(doc.keys("_root"),["bip","foo"])
 
       doc.delete("_root", "foo")
       doc.delete("_root", "baz")
-      let heads2 = doc.commit()
+      let hash2 = doc.commit()
 
       assert.deepEqual(doc.keys("_root"),["bip"])
-      assert.deepEqual(doc.keys("_root", heads1),["bip", "foo"])
-      assert.deepEqual(doc.keys("_root", heads2),["bip"])
+      assert.deepEqual(doc.keys("_root", [hash1]),["bip", "foo"])
+      assert.deepEqual(doc.keys("_root", [hash2]),["bip"])
       doc.free()
     })
 
@@ -232,7 +232,6 @@ describe('Automerge', () => {
       let root = "_root";
 
       let text = doc.putObject(root, "text", "");
-      if (!text) throw new Error('should not be undefined')
       doc.splice(text, 0, 0, "hello ")
       doc.splice(text, 6, 0, ["w","o","r","l","d"])
       doc.splice(text, 11, 0, ["!","?"])
@@ -294,15 +293,15 @@ describe('Automerge', () => {
       let doc = create()
       let text = doc.putObject("_root", "text", "");
       doc.splice(text, 0, 0, "hello world");
-      let heads1 = doc.commit();
+      let hash1 = doc.commit();
       doc.splice(text, 6, 0, "big bad ");
-      let heads2 = doc.commit();
+      let hash2 = doc.commit();
       assert.strictEqual(doc.text(text), "hello big bad world")
       assert.strictEqual(doc.length(text), 19)
-      assert.strictEqual(doc.text(text, heads1), "hello world")
-      assert.strictEqual(doc.length(text, heads1), 11)
-      assert.strictEqual(doc.text(text, heads2), "hello big bad world")
-      assert.strictEqual(doc.length(text, heads2), 19)
+      assert.strictEqual(doc.text(text, [ hash1 ]), "hello world")
+      assert.strictEqual(doc.length(text, [ hash1 ]), 11)
+      assert.strictEqual(doc.text(text, [ hash2 ]), "hello big bad world")
+      assert.strictEqual(doc.length(text, [ hash2 ]), 19)
       doc.free()
     })
 

--- a/automerge-wasm/tsconfig.json
+++ b/automerge-wasm/tsconfig.json
@@ -11,7 +11,7 @@
     "paths": { "dev": ["*"]},
     "rootDir": "",
     "target": "es2016",
-    "typeRoots": ["./dev/index.d.ts"]
+    "typeRoots": ["./index.d.ts"]
   },
   "exclude": ["dist/**/*"]
 }

--- a/automerge-wasm/web-index.js
+++ b/automerge-wasm/web-index.js
@@ -1,0 +1,13 @@
+export {
+  loadDoc as load,
+  create,
+  encodeChange,
+  decodeChange,
+  initSyncState,
+  encodeSyncMessage,
+  decodeSyncMessage,
+  encodeSyncState,
+  decodeSyncState,
+} from "./bindgen.js"
+import init from "./bindgen.js"
+export default init;

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "^0.10.3"
 flate2 = "^1.0.22"
 nonzero_ext = "^0.2.0"
 uuid = { version = "^0.8.2", features=["v4", "wasm-bindgen", "serde"] }
-smol_str = { version = "^0.1.22", features=["serde"] }
+smol_str = { version = "^0.1.21", features=["serde"] }
 tracing = { version = "^0.1.29", features = ["log"] }
 fxhash = "^0.2.1"
 tinyvec = { version = "^1.5.1", features = ["alloc"] }

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "^0.10.3"
 flate2 = "^1.0.22"
 nonzero_ext = "^0.2.0"
 uuid = { version = "^0.8.2", features=["v4", "wasm-bindgen", "serde"] }
-smol_str = "^0.1.21"
+smol_str = { version = "^0.1.22", features=["serde"] }
 tracing = { version = "^0.1.29", features = ["log"] }
 fxhash = "^0.2.1"
 tinyvec = { version = "^1.5.1", features = ["alloc"] }

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -73,6 +73,14 @@ impl AutoCommit {
         }
     }
 
+    pub fn fork_at(&mut self, heads: &[ChangeHash]) -> Result<Self, AutomergeError> {
+        self.ensure_transaction_closed();
+        Ok(Self {
+            doc: self.doc.fork_at(heads)?,
+            transaction: self.transaction.clone(),
+        })
+    }
+
     fn ensure_transaction_closed(&mut self) {
         if let Some(tx) = self.transaction.take() {
             tx.commit(&mut self.doc, None, None);

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -914,17 +914,17 @@ impl Automerge {
         } else {
             let n = s
                 .find('@')
-                .ok_or_else(|| AutomergeError::InvalidOpId(s.to_owned()))?;
+                .ok_or_else(|| AutomergeError::InvalidObjIdFormat(s.to_owned()))?;
             let counter = s[0..n]
                 .parse()
-                .map_err(|_| AutomergeError::InvalidOpId(s.to_owned()))?;
+                .map_err(|_| AutomergeError::InvalidObjIdFormat(s.to_owned()))?;
             let actor = ActorId::from(hex::decode(&s[(n + 1)..]).unwrap());
             let actor = self
                 .ops
                 .m
                 .actors
                 .lookup(&actor)
-                .ok_or_else(|| AutomergeError::ForeignObjId(s.to_owned()))?;
+                .ok_or_else(|| AutomergeError::InvalidObjId(s.to_owned()))?;
             Ok(ExId::Id(
                 counter,
                 self.ops.m.actors.cache[actor].clone(),

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -207,9 +207,9 @@ impl Automerge {
             if let Some(idx) = self.history_index.get(&hash) {
                 let change = &self.history[*idx];
                 for dep in &change.deps {
-                  if !seen.contains(dep) {
-                    heads.push(*dep);
-                  }
+                    if !seen.contains(dep) {
+                        heads.push(*dep);
+                    }
                 }
                 changes.push(change);
                 seen.insert(hash);

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -200,13 +200,19 @@ impl Automerge {
 
     /// Fork this document at the give heads
     pub fn fork_at(&self, heads: &[ChangeHash]) -> Result<Self, AutomergeError> {
+        let mut seen = heads.iter().cloned().collect::<HashSet<_>>();
         let mut heads = heads.to_vec();
         let mut changes = vec![];
         while let Some(hash) = heads.pop() {
             if let Some(idx) = self.history_index.get(&hash) {
                 let change = &self.history[*idx];
-                heads.extend(&change.deps);
+                for dep in &change.deps {
+                  if !seen.contains(dep) {
+                    heads.push(*dep);
+                  }
+                }
                 changes.push(change);
+                seen.insert(hash);
             } else {
                 return Err(AutomergeError::InvalidHash(hash));
             }

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -5,10 +5,10 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AutomergeError {
-    #[error("invalid opid format `{0}`")]
-    InvalidOpId(String),
-    #[error("obj id not from this document `{0}`")]
-    ForeignObjId(String),
+    #[error("invalid obj id format `{0}`")]
+    InvalidObjIdFormat(String),
+    #[error("invalid obj id `{0}`")]
+    InvalidObjId(String),
     #[error("there was an encoding problem: {0}")]
     Encoding(#[from] encoding::Error),
     #[error("there was a decoding problem: {0}")]

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -1,6 +1,6 @@
 use crate::types::{ActorId, ScalarValue};
 use crate::value::DataType;
-use crate::{decoding, encoding};
+use crate::{decoding, encoding, ChangeHash};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -21,7 +21,9 @@ pub enum AutomergeError {
     InvalidIndex(usize),
     #[error("duplicate seq {0} found for actor {1}")]
     DuplicateSeqNumber(u64, ActorId),
-    #[error("generic automerge error")]
+    #[error("invalid hash {0}")]
+    InvalidHash(ChangeHash),
+    #[error("general failure")]
     Fail,
 }
 

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.11.21",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
+    "automerge-wasm": "file:../../automerge-wasm/automerge-wasm-0.0.24.tgz",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/examples/cra/src/App.tsx
+++ b/examples/cra/src/App.tsx
@@ -5,10 +5,14 @@ import * as Automerge from "automerge-wasm"
 
 function App() {
   const [ doc, ] = useState(Automerge.create())
-  const [ edits, ] = useState(doc.set("_root", "edits", Automerge.TEXT) || "")
+  const [ edits, ] = useState(doc.putObject("_root", "edits", ""))
   const [ val, setVal ] = useState("");
   useEffect(() => {
       doc.splice(edits, 0, 0, "the quick fox jumps over the lazy dog")
+      let doc2 = Automerge.load(doc.save());
+      console.log("LOAD",Automerge.load)
+      console.log("DOC",doc.materialize("/"))
+      console.log("DOC2",doc2.materialize("/"))
       let result = doc.text(edits)
       setVal(result)
   }, [])


### PR DESCRIPTION
This is mostly a readme and packaging improvements for automerge-wasm.  There was some API cleanup as well.  Most notably the inclusion of a `fork_at()` method to allow a document to be forked at a point in time.