### PR TITLE
Don't queue or apply a change more than once

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -657,13 +657,17 @@ impl Automerge {
         dup
     }
 
+    fn history_indexed_or_queued(&self, hash: &ChangeHash) -> bool {
+        self.history_index.contains_key(hash) || self.queue.iter().any(|c| hash == &c.hash)
+    }
+
     /// Apply changes to this document.
     pub fn apply_changes(
         &mut self,
         changes: impl IntoIterator<Item = Change>,
     ) -> Result<(), AutomergeError> {
         for c in changes {
-            if !self.history_index.contains_key(&c.hash) {
+            if !self.history_indexed_or_queued(&c.hash) {
                 if self.duplicate_seq(&c) {
                     return Err(AutomergeError::DuplicateSeqNumber(
                         c.seq,


### PR DESCRIPTION
Fixes #337 

This checks that a `Change` hasn't already been queued in addition to checking that it's not in the history index.

Without this, a few bad things can happen that will corrupt a document's history:
- A change can be queued twice if it isn't causally ready twice
- A change might be applied if it's causally ready, even if the same change had been previously queued

Since the queue is looped through after applying changes, then the 2 aforementioned situation can lead to a change being applied twice, bypassing the duplicate check.