### PR TITLE
Implement OpTreeIter::nth correctly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           default: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v1
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           default: true
           components: clippy
       - uses: Swatinem/rust-cache@v1
@@ -42,7 +42,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/ci/docs
@@ -87,7 +87,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - name: Install CMocka
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.57.0
+          - 1.60.0
           - nightly
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     steps:
@@ -126,7 +126,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/ci/build-test
@@ -139,7 +139,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/ci/build-test

--- a/automerge/src/op_tree/iter.rs
+++ b/automerge/src/op_tree/iter.rs
@@ -1,32 +1,29 @@
+use std::cmp::Ordering;
+
 use crate::types::Op;
 
 use super::{OpTreeInternal, OpTreeNode};
 
 #[derive(Clone)]
-pub(crate) enum OpTreeIter<'a> {
-    Empty,
-    NonEmpty {
-        // A stack of (OpTreeNode, index) where `index` is the index in the elements of the optree node
-        // at which we descended into a child
-        ancestors: Vec<(&'a OpTreeNode, usize)>,
-        current: &'a OpTreeNode,
-        index: usize,
-        tree: &'a OpTreeInternal,
-    },
-}
+pub(crate) struct OpTreeIter<'a>(Inner<'a>);
 
 impl<'a> OpTreeIter<'a> {
     pub(crate) fn new(tree: &'a OpTreeInternal) -> OpTreeIter<'a> {
-        tree.root_node
-            .as_ref()
-            .map(|root| OpTreeIter::NonEmpty {
-                // This is a guess at the average depth of an OpTree
-                ancestors: Vec::with_capacity(6),
-                current: root,
-                index: 0,
-                tree,
-            })
-            .unwrap_or(OpTreeIter::Empty)
+        Self(
+            tree.root_node
+                .as_ref()
+                .map(|root| Inner::NonEmpty {
+                    // This is a guess at the average depth of an OpTree
+                    ancestors: Vec::with_capacity(6),
+                    current: NodeIter {
+                        node: root,
+                        index: 0,
+                    },
+                    cumulative_index: 0,
+                    root_node: root,
+                })
+                .unwrap_or(Inner::Empty),
+        )
     }
 }
 
@@ -34,31 +31,78 @@ impl<'a> Iterator for OpTreeIter<'a> {
     type Item = &'a Op;
 
     fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+}
+
+#[derive(Clone)]
+enum Inner<'a> {
+    Empty,
+    NonEmpty {
+        // A stack of nodes in the optree which we have descended in to to get to the current
+        // element.
+        ancestors: Vec<NodeIter<'a>>,
+        current: NodeIter<'a>,
+        // How far through the whole optree we are
+        cumulative_index: usize,
+        root_node: &'a OpTreeNode,
+    },
+}
+
+/// A node in the op tree which we are iterating over
+#[derive(Clone)]
+struct NodeIter<'a> {
+    /// The node itself
+    node: &'a OpTreeNode,
+    /// The index of the next element we will pull from the node. This means something different
+    /// depending on whether the node is a leaf node or not. If the node is a leaf node then this
+    /// index is the index in `node.elements` which will be returned on the next call to `next()`.
+    /// If the node is not an internal node then this index is the index of `children` which we are
+    /// currently iterating as well as being the index of the next element of `elements` which we
+    /// will return once we have finished iterating over the child node.
+    index: usize,
+}
+
+impl<'a> Iterator for Inner<'a> {
+    type Item = &'a Op;
+
+    fn next(&mut self) -> Option<Self::Item> {
         match self {
-            OpTreeIter::Empty => None,
-            OpTreeIter::NonEmpty {
+            Inner::Empty => None,
+            Inner::NonEmpty {
                 ancestors,
                 current,
-                index,
+                cumulative_index,
                 ..
             } => {
-                if current.is_leaf() {
+                if current.node.is_leaf() {
                     // If we're in a leaf node and we haven't exhausted it yet we just return the elements
                     // of the leaf node
-                    if *index < current.len() {
-                        let result = &current.elements[*index];
-                        *index += 1;
+                    if current.index < current.node.len() {
+                        let result = &current.node.elements[current.index];
+                        current.index += 1;
+                        *cumulative_index += 1;
                         Some(result)
                     } else {
                         // We've exhausted the leaf node, we must find the nearest non-exhausted parent (lol)
-                        let (parent, parent_index) = loop {
-                            if let Some((parent, parent_index)) = ancestors.pop() {
+                        let node_iter = loop {
+                            if let Some(
+                                node_iter @ NodeIter {
+                                    node: parent,
+                                    index: parent_index,
+                                },
+                            ) = ancestors.pop()
+                            {
                                 // We've exhausted this parent
                                 if parent_index >= parent.elements.len() {
                                     continue;
                                 } else {
                                     // This parent still has elements to process, let's use it!
-                                    break (parent, parent_index);
+                                    break node_iter;
                                 }
                             } else {
                                 // No parents left, we're done
@@ -68,23 +112,27 @@ impl<'a> Iterator for OpTreeIter<'a> {
                         // if we've finished the elements in a leaf node and there's a parent node then we
                         // return the element from the parent node which is one after the index at which we
                         // descended into the child
-                        *index = parent_index + 1;
-                        *current = parent;
-                        let result = &current.elements[parent_index];
+                        *current = node_iter;
+                        let result = &current.node.elements[current.index];
+                        current.index += 1;
+                        *cumulative_index += 1;
                         Some(result)
                     }
                 } else {
                     // If we're in a non-leaf node then the last iteration returned an element from the
                     // current nodes `elements`, so we must now descend into a leaf child
-                    ancestors.push((current, *index));
+                    ancestors.push(current.clone());
                     loop {
-                        let child = &current.children[*index];
-                        *index = 0;
+                        let child = &current.node.children[current.index];
+                        current.index = 0;
                         if !child.is_leaf() {
-                            ancestors.push((child, 0));
-                            *current = child
+                            ancestors.push(NodeIter {
+                                node: child,
+                                index: 0,
+                            });
+                            current.node = child
                         } else {
-                            *current = child;
+                            current.node = child;
                             break;
                         }
                     }
@@ -97,7 +145,61 @@ impl<'a> Iterator for OpTreeIter<'a> {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         match self {
             Self::Empty => None,
-            Self::NonEmpty { tree, .. } => tree.get(n),
+            Self::NonEmpty {
+                root_node,
+                cumulative_index,
+                current,
+                ancestors,
+                ..
+            } => {
+                // Make sure that we don't rewind when calling nth more than once
+                if n < *cumulative_index {
+                    None
+                } else if n >= root_node.len() {
+                    *cumulative_index = root_node.len() - 1;
+                    None
+                } else {
+                    // rather than trying to go back up through the ancestors to find the right
+                    // node we just start at the root.
+                    *current = NodeIter {
+                        node: root_node,
+                        index: n,
+                    };
+                    *cumulative_index = 0;
+                    ancestors.clear();
+                    while !current.node.is_leaf() {
+                        for (child_index, child) in current.node.children.iter().enumerate() {
+                            match (*cumulative_index + child.len()).cmp(&n) {
+                                Ordering::Less => {
+                                    *cumulative_index += child.len() + 1;
+                                    current.index = child_index + 1;
+                                }
+                                Ordering::Equal => {
+                                    *cumulative_index += child.len() + 1;
+                                    current.index = child_index + 1;
+                                    return Some(&current.node.elements[child_index]);
+                                }
+                                Ordering::Greater => {
+                                    current.index = child_index;
+                                    let old = std::mem::replace(
+                                        current,
+                                        NodeIter {
+                                            node: child,
+                                            index: 0,
+                                        },
+                                    );
+                                    ancestors.push(old);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    // we're in a leaf node and we kept track of the cumulative index as we went,
+                    let index_in_this_node = n.saturating_sub(*cumulative_index);
+                    current.index = index_in_this_node + 1;
+                    Some(&current.node.elements[index_in_this_node])
+                }
+            }
         }
     }
 }
@@ -108,10 +210,49 @@ mod tests {
     use crate::types::{Key, Op, OpId, OpType, ScalarValue};
     use proptest::prelude::*;
 
-    #[derive(Debug, Clone)]
+    #[derive(Clone)]
     enum Action {
         Insert(usize, Op),
         Delete(usize),
+    }
+
+    impl std::fmt::Debug for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Insert(index, ..) => write!(f, "Insert({})", index),
+                Self::Delete(index) => write!(f, "Delete({})", index),
+            }
+        }
+    }
+
+    // A struct which impls Debug by only printing the counters of the IDs of the  ops it wraps.
+    // This is useful because the only difference between the ops that we generate is the counter
+    // of their IDs. Wrapping a Vec<Op> in DebugOps will result in output from assert! etc. which
+    // only shows the counters. For example, the output of a failing assert_eq! like this
+    //
+    //     assert_eq!(DebugOps(&ops1), DebugOps(&ops2))
+    //
+    // Might look like this
+    //
+    //     left: `[0,1,2,3]
+    //     right: `[0,1,2,3,4]
+    //
+    // i.e. all the other details of the ops are elided
+    #[derive(PartialEq)]
+    struct DebugOps<'a>(&'a [Op]);
+
+    impl<'a> std::fmt::Debug for DebugOps<'a> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "[")?;
+            for (index, op) in self.0.iter().enumerate() {
+                if index < self.0.len() - 1 {
+                    write!(f, "{},", op.id.counter())?;
+                } else {
+                    write!(f, "{}]", op.id.counter())?
+                }
+            }
+            Ok(())
+        }
     }
 
     fn op(counter: u64) -> Op {
@@ -130,10 +271,19 @@ mod tests {
     /// apply it to the model and record the action we took. In the property test we replay the
     /// same actions against an `OpTree` and check that the iterator returns the same result as the
     /// `model`.
-    #[derive(Debug, Clone)]
+    #[derive(Clone)]
     struct Model {
         actions: Vec<Action>,
         model: Vec<Op>,
+    }
+
+    impl std::fmt::Debug for Model {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Model")
+                .field("actions", &self.actions)
+                .field("model", &DebugOps(&self.model))
+                .finish()
+        }
     }
 
     impl Model {
@@ -185,7 +335,7 @@ mod tests {
         }
     }
 
-    fn scenario() -> impl Strategy<Value = Model> {
+    fn model() -> impl Strategy<Value = Model> {
         (0_u64..150).prop_flat_map(|num_steps| {
             let mut strat = Just((
                 0,
@@ -212,19 +362,77 @@ mod tests {
         })
     }
 
-    proptest! {
-        #[test]
-        fn optree_iter_proptest(Model{actions, model} in scenario()) {
-            let mut optree = OpTreeInternal::new();
-            for action in actions {
-                match action {
-                    Action::Insert(index, op) => optree.insert(index, op),
-                    Action::Delete(index) => { optree.remove(index); },
+    fn make_optree(actions: &[Action]) -> super::OpTreeInternal {
+        let mut optree = OpTreeInternal::new();
+        for action in actions {
+            match action {
+                Action::Insert(index, op) => optree.insert(*index, op.clone()),
+                Action::Delete(index) => {
+                    optree.remove(*index);
                 }
             }
+        }
+        optree
+    }
+
+    /// A model for calls to `nth`. `NthModel::n` is guarnateed to be in `(0..model.len())`
+    #[derive(Clone)]
+    struct NthModel {
+        model: Vec<Op>,
+        actions: Vec<Action>,
+        n: usize,
+    }
+
+    impl std::fmt::Debug for NthModel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Model")
+                .field("actions", &self.actions)
+                .field("model", &DebugOps(&self.model))
+                .field("n", &self.n)
+                .finish()
+        }
+    }
+
+    fn nth_model() -> impl Strategy<Value = NthModel> {
+        model().prop_flat_map(|model| {
+            if model.model.is_empty() {
+                Just(NthModel {
+                    model: model.model,
+                    actions: model.actions,
+                    n: 0,
+                })
+                .boxed()
+            } else {
+                (0..model.model.len(), Just(model))
+                    .prop_map(|(index, model)| NthModel {
+                        model: model.model,
+                        actions: model.actions,
+                        n: index,
+                    })
+                    .boxed()
+            }
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn optree_iter_proptest(model in model()) {
+            let optree = make_optree(&model.actions);
             let iter = super::OpTreeIter::new(&optree);
             let iterated = iter.cloned().collect::<Vec<_>>();
-            assert_eq!(model, iterated)
+            assert_eq!(DebugOps(&model.model), DebugOps(&iterated))
+        }
+
+        #[test]
+        fn optree_iter_nth(model in nth_model()) {
+            let optree = make_optree(&model.actions);
+            let mut iter = super::OpTreeIter::new(&optree);
+            let mut model_iter = model.model.iter();
+            assert_eq!(model_iter.nth(model.n), iter.nth(model.n));
+
+            let tail = iter.cloned().collect::<Vec<_>>();
+            let expected_tail = model_iter.cloned().collect::<Vec<_>>();
+            assert_eq!(DebugOps(tail.as_slice()), DebugOps(expected_tail.as_slice()));
         }
     }
 }


### PR DESCRIPTION
The previous implementation of nth was incorrect, it returned the nth
element of the optree but it did not modify the internal state of the
iterator such that future calls to `next()` were after the nth element.
This commit fixes that.

Signed-off-by: Alex Good <alex@memoryandthought.me>