### PR TITLE
duplicate changes in the queue could corrupt internal state

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -678,7 +678,9 @@ impl Automerge {
             }
         }
         while let Some(c) = self.pop_next_causally_ready_change() {
-            self.apply_change(c);
+            if !self.history_index.contains_key(&c.hash) {
+                self.apply_change(c);
+            }
         }
         Ok(())
     }

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -831,10 +831,10 @@ fn handle_repeated_out_of_order_changes() -> Result<(), automerge::AutomergeErro
     doc1.commit();
     doc1.insert(&list, 3, "d")?;
     doc1.commit();
-    let changes = doc1.get_changes(&[]);
-    doc2.apply_changes(changes[2..].iter().cloned().cloned().collect())?;
-    doc2.apply_changes(changes[2..].iter().cloned().cloned().collect())?;
-    doc2.apply_changes(changes.iter().cloned().cloned().collect())?;
+    let changes = doc1.get_changes(&[]).into_iter().cloned().collect::<Vec<_>>();
+    doc2.apply_changes(changes[2..].iter().cloned().collect())?;
+    doc2.apply_changes(changes[2..].iter().cloned().collect())?;
+    doc2.apply_changes(changes)?;
     assert_eq!(doc1.save(), doc2.save());
     Ok(())
 }

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -831,7 +831,11 @@ fn handle_repeated_out_of_order_changes() -> Result<(), automerge::AutomergeErro
     doc1.commit();
     doc1.insert(&list, 3, "d")?;
     doc1.commit();
-    let changes = doc1.get_changes(&[]).into_iter().cloned().collect::<Vec<_>>();
+    let changes = doc1
+        .get_changes(&[])
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>();
     doc2.apply_changes(changes[2..].iter().cloned().collect())?;
     doc2.apply_changes(changes[2..].iter().cloned().collect())?;
     doc2.apply_changes(changes)?;

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -836,8 +836,8 @@ fn handle_repeated_out_of_order_changes() -> Result<(), automerge::AutomergeErro
         .into_iter()
         .cloned()
         .collect::<Vec<_>>();
-    doc2.apply_changes(changes[2..].iter().cloned().collect())?;
-    doc2.apply_changes(changes[2..].iter().cloned().collect())?;
+    doc2.apply_changes(changes[2..].to_vec())?;
+    doc2.apply_changes(changes[2..].to_vec())?;
     doc2.apply_changes(changes)?;
     assert_eq!(doc1.save(), doc2.save());
     Ok(())


### PR DESCRIPTION
If a change got out of order queued multiple times it could be applied multiple times and corrupt internal state.  Added a test to expose the problem and a fix to fix it.  Code to prevent the problem at queue push time instead of pop time could be more memory efficient but as this is an unusual edge case I figured the simple fix would be good enough for now.  