### PR TITLE
Get changes opt

### DIFF
--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -1395,7 +1395,7 @@ pub unsafe extern "C" fn AMgetChanges(
         Some(have_deps) => have_deps.as_ref(),
         None => &empty_deps,
     };
-    to_result(Ok(doc.get_changes(have_deps)))
+    to_result(doc.get_changes(have_deps))
 }
 
 /// \memberof AMchange

--- a/automerge-cli/src/examine.rs
+++ b/automerge-cli/src/examine.rs
@@ -31,7 +31,12 @@ pub fn examine(
         .map_err(|e| ExamineError::ReadingChanges { source: e })?;
     let doc = am::Automerge::load(&buf)
         .map_err(|e| ExamineError::ApplyingInitialChanges { source: e })?;
-    let uncompressed_changes: Vec<_> = doc.get_changes(&[]).iter().map(|c| c.decode()).collect();
+    let uncompressed_changes: Vec<_> = doc
+        .get_changes(&[])
+        .unwrap()
+        .iter()
+        .map(|c| c.decode())
+        .collect();
     if is_tty {
         let json_changes = serde_json::to_value(uncompressed_changes).unwrap();
         colored_json::write_colored_json(&json_changes, &mut output).unwrap();

--- a/automerge-wasm/src/lib.rs
+++ b/automerge-wasm/src/lib.rs
@@ -572,7 +572,7 @@ impl Automerge {
     pub fn get_changes(&mut self, have_deps: JsValue) -> Result<Array, JsValue> {
         self.ensure_transaction_closed();
         let deps: Vec<_> = JS(have_deps).try_into()?;
-        let changes = self.doc.get_changes(&deps);
+        let changes = self.doc.get_changes(&deps)?;
         let changes: Array = changes
             .iter()
             .map(|c| Uint8Array::from(c.raw_bytes()))

--- a/automerge-wasm/test/test.ts
+++ b/automerge-wasm/test/test.ts
@@ -312,11 +312,12 @@ describe('Automerge', () => {
       doc1.put("_root", "hello", "world")
       let doc2 = load(doc1.save(), "bbbb");
       let doc3 = load(doc1.save(), "cccc");
+      let heads = doc1.getHeads()
       doc1.put("_root", "cnt", 20)
       doc2.put("_root", "cnt", 0, "counter")
       doc3.put("_root", "cnt", 10, "counter")
-      doc1.applyChanges(doc2.getChanges(doc1.getHeads()))
-      doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
+      doc1.applyChanges(doc2.getChanges(heads))
+      doc1.applyChanges(doc3.getChanges(heads))
       let result = doc1.getAll("_root", "cnt")
       assert.deepEqual(result,[
         ['int',20,'2@aaaa'],
@@ -345,11 +346,12 @@ describe('Automerge', () => {
       doc1.insert(seq, 0, "hello")
       let doc2 = load(doc1.save(), "bbbb");
       let doc3 = load(doc1.save(), "cccc");
+      let heads = doc1.getHeads()
       doc1.put(seq, 0, 20)
       doc2.put(seq, 0, 0, "counter")
       doc3.put(seq, 0, 10, "counter")
-      doc1.applyChanges(doc2.getChanges(doc1.getHeads()))
-      doc1.applyChanges(doc3.getChanges(doc1.getHeads()))
+      doc1.applyChanges(doc2.getChanges(heads))
+      doc1.applyChanges(doc3.getChanges(heads))
       let result = doc1.getAll(seq, 0)
       assert.deepEqual(result,[
         ['int',20,'3@aaaa'],

--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -51,3 +51,7 @@ harness = false
 [[bench]]
 name = "map"
 harness = false
+
+[[bench]]
+name = "sync"
+harness = false

--- a/automerge/benches/map.rs
+++ b/automerge/benches/map.rs
@@ -181,6 +181,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || {
                     repeated_put(size)
                         .get_changes(&[])
+                        .unwrap()
                         .into_iter()
                         .cloned()
                         .collect::<Vec<_>>()
@@ -200,6 +201,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     || {
                         repeated_increment(size)
                             .get_changes(&[])
+                            .unwrap()
                             .into_iter()
                             .cloned()
                             .collect::<Vec<_>>()
@@ -222,6 +224,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     || {
                         increasing_put(size)
                             .get_changes(&[])
+                            .unwrap()
                             .into_iter()
                             .cloned()
                             .collect::<Vec<_>>()
@@ -244,6 +247,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     || {
                         decreasing_put(size)
                             .get_changes(&[])
+                            .unwrap()
                             .into_iter()
                             .cloned()
                             .collect::<Vec<_>>()

--- a/automerge/benches/sync.rs
+++ b/automerge/benches/sync.rs
@@ -1,0 +1,95 @@
+use automerge::{sync, transaction::Transactable, Automerge, ROOT};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+#[derive(Default)]
+struct DocWithSync {
+    doc: Automerge,
+    peer_state: sync::State,
+}
+
+impl From<Automerge> for DocWithSync {
+    fn from(doc: Automerge) -> Self {
+        Self {
+            doc,
+            peer_state: sync::State::default(),
+        }
+    }
+}
+
+fn increasing_put(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    for i in 0..n {
+        tx.put(ROOT, i.to_string(), i).unwrap();
+    }
+    tx.commit();
+    doc
+}
+
+// keep syncing until doc1 no longer generates a sync message for doc2.
+fn sync(doc1: &mut DocWithSync, doc2: &mut DocWithSync) {
+    loop {
+        if let Some(message1) = doc1.doc.generate_sync_message(&mut doc1.peer_state) {
+            doc2.doc
+                .receive_sync_message(&mut doc2.peer_state, message1)
+                .unwrap()
+        } else {
+            break;
+        }
+
+        if let Some(message2) = doc2.doc.generate_sync_message(&mut doc2.peer_state) {
+            doc1.doc
+                .receive_sync_message(&mut doc1.peer_state, message2)
+                .unwrap()
+        }
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let sizes = [100, 1_000, 10_000];
+
+    let mut group = c.benchmark_group("sync unidirectional");
+    for size in &sizes {
+        group.throughput(criterion::Throughput::Elements(*size));
+
+        group.bench_with_input(
+            BenchmarkId::new("increasing put", size),
+            size,
+            |b, &size| {
+                b.iter_batched(
+                    || (increasing_put(size), DocWithSync::default()),
+                    |(doc1, mut doc2)| sync(&mut doc1.into(), &mut doc2),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("sync unidirectional every change");
+    for size in &sizes {
+        group.throughput(criterion::Throughput::Elements(*size));
+
+        group.bench_with_input(
+            BenchmarkId::new("increasing put", size),
+            size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut doc1 = DocWithSync::default();
+                    let mut doc2 = DocWithSync::default();
+
+                    for i in 0..size {
+                        let mut tx = doc1.doc.transaction();
+                        tx.put(ROOT, i.to_string(), i).unwrap();
+                        tx.commit();
+                        sync(&mut doc1, &mut doc2);
+                    }
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/automerge/examples/quickstart.rs
+++ b/automerge/examples/quickstart.rs
@@ -50,7 +50,7 @@ fn main() {
 
     doc1.merge(&mut doc2).unwrap();
 
-    for change in doc1.get_changes(&[]) {
+    for change in doc1.get_changes(&[]).unwrap() {
         let length = doc1.length_at(&cards, &[change.hash]);
         println!("{} {}", change.message().unwrap(), length);
     }

--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -170,7 +170,10 @@ impl AutoCommit {
         self.doc.get_last_local_change()
     }
 
-    pub fn get_changes(&mut self, have_deps: &[ChangeHash]) -> Vec<&Change> {
+    pub fn get_changes(
+        &mut self,
+        have_deps: &[ChangeHash],
+    ) -> Result<Vec<&Change>, AutomergeError> {
         self.ensure_transaction_closed();
         self.doc.get_changes(have_deps)
     }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -974,7 +974,7 @@ impl Automerge {
 
         let actor_index = self.ops.m.actors.cache(change.actor_id().clone());
         self.states
-            .entry(self.ops.m.actors.cache(change.actor_id().clone()))
+            .entry(actor_index)
             .or_default()
             .push(history_index);
 

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -943,24 +943,7 @@ impl Automerge {
     }
 
     pub fn get_changes(&self, have_deps: &[ChangeHash]) -> Result<Vec<&Change>, AutomergeError> {
-        let changes = if let Some(changes) = self.get_changes_fast(have_deps) {
-            changes
-        } else {
-            self.get_changes_slow(have_deps)
-        };
-        let clock_changes = self.get_changes_clock(have_deps)?;
-        assert_eq!(
-            changes,
-            clock_changes,
-            "{:#?} {:#?} {:#?}",
-            changes.iter().map(|c| c.hash).collect::<Vec<_>>(),
-            clock_changes
-                .iter()
-                .map(|c| (c.hash, c.actor_id()))
-                .collect::<Vec<_>>(),
-            self.clock_at(have_deps),
-        );
-        Ok(changes)
+        self.get_changes_clock(have_deps)
     }
 
     /// Get the last change this actor made to the document.

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -980,7 +980,10 @@ impl Automerge {
 
         let mut clock = Clock::new();
         for hash in &change.deps {
-            let c = self.clocks.get(hash).unwrap();
+            let c = self
+                .clocks
+                .get(hash)
+                .expect("Change's deps should already be in the document");
             clock.merge(c);
         }
         clock.include(

--- a/automerge/src/automerge/tests.rs
+++ b/automerge/src/automerge/tests.rs
@@ -1473,7 +1473,7 @@ fn observe_counter_change_application() {
     doc.put(ROOT, "counter", ScalarValue::counter(1)).unwrap();
     doc.increment(ROOT, "counter", 2).unwrap();
     doc.increment(ROOT, "counter", 5).unwrap();
-    let changes = doc.get_changes(&[]).into_iter().cloned().collect();
+    let changes = doc.get_changes(&[]).unwrap().into_iter().cloned().collect();
 
     let mut new_doc = AutoCommit::new();
     let mut observer = VecOpObserver::default();
@@ -1517,5 +1517,5 @@ fn get_changes_heads_empty() {
     doc.put(ROOT, "key2", 1).unwrap();
     doc.commit();
     let heads = doc.get_heads();
-    assert_eq!(doc.get_changes(&heads), Vec::<&Change>::new());
+    assert_eq!(doc.get_changes(&heads).unwrap(), Vec::<&Change>::new());
 }

--- a/automerge/src/automerge/tests.rs
+++ b/automerge/src/automerge/tests.rs
@@ -1508,3 +1508,14 @@ fn observe_counter_change_application() {
         ]
     );
 }
+
+#[test]
+fn get_changes_heads_empty() {
+    let mut doc = AutoCommit::new();
+    doc.put(ROOT, "key1", 1).unwrap();
+    doc.commit();
+    doc.put(ROOT, "key2", 1).unwrap();
+    doc.commit();
+    let heads = doc.get_heads();
+    assert_eq!(doc.get_changes(&heads), Vec::<&Change>::new());
+}

--- a/automerge/src/change.rs
+++ b/automerge/src/change.rs
@@ -333,6 +333,7 @@ pub struct Change {
     pub deps: Vec<amp::ChangeHash>,
     ops: HashMap<u32, Range<usize>>,
     extra_bytes: Range<usize>,
+    /// The number of operations in this change.
     num_ops: usize,
 }
 

--- a/automerge/src/clock.rs
+++ b/automerge/src/clock.rs
@@ -25,6 +25,11 @@ impl Clock {
             false
         }
     }
+
+    /// Get the max_op recorded in this clock for the actor.
+    pub(crate) fn get_for_actor(&self, actor_index: &usize) -> Option<&u64> {
+        self.0.get(actor_index)
+    }
 }
 
 #[cfg(test)]

--- a/automerge/src/clock.rs
+++ b/automerge/src/clock.rs
@@ -1,40 +1,51 @@
 use crate::types::OpId;
 use fxhash::FxBuildHasher;
-use std::cmp;
 use std::collections::HashMap;
+
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ClockData {
+    /// Maximum operation counter of the actor at the point in time.
+    pub(crate) max_op: u64,
+    /// Sequence number of the change from this actor.
+    pub(crate) seq: u64,
+}
 
 /// Vector clock mapping actor indices to the max op counter of the changes created by that actor.
 #[derive(Default, Debug, Clone, PartialEq)]
-pub(crate) struct Clock(HashMap<usize, u64, FxBuildHasher>);
+pub(crate) struct Clock(HashMap<usize, ClockData, FxBuildHasher>);
 
 impl Clock {
     pub(crate) fn new() -> Self {
         Clock(Default::default())
     }
 
-    pub(crate) fn include(&mut self, actor_index: usize, max_op: u64) {
+    pub(crate) fn include(&mut self, actor_index: usize, data: ClockData) {
         self.0
             .entry(actor_index)
-            .and_modify(|m| *m = cmp::max(max_op, *m))
-            .or_insert(max_op);
+            .and_modify(|d| {
+                if data.max_op > d.max_op {
+                    *d = data;
+                }
+            })
+            .or_insert(data);
     }
 
     pub(crate) fn covers(&self, id: &OpId) -> bool {
-        if let Some(max_op) = self.0.get(&id.1) {
-            max_op >= &id.0
+        if let Some(data) = self.0.get(&id.1) {
+            data.max_op >= id.0
         } else {
             false
         }
     }
 
     /// Get the max_op counter recorded in this clock for the actor.
-    pub(crate) fn get_for_actor(&self, actor_index: &usize) -> Option<&u64> {
+    pub(crate) fn get_for_actor(&self, actor_index: &usize) -> Option<&ClockData> {
         self.0.get(actor_index)
     }
 
     pub(crate) fn merge(&mut self, other: &Self) {
-        for (actor, max_op) in &other.0 {
-            self.include(*actor, *max_op);
+        for (actor, data) in &other.0 {
+            self.include(*actor, *data);
         }
     }
 }
@@ -47,8 +58,8 @@ mod tests {
     fn covers() {
         let mut clock = Clock::new();
 
-        clock.include(1, 20);
-        clock.include(2, 10);
+        clock.include(1, ClockData { max_op: 20, seq: 1 });
+        clock.include(2, ClockData { max_op: 10, seq: 2 });
 
         assert!(clock.covers(&OpId(10, 1)));
         assert!(clock.covers(&OpId(20, 1)));

--- a/automerge/src/clock.rs
+++ b/automerge/src/clock.rs
@@ -3,7 +3,8 @@ use fxhash::FxBuildHasher;
 use std::cmp;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, PartialEq)]
+/// Vector clock mapping actor indices to the max op counter of the changes created by that actor.
+#[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct Clock(HashMap<usize, u64, FxBuildHasher>);
 
 impl Clock {
@@ -11,24 +12,30 @@ impl Clock {
         Clock(Default::default())
     }
 
-    pub(crate) fn include(&mut self, key: usize, n: u64) {
+    pub(crate) fn include(&mut self, actor_index: usize, max_op: u64) {
         self.0
-            .entry(key)
-            .and_modify(|m| *m = cmp::max(n, *m))
-            .or_insert(n);
+            .entry(actor_index)
+            .and_modify(|m| *m = cmp::max(max_op, *m))
+            .or_insert(max_op);
     }
 
     pub(crate) fn covers(&self, id: &OpId) -> bool {
-        if let Some(val) = self.0.get(&id.1) {
-            val >= &id.0
+        if let Some(max_op) = self.0.get(&id.1) {
+            max_op >= &id.0
         } else {
             false
         }
     }
 
-    /// Get the max_op recorded in this clock for the actor.
+    /// Get the max_op counter recorded in this clock for the actor.
     pub(crate) fn get_for_actor(&self, actor_index: &usize) -> Option<&u64> {
         self.0.get(actor_index)
+    }
+
+    pub(crate) fn merge(&mut self, other: &Self) {
+        for (actor, max_op) in &other.0 {
+            self.include(*actor, *max_op);
+        }
     }
 }
 

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -23,6 +23,8 @@ pub enum AutomergeError {
     DuplicateSeqNumber(u64, ActorId),
     #[error("invalid hash {0}")]
     InvalidHash(ChangeHash),
+    #[error("hash {0} does not correspond to a change in this document")]
+    MissingHash(ChangeHash),
     #[error("increment operations must be against a counter value")]
     MissingCounter,
     #[error("general failure")]

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -838,6 +838,7 @@ fn handle_repeated_out_of_order_changes() -> Result<(), automerge::AutomergeErro
     doc1.commit();
     let changes = doc1
         .get_changes(&[])
+        .unwrap()
         .into_iter()
         .cloned()
         .collect::<Vec<_>>();
@@ -937,7 +938,7 @@ fn observe_counter_change_application() {
     doc.put(ROOT, "counter", ScalarValue::counter(1)).unwrap();
     doc.increment(ROOT, "counter", 2).unwrap();
     doc.increment(ROOT, "counter", 5).unwrap();
-    let changes = doc.get_changes(&[]).into_iter().cloned().collect();
+    let changes = doc.get_changes(&[]).unwrap().into_iter().cloned().collect();
 
     let mut doc = AutoCommit::new();
     let mut observer = VecOpObserver::default();


### PR DESCRIPTION
In order to improve sync performance I've taken a look at the `generate_sync_message` functionality and it was quite largely spending time in getting the changes, this can be especially bad when we can't use the fast version...

This PR optimises the `get_changes` function by doing the following:
- Maintain a vector clock for each change (hash) to allow constant time calculation of the vector clock
- Use this new `clocks` state to speed up finding the clock at any given hash
- Change `get_changes` to use the clocks under the hood, converting the hashes first to a single clock and then building the resulting changes from that
- Precalculate the number of operations in a change and store it alongside, otherwise we have to individually count the operations every time

This does add overhead to each document's memory to store the clocks, I'm sure we can optimise this somehow but I'm basically trying to have syncing not take too long, even though it is something that shouldn't be done too frequently it still shouldn't take multiple seconds!

**Note**: speeding up the `clock_at` function also speeds up all of the `_at` queries for historical content so this is kind of a double win!

And this turned up a bug in the wasm tests which is fixed here.