### PR TITLE
Add a port of Rust's quickstart to the C API

### DIFF
--- a/automerge-c/CMakeLists.txt
+++ b/automerge-c/CMakeLists.txt
@@ -96,6 +96,8 @@ if(BUILD_TESTING)
     enable_testing()
 endif()
 
+add_subdirectory(examples EXCLUDE_FROM_ALL)
+
 # Generate and install .cmake files
 set(PROJECT_CONFIG_NAME "${PROJECT_NAME}-config")
 

--- a/automerge-c/cbindgen.toml
+++ b/automerge-c/cbindgen.toml
@@ -25,7 +25,7 @@ language = "C"
 line_length = 140
 no_includes = true
 style = "both"
-sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
+sys_includes = ["stdbool.h", "stddef.h", "stdint.h", "time.h"]
 usize_is_size_t = true
 
 [enum]

--- a/automerge-c/examples/CMakeLists.txt
+++ b/automerge-c/examples/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+add_executable(
+    example_quickstart
+        quickstart.c
+)
+
+set_target_properties(example_quickstart PROPERTIES LINKER_LANGUAGE C)
+
+# \note An imported library's INTERFACE_INCLUDE_DIRECTORIES property can't
+#       contain a non-existent path so its build-time include directory
+#       must be specified for all of its dependent targets instead.
+target_include_directories(
+    example_quickstart
+    PRIVATE "$<BUILD_INTERFACE:${CARGO_TARGET_DIR}>"
+)
+
+target_link_libraries(example_quickstart PRIVATE ${LIBRARY_NAME})
+
+add_dependencies(example_quickstart ${LIBRARY_NAME}_artifacts)
+
+if(BUILD_SHARED_LIBS AND WIN32)
+    add_custom_command(
+        TARGET example_quickstart
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${CARGO_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_${CMAKE_BUILD_TYPE}_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
+                ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Copying the DLL built by Cargo into the examples directory..."
+        VERBATIM
+    )
+endif()
+
+add_custom_command(
+    TARGET example_quickstart
+    POST_BUILD
+    COMMAND
+        example_quickstart
+    COMMENT
+        "Running the example quickstart..."
+    VERBATIM
+)

--- a/automerge-c/examples/README.md
+++ b/automerge-c/examples/README.md
@@ -1,0 +1,9 @@
+# Automerge C examples
+
+## Quickstart
+
+```shell
+cmake -E make_directory automerge-c/build
+cmake -S automerge-c -B automerge-c/build
+cmake --build automerge-c/build --target example_quickstart
+```

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -56,8 +56,8 @@ int main(int argc, char** argv) {
     value = test(save_result, AM_VALUE_BYTES);
     AMbyteSpan binary = value.bytes;
     doc2 = AMalloc();
-    AMresult* const load_result = AMload(doc2, binary.src, binary.count);
-    AMfreeResult(load_result);
+    result = AMload(doc2, binary.src, binary.count);
+    AMfreeResult(result);
     AMfreeResult(save_result);
 
     result = AMmapPutBool(doc1, card1, "done", true);

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -52,11 +52,11 @@ int main(int argc, char** argv) {
     AMfreeResult(result);
     AMfreeDoc(doc2);
 
-    AMresult* save_result = AMsave(doc1);
-    AMvalue save_value = test(save_result, AM_VALUE_BYTES);
-    AMbyteSpan binary = save_value.bytes;
+    AMresult* const save_result = AMsave(doc1);
+    value = test(save_result, AM_VALUE_BYTES);
+    AMbyteSpan binary = value.bytes;
     doc2 = AMalloc();
-    AMresult* load_result = AMload(doc2, binary.src, binary.count);
+    AMresult* const load_result = AMload(doc2, binary.src, binary.count);
     AMfreeResult(load_result);
     AMfreeResult(save_result);
 

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <automerge.h>
+
+AMvalue test(AMresult* result, AMvalueVariant const value_tag) {
+    if (result == NULL) {
+        fprintf(stderr, "Invalid AMresult struct.");
+        exit(-1);
+    }
+    AMstatus const status = AMresultStatus(result);
+    if (status != AM_STATUS_OK) {
+        fprintf(stderr, "Unexpected AMstatus enum tag %d.", status);
+        exit(-2);
+    }
+    AMvalue const value = AMresultValue(result, 0);
+    if (value.tag != value_tag) {
+        fprintf(stderr, "Unexpected AMvalueVariant enum tag %d.", value.tag);
+        exit(-3);
+    }
+    return value;
+}
+
+/*
+ *  Based on https://automerge.github.io/docs/quickstart
+ */
+int main(int argc, char** argv) {
+    AMdoc* const doc1 = AMalloc();
+    AMresult* const cards_result = AMmapPutObject(doc1, AM_ROOT, "cards", AM_OBJ_TYPE_LIST);
+    AMvalue value = test(cards_result, AM_VALUE_OBJ_ID);
+    AMobjId const* const cards = value.obj_id;
+    AMresult* const card1_result = AMlistPutObject(doc1, cards, 0, true, AM_OBJ_TYPE_MAP);
+    value = test(card1_result, AM_VALUE_OBJ_ID);
+    AMobjId const* const card1 = value.obj_id;
+    AMresult* result = AMmapPutStr(doc1, card1, "title", "Rewrite everything in Clojure");
+    AMfreeResult(result);
+    result = AMmapPutBool(doc1, card1, "done", false);
+    AMfreeResult(result);
+    AMresult* const card2_result = AMlistPutObject(doc1, cards, 0, true, AM_OBJ_TYPE_MAP);
+    value = test(card2_result, AM_VALUE_OBJ_ID);
+    AMobjId const* const card2 = value.obj_id;
+    result = AMmapPutStr(doc1, card2, "title", "Rewrite everything in Haskell");
+    AMfreeResult(result);
+    result = AMmapPutBool(doc1, card2, "done", false);
+    AMfreeResult(result);
+    AMfreeResult(card2_result);
+    result = AMcommit(doc1, "Add card", NULL);
+    AMfreeResult(result);
+
+    AMdoc* doc2 = AMalloc();
+    result = AMmerge(doc2, doc1);
+    AMfreeResult(result);
+    AMfreeDoc(doc2);
+
+    AMresult* save_result = AMsave(doc1);
+    AMvalue save_value = test(save_result, AM_VALUE_BYTES);
+    AMbyteSpan binary = save_value.bytes;
+    doc2 = AMalloc();
+    AMresult* load_result = AMload(doc2, binary.src, binary.count);
+    AMfreeResult(load_result);
+    AMfreeResult(save_result);
+
+    result = AMmapPutBool(doc1, card1, "done", true);
+    AMfreeResult(result);
+    AMcommit(doc1, "Mark card as done", NULL);
+    AMfreeResult(card1_result);
+
+    result = AMlistDelete(doc2, cards, 0);
+    AMfreeResult(result);
+    AMcommit(doc2, "Delete card", NULL);
+
+    result = AMmerge(doc1, doc2);
+    AMfreeResult(result);
+    AMfreeDoc(doc2);
+
+    result = AMgetChanges(doc1, NULL);
+    value = test(result, AM_VALUE_CHANGES);
+    AMchange const* change = NULL;
+    while (value.changes.ptr && (change = AMnextChange(&value.changes, 1))) {
+        size_t const size = AMobjSizeAt(doc1, cards, change);
+        printf("%s %ld\n", AMgetMessage(change), size);
+    }
+    AMfreeResult(result);
+    AMfreeResult(cards_result);
+    AMfreeDoc(doc1);
+}

--- a/automerge-c/src/CMakeLists.txt
+++ b/automerge-c/src/CMakeLists.txt
@@ -50,9 +50,11 @@ add_custom_command(
     MAIN_DEPENDENCY
         lib.rs
     DEPENDS
+        byte_span.rs
+        change_hashes.rs
+        changes.rs
         doc.rs
         result.rs
-        utils.rs
         ${CMAKE_SOURCE_DIR}/build.rs
         ${CMAKE_SOURCE_DIR}/Cargo.toml
         ${CMAKE_SOURCE_DIR}/cbindgen.toml

--- a/automerge-c/src/byte_span.rs
+++ b/automerge-c/src/byte_span.rs
@@ -1,0 +1,61 @@
+use automerge as am;
+
+use crate::AMchange;
+
+/// \struct AMbyteSpan
+/// \brief A contiguous sequence of bytes.
+///
+#[repr(C)]
+pub struct AMbyteSpan {
+    /// A pointer to an array of bytes.
+    /// \warning \p src is only valid until the `AMfreeResult()` function is called
+    ///          on the `AMresult` struct hosting the array of bytes to which
+    ///          it points.
+    src: *const u8,
+    /// The number of bytes in the array.
+    count: usize,
+}
+
+impl Default for AMbyteSpan {
+    fn default() -> Self {
+        Self {
+            src: std::ptr::null(),
+            count: 0,
+        }
+    }
+}
+
+impl From<&AMchange> for AMbyteSpan {
+    fn from(change: &AMchange) -> Self {
+        let change_hash = &(change.as_ref()).hash;
+        change_hash.into()
+    }
+}
+
+impl From<&mut am::ActorId> for AMbyteSpan {
+    fn from(actor: &mut am::ActorId) -> Self {
+        let slice = actor.to_bytes();
+        Self {
+            src: slice.as_ptr(),
+            count: slice.len(),
+        }
+    }
+}
+
+impl From<&am::ChangeHash> for AMbyteSpan {
+    fn from(change_hash: &am::ChangeHash) -> Self {
+        Self {
+            src: change_hash.0.as_ptr(),
+            count: change_hash.0.len(),
+        }
+    }
+}
+
+impl From<&Vec<u8>> for AMbyteSpan {
+    fn from(v: &Vec<u8>) -> Self {
+        Self {
+            src: (*v).as_ptr(),
+            count: (*v).len(),
+        }
+    }
+}

--- a/automerge-c/src/change_hashes.rs
+++ b/automerge-c/src/change_hashes.rs
@@ -1,0 +1,159 @@
+use automerge as am;
+use std::ffi::c_void;
+
+use crate::AMbyteSpan;
+
+/// \struct AMchangeHashes
+/// \brief A bidirectional iterator over a sequence of `AMbyteSpan` structs.
+#[repr(C)]
+pub struct AMchangeHashes {
+    len: usize,
+    offset: isize,
+    ptr: *const c_void,
+}
+
+impl AsRef<[am::ChangeHash]> for AMchangeHashes {
+    fn as_ref(&self) -> &[am::ChangeHash] {
+        unsafe { std::slice::from_raw_parts(self.ptr as *const am::ChangeHash, self.len) }
+    }
+}
+
+impl AMchangeHashes {
+    pub fn new(change_hashes: &[am::ChangeHash]) -> Self {
+        Self {
+            len: change_hashes.len(),
+            offset: 0,
+            ptr: change_hashes.as_ptr() as *const c_void,
+        }
+    }
+
+    pub fn advance(&mut self, n: isize) {
+        let len = self.len as isize;
+        if n != 0 && self.offset >= -len && self.offset < len {
+            // It's being advanced and it's hasn't stopped.
+            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
+        };
+    }
+
+    pub fn next(&mut self, n: isize) -> Option<&am::ChangeHash> {
+        let len = self.len as isize;
+        if self.offset < -len || self.offset == len {
+            // It's stopped.
+            None
+        } else {
+            let slice =
+                unsafe { std::slice::from_raw_parts(self.ptr as *const am::ChangeHash, self.len) };
+            let index = (self.offset + if self.offset < 0 { len } else { 0 }) as usize;
+            let element = Some(&slice[index]);
+            self.advance(n);
+            element
+        }
+    }
+
+    pub fn prev(&mut self, n: isize) -> Option<&am::ChangeHash> {
+        self.advance(n);
+        let len = self.len as isize;
+        if self.offset < -len || self.offset == len {
+            // It's stopped.
+            None
+        } else {
+            let slice =
+                unsafe { std::slice::from_raw_parts(self.ptr as *const am::ChangeHash, self.len) };
+            let index = (self.offset + if self.offset < 0 { len } else { 0 }) as usize;
+            Some(&slice[index])
+        }
+    }
+}
+
+/// \memberof AMchangeHashes
+/// \brief Advances/rewinds an `AMchangeHashes` struct by at most \p |n|
+/// positions.
+///
+/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
+/// number of positions to advance/rewind.
+/// \pre \p change_hashes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// change_hashes must be a pointer to a valid AMchangeHashes
+#[no_mangle]
+pub unsafe extern "C" fn AMadvanceChangeHashes(change_hashes: *mut AMchangeHashes, n: isize) {
+    if let Some(change_hashes) = change_hashes.as_mut() {
+        change_hashes.advance(n);
+    };
+}
+
+/// \memberof AMchangeHashes
+/// \brief Gets the size of an `AMchangeHashes` struct.
+///
+/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \return The count of values in \p change_hashes.
+/// \pre \p change_hashes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// change_hashes must be a pointer to a valid AMchangeHashes
+#[no_mangle]
+pub unsafe extern "C" fn AMchangeHashesSize(change_hashes: *const AMchangeHashes) -> usize {
+    if let Some(change_hashes) = change_hashes.as_ref() {
+        change_hashes.len
+    } else {
+        0
+    }
+}
+
+/// \memberof AMchangeHashes
+/// \brief Gets the `AMbyteSpan` struct at the current position of an
+/// `AMchangeHashes`struct and then advances/rewinds it by at most \p |n|
+/// positions.
+///
+/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
+/// number of positions to advance/rewind.
+/// \return An `AMbyteSpan` struct that's invalid when \p change_hashes was
+/// previously advanced/rewound past its forward/backward limit.
+/// \pre \p change_hashes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// change_hashes must be a pointer to a valid AMchangeHashes
+#[no_mangle]
+pub unsafe extern "C" fn AMnextChangeHash(
+    change_hashes: *mut AMchangeHashes,
+    n: isize,
+) -> AMbyteSpan {
+    if let Some(change_hashes) = change_hashes.as_mut() {
+        if let Some(change_hash) = change_hashes.next(n) {
+            return change_hash.into();
+        }
+    }
+    AMbyteSpan::default()
+}
+
+/// \memberof AMchangeHashes
+/// \brief Advances/rewinds an `AMchangeHashes` struct by at most \p |n|
+/// positions and then gets the `AMbyteSpan` struct at its current position.
+///
+/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
+/// number of positions to advance/rewind.
+/// \return An `AMbyteSpan` struct that's invalid when \p change_hashes is
+/// presently advanced/rewound past its forward/backward limit.
+/// \pre \p change_hashes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// change_hashes must be a pointer to a valid AMchangeHashes
+#[no_mangle]
+pub unsafe extern "C" fn AMprevChangeHash(
+    change_hashes: *mut AMchangeHashes,
+    n: isize,
+) -> AMbyteSpan {
+    if let Some(change_hashes) = change_hashes.as_mut() {
+        if let Some(change_hash) = change_hashes.prev(n) {
+            return change_hash.into();
+        }
+    }
+    AMbyteSpan::default()
+}

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -1,0 +1,181 @@
+use automerge as am;
+use std::ffi::{c_void, CString};
+
+/// \struct AMchange
+/// \brief A group of operations performed by an actor.
+pub struct AMchange {
+    body: am::Change,
+    c_message: Option<CString>,
+}
+
+impl AMchange {
+    pub fn new(change: am::Change) -> Self {
+        let c_message = match change.message() {
+            Some(c_message) => CString::new(c_message).ok(),
+            None => None,
+        };
+        Self {
+            body: change,
+            c_message,
+        }
+    }
+
+    pub fn c_message(&self) -> Option<&CString> {
+        self.c_message.as_ref()
+    }
+}
+
+impl AsRef<am::Change> for AMchange {
+    fn as_ref(&self) -> &am::Change {
+        &self.body
+    }
+}
+
+/// \struct AMchanges
+/// \brief A bidirectional iterator over a sequence of `AMchange` structs.
+#[repr(C)]
+pub struct AMchanges {
+    len: usize,
+    offset: isize,
+    ptr: *const c_void,
+}
+
+impl AsRef<[AMchange]> for AMchanges {
+    fn as_ref(&self) -> &[AMchange] {
+        unsafe { std::slice::from_raw_parts(self.ptr as *const AMchange, self.len) }
+    }
+}
+
+impl AMchanges {
+    pub fn new(changes: &[AMchange]) -> Self {
+        Self {
+            len: changes.len(),
+            offset: 0,
+            ptr: changes.as_ptr() as *const c_void,
+        }
+    }
+
+    pub fn advance(&mut self, n: isize) {
+        let len = self.len as isize;
+        if n != 0 && self.offset >= -len && self.offset < len {
+            // It's being advanced and it hasn't stopped.
+            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
+        };
+    }
+
+    pub fn next(&mut self, n: isize) -> Option<&AMchange> {
+        let len = self.len as isize;
+        if self.offset < -len || self.offset == len {
+            // It's stopped.
+            None
+        } else {
+            let slice =
+                unsafe { std::slice::from_raw_parts(self.ptr as *const AMchange, self.len) };
+            let index = (self.offset + if self.offset < 0 { len } else { 0 }) as usize;
+            let element = Some(&slice[index]);
+            self.advance(n);
+            element
+        }
+    }
+
+    pub fn prev(&mut self, n: isize) -> Option<&AMchange> {
+        self.advance(n);
+        let len = self.len as isize;
+        if self.offset < -len || self.offset == len {
+            // It's stopped.
+            None
+        } else {
+            let slice =
+                unsafe { std::slice::from_raw_parts(self.ptr as *const AMchange, self.len) };
+            let index = (self.offset + if self.offset < 0 { len } else { 0 }) as usize;
+            Some(&slice[index])
+        }
+    }
+}
+
+/// \memberof AMchanges
+/// \brief Advances/rewinds an `AMchanges` struct by at most \p |n|
+/// positions.
+///
+/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
+/// number of positions to advance/rewind.
+/// \pre \p changes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// changes must be a pointer to a valid AMchanges
+#[no_mangle]
+pub unsafe extern "C" fn AMadvanceChanges(changes: *mut AMchanges, n: isize) {
+    if let Some(changes) = changes.as_mut() {
+        changes.advance(n);
+    };
+}
+
+/// \memberof AMchanges
+/// \brief Gets the size of an `AMchanges` struct.
+///
+/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \return The count of values in \p changes.
+/// \pre \p changes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// changes must be a pointer to a valid AMchanges
+#[no_mangle]
+pub unsafe extern "C" fn AMchangesSize(changes: *const AMchanges) -> usize {
+    if let Some(changes) = changes.as_ref() {
+        changes.len
+    } else {
+        0
+    }
+}
+
+/// \memberof AMchanges
+/// \brief Gets the `AMchange` struct at the current position of an
+/// `AMchanges`struct and then advances/rewinds it by at most \p |n|
+/// positions.
+///
+/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
+/// number of positions to advance/rewind.
+/// \return A pointer to an `AMchange` struct that's invalid when \p changes was
+/// previously advanced/rewound past its forward/backward limit.
+/// \pre \p changes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// changes must be a pointer to a valid AMchanges
+#[no_mangle]
+pub unsafe extern "C" fn AMnextChange(changes: *mut AMchanges, n: isize) -> *const AMchange {
+    if let Some(changes) = changes.as_mut() {
+        if let Some(change) = changes.next(n) {
+            return change;
+        }
+    }
+    std::ptr::null()
+}
+
+/// \memberof AMchanges
+/// \brief Advances/rewinds an `AMchanges` struct by at most \p |n|
+/// positions and then gets the `AMchange` struct at its current position.
+///
+/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
+/// number of positions to advance/rewind.
+/// \return A pointer to an `AMchange` struct that's invalid when \p changes is
+/// presently advanced/rewound past its forward/backward limit.
+/// \pre \p changes must be a valid address.
+/// \internal
+///
+/// #Safety
+/// changes must be a pointer to a valid AMchanges
+#[no_mangle]
+pub unsafe extern "C" fn AMprevChange(changes: *mut AMchanges, n: isize) -> *const AMchange {
+    if let Some(changes) = changes.as_mut() {
+        if let Some(change) = changes.prev(n) {
+            return change;
+        }
+    }
+    std::ptr::null()
+}

--- a/automerge-c/src/doc.rs
+++ b/automerge-c/src/doc.rs
@@ -1,66 +1,14 @@
 use automerge as am;
-use std::collections::BTreeSet;
 use std::ops::{Deref, DerefMut};
-
-use crate::result::AMobjId;
-use automerge::transaction::Transactable;
 
 /// \struct AMdoc
 /// \brief A JSON-like CRDT.
 #[derive(Clone)]
-pub struct AMdoc {
-    body: am::AutoCommit,
-    obj_ids: BTreeSet<AMobjId>,
-}
+pub struct AMdoc(am::AutoCommit);
 
 impl AMdoc {
     pub fn new(body: am::AutoCommit) -> Self {
-        Self {
-            body,
-            obj_ids: BTreeSet::new(),
-        }
-    }
-
-    pub fn insert_object(
-        &mut self,
-        obj: &am::ObjId,
-        index: usize,
-        value: am::ObjType,
-    ) -> Result<&AMobjId, am::AutomergeError> {
-        match self.body.insert_object(obj, index, value) {
-            Ok(ex_id) => {
-                let obj_id = AMobjId::new(ex_id);
-                self.obj_ids.insert(obj_id.clone());
-                match self.obj_ids.get(&obj_id) {
-                    Some(obj_id) => Ok(obj_id),
-                    None => Err(am::AutomergeError::Fail),
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub fn put_object<O: AsRef<am::ObjId>, P: Into<am::Prop>>(
-        &mut self,
-        obj: O,
-        prop: P,
-        value: am::ObjType,
-    ) -> Result<&AMobjId, am::AutomergeError> {
-        match self.body.put_object(obj, prop, value) {
-            Ok(ex_id) => {
-                let obj_id = AMobjId::new(ex_id);
-                self.obj_ids.insert(obj_id.clone());
-                match self.obj_ids.get(&obj_id) {
-                    Some(obj_id) => Ok(obj_id),
-                    None => Err(am::AutomergeError::Fail),
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub fn drop_obj_id(&mut self, obj_id: &AMobjId) -> bool {
-        self.obj_ids.remove(obj_id)
+        Self(body)
     }
 }
 
@@ -68,13 +16,13 @@ impl Deref for AMdoc {
     type Target = am::AutoCommit;
 
     fn deref(&self) -> &Self::Target {
-        &self.body
+        &self.0
     }
 }
 
 impl DerefMut for AMdoc {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.body
+        &mut self.0
     }
 }
 

--- a/automerge-c/src/utils.rs
+++ b/automerge-c/src/utils.rs
@@ -1,7 +1,0 @@
-use crate::AMresult;
-
-impl<'a> From<AMresult<'a>> for *mut AMresult<'a> {
-    fn from(b: AMresult<'a>) -> Self {
-        Box::into_raw(Box::new(b))
-    }
-}

--- a/automerge-c/test/amdoc_property_tests.c
+++ b/automerge-c/test/amdoc_property_tests.c
@@ -60,7 +60,7 @@ static void test_AMputActor(void **state) {
     }
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);
+    assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfreeResult(res);
     res = AMgetActor(group_state->doc);
     if (AMresultStatus(res) != AM_STATUS_OK) {
@@ -86,7 +86,7 @@ static void test_AMputActorHex(void **state) {
     }
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);
+    assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfreeResult(res);
     res = AMgetActorHex(group_state->doc);
     if (AMresultStatus(res) != AM_STATUS_OK) {

--- a/automerge-c/test/amlistput_tests.c
+++ b/automerge-c/test/amlistput_tests.c
@@ -26,7 +26,7 @@ static void test_AMlistPut ## suffix ## _ ## mode(void **state) {             \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);                            \
+    assert_int_equal(value.tag, AM_VALUE_VOID);                            \
     AMfreeResult(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
@@ -59,7 +59,7 @@ static void test_AMlistPutBytes_ ## mode(void **state) {                      \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);                            \
+    assert_int_equal(value.tag, AM_VALUE_VOID);                            \
     AMfreeResult(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
@@ -85,7 +85,7 @@ static void test_AMlistPutNull_ ## mode(void **state) {                       \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);                            \
+    assert_int_equal(value.tag, AM_VALUE_VOID);                            \
     AMfreeResult(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
@@ -115,15 +115,9 @@ static void test_AMlistPutObject_ ## label ## _ ## mode(void **state) {       \
     assert_int_equal(AMresultSize(res), 1);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
-    /**                                                                       \
-     * \note The `AMresult` struct can be deallocated immediately when its    \
-     *       value is a pointer to an opaque struct because its lifetime      \
-     *       is tied to the `AMdoc` struct instead.                           \
-     */                                                                       \
-    AMfreeResult(res);                                                        \
     assert_non_null(value.obj_id);                                            \
     assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
-    AMfreeObjId(group_state->doc, value.obj_id);                              \
+    AMfreeResult(res);                                                        \
 }
 
 #define test_AMlistPutStr(mode) test_AMlistPutStr ## _ ## mode
@@ -145,7 +139,7 @@ static void test_AMlistPutStr_ ## mode(void **state) {                        \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);                            \
+    assert_int_equal(value.tag, AM_VALUE_VOID);                            \
     AMfreeResult(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
@@ -158,6 +152,10 @@ static void test_AMlistPutStr_ ## mode(void **state) {                        \
     assert_memory_equal(value.str, str_value, STR_LEN + 1);                   \
     AMfreeResult(res);                                                        \
 }
+
+static_void_test_AMlistPut(Bool, insert, boolean, true)
+
+static_void_test_AMlistPut(Bool, update, boolean, true)
 
 static uint8_t const BYTES_VALUE[] = {INT8_MIN, INT8_MAX / 2, INT8_MAX};
 
@@ -207,6 +205,8 @@ static_void_test_AMlistPut(Uint, update, uint, UINT64_MAX)
 
 int run_AMlistPut_tests(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_AMlistPut(Bool, insert)),
+        cmocka_unit_test(test_AMlistPut(Bool, update)),
         cmocka_unit_test(test_AMlistPutBytes(insert)),
         cmocka_unit_test(test_AMlistPutBytes(update)),
         cmocka_unit_test(test_AMlistPut(Counter, insert)),

--- a/automerge-c/test/ammapput_tests.c
+++ b/automerge-c/test/ammapput_tests.c
@@ -29,7 +29,7 @@ static void test_AMmapPut ## suffix(void **state) {                           \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);                            \
+    assert_int_equal(value.tag, AM_VALUE_VOID);                            \
     AMfreeResult(res);                                                        \
     res = AMmapGet(group_state->doc, AM_ROOT, #suffix);                       \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
@@ -59,16 +59,12 @@ static void test_AMmapPutObject_ ## label(void **state) {                     \
     assert_int_equal(AMresultSize(res), 1);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
-    /**                                                                       \
-     * \note The `AMresult` struct can be deallocated immediately when its    \
-     *       value is a pointer to an opaque struct because its lifetime      \
-     *       is tied to the `AMdoc` struct instead.                           \
-     */                                                                       \
-    AMfreeResult(res);                                                        \
     assert_non_null(value.obj_id);                                            \
     assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
-    AMfreeObjId(group_state->doc, value.obj_id);                                                             \
+    AMfreeResult(res);                                                        \
 }
+
+static_void_test_AMmapPut(Bool, boolean, true)
 
 static void test_AMmapPutBytes(void **state) {
     static char const* const KEY = "Bytes";
@@ -88,7 +84,7 @@ static void test_AMmapPutBytes(void **state) {
     }
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);
+    assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfreeResult(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
     if (AMresultStatus(res) != AM_STATUS_OK) {
@@ -118,7 +114,7 @@ static void test_AMmapPutNull(void **state) {
     }
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);
+    assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfreeResult(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
     if (AMresultStatus(res) != AM_STATUS_OK) {
@@ -153,7 +149,7 @@ static void test_AMmapPutStr(void **state) {
     }
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
-    assert_int_equal(value.tag, AM_VALUE_NOTHING);
+    assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfreeResult(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
     if (AMresultStatus(res) != AM_STATUS_OK) {
@@ -173,6 +169,7 @@ static_void_test_AMmapPut(Uint, uint, UINT64_MAX)
 
 int run_AMmapPut_tests(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_AMmapPut(Bool)),
         cmocka_unit_test(test_AMmapPutBytes),
         cmocka_unit_test(test_AMmapPut(Counter)),
         cmocka_unit_test(test_AMmapPut(F64)),

--- a/automerge-c/test/group_state.c
+++ b/automerge-c/test/group_state.c
@@ -5,7 +5,7 @@
 
 int group_setup(void** state) {
     GroupState* group_state = calloc(1, sizeof(GroupState));
-    group_state->doc = AMallocDoc();
+    group_state->doc = AMalloc();
     *state = group_state;
     return 0;
 }

--- a/automerge-c/test/macro_utils.c
+++ b/automerge-c/test/macro_utils.c
@@ -4,7 +4,8 @@
 #include "macro_utils.h"
 
 AMvalueVariant AMvalue_discriminant(char const* suffix) {
-    if (!strcmp(suffix, "Bytes"))          return AM_VALUE_BYTES;
+    if (!strcmp(suffix, "Bool"))           return AM_VALUE_BOOLEAN;
+    else if (!strcmp(suffix, "Bytes"))     return AM_VALUE_BYTES;
     else if (!strcmp(suffix, "Counter"))   return AM_VALUE_COUNTER;
     else if (!strcmp(suffix, "F64"))       return AM_VALUE_F64;
     else if (!strcmp(suffix, "Int"))       return AM_VALUE_INT;
@@ -12,7 +13,7 @@ AMvalueVariant AMvalue_discriminant(char const* suffix) {
     else if (!strcmp(suffix, "Str"))       return AM_VALUE_STR;
     else if (!strcmp(suffix, "Timestamp")) return AM_VALUE_TIMESTAMP;
     else if (!strcmp(suffix, "Uint"))      return AM_VALUE_UINT;
-    else return AM_VALUE_NOTHING;
+    else return AM_VALUE_VOID;
 }
 
 AMobjType AMobjType_tag(char const* obj_type_label) {


### PR DESCRIPTION
@orionz and @alexjg, this PR adds my port of `quickstart.rs` to the C API.

As with Rust's quickstart example, the instructions for building and running it are in the `automerge-c/examples/README.md` file.