### PR TITLE
Optimise prop query

### DIFF
--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -43,3 +43,12 @@ proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
 serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features=true }
 maplit = { version = "^1.0" }
 decorum = "0.3.1"
+criterion = "0.3.5"
+
+[[bench]]
+name = "range"
+harness = false
+
+[[bench]]
+name = "map"
+harness = false

--- a/automerge/benches/map.rs
+++ b/automerge/benches/map.rs
@@ -1,0 +1,84 @@
+use automerge::{transaction::Transactable, Automerge, ScalarValue, ROOT};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn repeated_increment(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    tx.put(ROOT, "counter", ScalarValue::counter(0)).unwrap();
+    for _ in 0..n {
+        tx.increment(ROOT, "counter", 1).unwrap();
+    }
+    tx.commit();
+    doc
+}
+
+fn repeated_put(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    for i in 0..n {
+        tx.put(ROOT, "0", i).unwrap();
+    }
+    tx.commit();
+    doc
+}
+
+fn increasing_put(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    for i in 0..n {
+        tx.put(ROOT, i.to_string(), i).unwrap();
+    }
+    tx.commit();
+    doc
+}
+
+fn decreasing_put(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    for i in (0..n).rev() {
+        tx.put(ROOT, i.to_string(), i).unwrap();
+    }
+    tx.commit();
+    doc
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let small = 1_000;
+
+    c.bench_function(&format!("repeated increment {}", small), |b| {
+        b.iter(|| repeated_increment(black_box(small)))
+    });
+
+    c.bench_function(&format!("repeated put {}", small), |b| {
+        b.iter(|| repeated_put(black_box(small)))
+    });
+
+    c.bench_function(&format!("increasing put {}", small), |b| {
+        b.iter(|| increasing_put(black_box(small)))
+    });
+
+    c.bench_function(&format!("decreasing put {}", small), |b| {
+        b.iter(|| decreasing_put(black_box(small)))
+    });
+
+    let large = 10_000;
+
+    c.bench_function(&format!("repeated increment {}", large), |b| {
+        b.iter(|| repeated_increment(black_box(large)))
+    });
+
+    c.bench_function(&format!("repeated put {}", large), |b| {
+        b.iter(|| repeated_put(black_box(large)))
+    });
+
+    c.bench_function(&format!("increasing put {}", large), |b| {
+        b.iter(|| increasing_put(black_box(large)))
+    });
+
+    c.bench_function(&format!("decreasing put {}", large), |b| {
+        b.iter(|| decreasing_put(black_box(large)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/automerge/benches/map.rs
+++ b/automerge/benches/map.rs
@@ -72,6 +72,106 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
     }
     group.finish();
+
+    let mut group = c.benchmark_group("map save");
+    for size in &sizes {
+        group.throughput(criterion::Throughput::Elements(*size));
+        group.bench_with_input(BenchmarkId::new("repeated put", size), size, |b, &size| {
+            b.iter_batched(
+                || repeated_put(size),
+                |mut doc| doc.save(),
+                criterion::BatchSize::LargeInput,
+            )
+        });
+        group.bench_with_input(
+            BenchmarkId::new("repeated increment", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || repeated_increment(size),
+                    |mut doc| doc.save(),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+
+        group.throughput(criterion::Throughput::Elements(*size));
+        group.bench_with_input(
+            BenchmarkId::new("increasing put", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || increasing_put(size),
+                    |mut doc| doc.save(),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+
+        group.throughput(criterion::Throughput::Elements(*size));
+        group.bench_with_input(
+            BenchmarkId::new("decreasing put", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || decreasing_put(size),
+                    |mut doc| doc.save(),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("map load");
+    for size in &sizes {
+        group.throughput(criterion::Throughput::Elements(*size));
+        group.bench_with_input(BenchmarkId::new("repeated put", size), size, |b, &size| {
+            b.iter_batched(
+                || repeated_put(size).save(),
+                |bytes| Automerge::load(&bytes).unwrap(),
+                criterion::BatchSize::LargeInput,
+            )
+        });
+        group.bench_with_input(
+            BenchmarkId::new("repeated increment", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || repeated_increment(size).save(),
+                    |bytes| Automerge::load(&bytes).unwrap(),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+
+        group.throughput(criterion::Throughput::Elements(*size));
+        group.bench_with_input(
+            BenchmarkId::new("increasing put", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || increasing_put(size).save(),
+                    |bytes| Automerge::load(&bytes).unwrap(),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+
+        group.throughput(criterion::Throughput::Elements(*size));
+        group.bench_with_input(
+            BenchmarkId::new("decreasing put", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || decreasing_put(size).save(),
+                    |bytes| Automerge::load(&bytes).unwrap(),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+    group.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/automerge/benches/range.rs
+++ b/automerge/benches/range.rs
@@ -1,0 +1,52 @@
+use automerge::{transaction::Transactable, Automerge, ROOT};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn doc(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    for i in 0..n {
+        tx.put(ROOT, i.to_string(), i.to_string()).unwrap();
+    }
+    tx.commit();
+    doc
+}
+
+fn range(doc: &Automerge) {
+    let range = doc.values(ROOT);
+    range.for_each(drop);
+}
+
+fn range_rev(doc: &Automerge) {
+    let range = doc.values(ROOT).rev();
+    range.for_each(drop);
+}
+
+fn range_at(doc: &Automerge) {
+    let range = doc.values_at(ROOT, &doc.get_heads());
+    range.for_each(drop);
+}
+
+fn range_at_rev(doc: &Automerge) {
+    let range = doc.values_at(ROOT, &doc.get_heads()).rev();
+    range.for_each(drop);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let n = 100_000;
+    let doc = doc(n);
+    c.bench_function(&format!("range {}", n), |b| {
+        b.iter(|| range(black_box(&doc)))
+    });
+    c.bench_function(&format!("range rev {}", n), |b| {
+        b.iter(|| range_rev(black_box(&doc)))
+    });
+    c.bench_function(&format!("range_at {}", n), |b| {
+        b.iter(|| range_at(black_box(&doc)))
+    });
+    c.bench_function(&format!("range_at rev {}", n), |b| {
+        b.iter(|| range_at_rev(black_box(&doc)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -8,7 +8,7 @@ use std::{
 pub(crate) use crate::op_set::OpSetMetadata;
 use crate::{
     clock::Clock,
-    query::{self, Index, QueryResult, TreeQuery},
+    query::{self, Index, QueryResult, ReplaceArgs, TreeQuery},
 };
 use crate::{
     types::{ObjId, Op, OpId},
@@ -552,16 +552,24 @@ impl OpTreeNode {
     /// Update the operation at the given index using the provided function.
     ///
     /// This handles updating the indices after the update.
-    pub(crate) fn update<F>(&mut self, index: usize, f: F) -> (Op, &Op)
+    pub(crate) fn update<F>(&mut self, index: usize, f: F) -> ReplaceArgs
     where
         F: FnOnce(&mut Op),
     {
         if self.is_leaf() {
             let new_element = self.elements.get_mut(index).unwrap();
-            let old_element = new_element.clone();
+            let old_id = new_element.id;
+            let old_visible = new_element.visible();
             f(new_element);
-            self.index.replace(&old_element, new_element);
-            (old_element, new_element)
+            let replace_args = ReplaceArgs {
+                old_id,
+                new_id: new_element.id,
+                old_visible,
+                new_visible: new_element.visible(),
+                new_key: new_element.elemid_or_key(),
+            };
+            self.index.replace(&replace_args);
+            replace_args
         } else {
             let mut cumulative_len = 0;
             let len = self.len();
@@ -572,15 +580,23 @@ impl OpTreeNode {
                     }
                     Ordering::Equal => {
                         let new_element = self.elements.get_mut(child_index).unwrap();
-                        let old_element = new_element.clone();
+                        let old_id = new_element.id;
+                        let old_visible = new_element.visible();
                         f(new_element);
-                        self.index.replace(&old_element, new_element);
-                        return (old_element, new_element);
+                        let replace_args = ReplaceArgs {
+                            old_id,
+                            new_id: new_element.id,
+                            old_visible,
+                            new_visible: new_element.visible(),
+                            new_key: new_element.elemid_or_key(),
+                        };
+                        self.index.replace(&replace_args);
+                        return replace_args;
                     }
                     Ordering::Greater => {
-                        let (old_element, new_element) = child.update(index - cumulative_len, f);
-                        self.index.replace(&old_element, new_element);
-                        return (old_element, new_element);
+                        let replace_args = child.update(index - cumulative_len, f);
+                        self.index.replace(&replace_args);
+                        return replace_args;
                     }
                 }
             }

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -86,6 +86,8 @@ pub(crate) trait TreeQuery<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum QueryResult {
     Next,
+    /// Skip this many elements, only allowed from the root node.
+    Skip(usize),
     Descend,
     Finish,
 }

--- a/automerge/src/query/elem_id_pos.rs
+++ b/automerge/src/query/elem_id_pos.rs
@@ -1,4 +1,7 @@
-use crate::{op_tree::OpTreeNode, types::ElemId};
+use crate::{
+    op_tree::OpTreeNode,
+    types::{ElemId, Key},
+};
 
 use super::{QueryResult, TreeQuery};
 
@@ -30,7 +33,7 @@ impl ElemIdPos {
 impl<'a> TreeQuery<'a> for ElemIdPos {
     fn query_node(&mut self, child: &OpTreeNode) -> QueryResult {
         // if index has our element then we can continue
-        if child.index.has_visible(&Some(self.elemid)) {
+        if child.index.has_visible(&Key::Seq(self.elemid)) {
             // element is in this node somewhere
             QueryResult::Descend
         } else {

--- a/automerge/src/query/prop.rs
+++ b/automerge/src/query/prop.rs
@@ -30,19 +30,24 @@ impl<'a> TreeQuery<'a> for Prop<'a> {
         child: &'a OpTreeNode,
         m: &OpSetMetadata,
     ) -> QueryResult {
-        // in the root node find the first op position for the key
-        if self.start.is_none() {
+        if let Some(start) = self.start {
+            if self.pos + child.len() >= start {
+                // skip empty nodes
+                if child.index.visible_len() == 0 {
+                    self.pos += child.len();
+                    QueryResult::Next
+                } else {
+                    QueryResult::Descend
+                }
+            } else {
+                self.pos += child.len();
+                QueryResult::Next
+            }
+        } else {
+            // in the root node find the first op position for the key
             let start = binary_search_by(child, |op| m.key_cmp(&op.key, &self.key));
             self.start = Some(start);
             QueryResult::Descend
-        } else {
-            // skip empty nodes
-            if child.index.visible_len() == 0 {
-                self.pos += child.len();
-                QueryResult::Next
-            } else {
-                QueryResult::Descend
-            }
         }
     }
 

--- a/automerge/src/query/prop.rs
+++ b/automerge/src/query/prop.rs
@@ -34,8 +34,16 @@ impl<'a> TreeQuery<'a> for Prop<'a> {
         if self.start.is_none() {
             let start = binary_search_by(child, |op| m.key_cmp(&op.key, &self.key));
             self.start = Some(start);
-        };
-        QueryResult::Descend
+            QueryResult::Descend
+        } else {
+            // skip empty nodes
+            if child.index.visible_len() == 0 {
+                self.pos += child.len();
+                QueryResult::Next
+            } else {
+                QueryResult::Descend
+            }
+        }
     }
 
     fn query_element(&mut self, op: &'a Op) -> QueryResult {

--- a/automerge/src/query/prop.rs
+++ b/automerge/src/query/prop.rs
@@ -47,16 +47,12 @@ impl<'a> TreeQuery<'a> for Prop<'a> {
             // in the root node find the first op position for the key
             let start = binary_search_by(child, |op| m.key_cmp(&op.key, &self.key));
             self.start = Some(start);
-            QueryResult::Descend
+            self.pos = start;
+            QueryResult::Skip(start)
         }
     }
 
     fn query_element(&mut self, op: &'a Op) -> QueryResult {
-        // skip to our start
-        if self.pos < self.start.unwrap() {
-            self.pos += 1;
-            return QueryResult::Next;
-        }
         // don't bother looking at things past our key
         if op.key != self.key {
             return QueryResult::Finish;


### PR DESCRIPTION
Results from critcmp using the new benchmarks:
```
group                       main                                    opt-prop
-----                       ----                                    --------
decreasing put 1000         1.00  1267.9±80.15µs        ? ?/sec     1.13  1438.7±39.22µs        ? ?/sec
decreasing put 10000        1.00     16.0±1.14ms        ? ?/sec     1.24     19.9±1.24ms        ? ?/sec
increasing put 1000         1.00  1460.2±103.95µs        ? ?/sec    1.20  1750.3±16.75µs        ? ?/sec
increasing put 10000        1.00     19.6±1.08ms        ? ?/sec     1.28     25.1±1.18ms        ? ?/sec
repeated increment 1000     9.17     11.7±1.14ms        ? ?/sec     1.00  1277.1±14.38µs        ? ?/sec
repeated increment 10000    98.99 1708.5±55.31ms        ? ?/sec     1.00     17.3±0.56ms        ? ?/sec
repeated put 1000           7.30     11.7±1.03ms        ? ?/sec     1.00  1605.7±43.10µs        ? ?/sec
repeated put 10000          79.08 1655.9±11.38ms        ? ?/sec     1.00     20.9±0.53ms        ? ?/sec
```

When there is a unique op for the key the old version is faster (currently, I have ideas to improve it later). But, when there are multiple updates to a key (`repeated *`) there is a massive speedup, basically by skipping non-visible ops and tracking visibility in the index, even for maps.

Fixes #349 