### PR TITLE
Use an `UnknownObject` type alias

### DIFF
--- a/automerge-js/src/common.ts
+++ b/automerge-js/src/common.ts
@@ -1,4 +1,6 @@
-export function isObject(obj: any) : boolean {
+import { UnknownObject } from './types';
+
+export function isObject(obj: unknown) : obj is UnknownObject {
   return typeof obj === 'object' && obj !== null
 }
 
@@ -6,9 +8,9 @@ export function isObject(obj: any) : boolean {
  * Returns a shallow copy of the object `obj`. Faster than `Object.assign({}, obj)`.
  * https://jsperf.com/cloning-large-objects/1
  */
-export function copyObject(obj: any) : any {
+export function copyObject<T extends UnknownObject>(obj: T) : T {
   if (!isObject(obj)) return {}
-  const copy : any = {}
+  const copy = {}
   for (const key of Object.keys(obj)) {
     copy[key] = obj[key]
   }

--- a/automerge-js/src/types.ts
+++ b/automerge-js/src/types.ts
@@ -1,0 +1,2 @@
+export type UnknownObject = Record<string | number | symbol, unknown>;
+export type Dictionary<T> = Record<string, T>;


### PR DESCRIPTION
Fix the `any` lint issues in `common.ts` by using an `UnknownObject` type alias. This is the correct type of arbitrary POJO-like objects where you don't know or care about the value types.

Added `Dictionary<T>` for the more standard cases where you have a `string` key and arbitrary (but known!) value types.