### PR TITLE
Some more sync optimisations

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1,4 +1,5 @@
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::num::NonZeroU64;
 use std::ops::RangeBounds;
@@ -769,62 +770,28 @@ impl Automerge {
     /// Filter the changes down to those that are not transitive dependencies of the heads.
     ///
     /// Thus a graph with these heads has not seen the remaining changes.
-    pub(crate) fn filter_changes(&self, heads: &[ChangeHash], changes: &mut BTreeSet<ChangeHash>) {
-        // Reduce the working set to find to those which we may be able to find.
-        // This filters out those hashes that are successors of or concurrent with all of the
-        // heads.
-        // This can help in avoiding traversing the entire graph back to the roots when we try to
-        // search for a hash we can know won't be found there.
-        let max_head_index = heads
+    pub(crate) fn filter_changes(
+        &self,
+        heads: &[ChangeHash],
+        changes: &mut BTreeSet<ChangeHash>,
+    ) -> Result<(), AutomergeError> {
+        let heads = heads
             .iter()
-            .map(|h| self.history_index.get(h).unwrap_or(&0))
-            .max()
-            .unwrap_or(&0);
-        let mut may_find: HashSet<ChangeHash> = changes
-            .iter()
-            .filter(|hash| {
-                let change_index = self.history_index.get(hash).unwrap_or(&0);
-                change_index <= max_head_index
-            })
+            .filter(|hash| self.history_index.contains_key(hash))
             .copied()
-            .collect();
+            .collect::<Vec<_>>();
+        let heads_clock = self.clock_at(&heads)?;
 
-        if may_find.is_empty() {
-            return;
-        }
-
-        let mut queue: VecDeque<_> = heads.iter().collect();
-        let mut seen = HashSet::new();
-        while let Some(hash) = queue.pop_front() {
-            if seen.contains(hash) {
-                continue;
-            }
-            seen.insert(hash);
-
-            let removed = may_find.remove(hash);
-            changes.remove(hash);
-            if may_find.is_empty() {
-                break;
-            }
-
-            for dep in self
-                .history_index
+        // keep the hashes that are concurrent or after the heads
+        changes.retain(|hash| {
+            self.clocks
                 .get(hash)
-                .and_then(|i| self.history.get(*i))
-                .map(|c| c.deps.as_slice())
-                .unwrap_or_default()
-            {
-                // if we just removed something from our hashes then it is likely there is more
-                // down here so do a quick inspection on the children.
-                // When we don't remove anything it is less likely that there is something down
-                // that chain so delay it.
-                if removed {
-                    queue.push_front(dep);
-                } else {
-                    queue.push_back(dep);
-                }
-            }
-        }
+                .unwrap()
+                .partial_cmp(&heads_clock)
+                .map_or(true, |o| o == Ordering::Greater)
+        });
+
+        Ok(())
     }
 
     /// Get the hashes of the changes in this document that aren't transitive dependencies of the

--- a/automerge/src/clock.rs
+++ b/automerge/src/clock.rs
@@ -1,6 +1,6 @@
 use crate::types::OpId;
 use fxhash::FxBuildHasher;
-use std::collections::HashMap;
+use std::{cmp::Ordering, collections::HashMap};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ClockData {
@@ -10,9 +10,37 @@ pub(crate) struct ClockData {
     pub(crate) seq: u64,
 }
 
+// a clock for the same actor is ahead of another if it has a higher max_op
+impl PartialOrd for ClockData {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.max_op.partial_cmp(&other.max_op)
+    }
+}
+
 /// Vector clock mapping actor indices to the max op counter of the changes created by that actor.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub(crate) struct Clock(HashMap<usize, ClockData, FxBuildHasher>);
+
+// A general clock is greater if it has one element the other does not or has a counter higher than
+// the other for a given actor.
+//
+// It is equal with another clock if it has the same entries everywhere.
+//
+// It is less than another clock otherwise.
+impl PartialOrd for Clock {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.0 == other.0 {
+            Some(Ordering::Equal)
+        } else if self.is_greater(other) {
+            Some(Ordering::Greater)
+        } else if other.is_greater(self) {
+            Some(Ordering::Less)
+        } else {
+            // concurrent
+            None
+        }
+    }
+}
 
 impl Clock {
     pub(crate) fn new() -> Self {
@@ -48,6 +76,40 @@ impl Clock {
             self.include(*actor, *data);
         }
     }
+
+    fn is_greater(&self, other: &Self) -> bool {
+        let mut has_greater = false;
+
+        let mut others_found = 0;
+
+        for (actor, data) in &self.0 {
+            if let Some(other_data) = other.0.get(actor) {
+                if data < other_data {
+                    // may be concurrent or less
+                    return false;
+                } else if data > other_data {
+                    has_greater = true;
+                }
+                others_found += 1;
+            } else {
+                // other doesn't have this so effectively has a greater element
+                has_greater = true;
+            }
+        }
+
+        if has_greater {
+            // if they are equal then we have seen every key in the other clock and have at least
+            // one greater element so our clock is greater
+            //
+            // If they aren't the same then we haven't seen every key but have a greater element
+            // anyway so are concurrent
+            others_found == other.0.len()
+        } else {
+            // our clock doesn't have anything greater than the other clock so can't be greater but
+            // could still be concurrent
+            false
+        }
+    }
 }
 
 #[cfg(test)]
@@ -71,5 +133,35 @@ mod tests {
 
         assert!(!clock.covers(&OpId(1, 3)));
         assert!(!clock.covers(&OpId(100, 3)));
+    }
+
+    #[test]
+    fn comparison() {
+        let mut base_clock = Clock::new();
+        base_clock.include(1, ClockData { max_op: 1, seq: 1 });
+        base_clock.include(2, ClockData { max_op: 1, seq: 1 });
+
+        let mut after_clock = base_clock.clone();
+        after_clock.include(1, ClockData { max_op: 2, seq: 2 });
+
+        assert!(after_clock > base_clock);
+        assert!(base_clock < after_clock);
+
+        assert!(base_clock == base_clock);
+
+        let mut new_actor_clock = base_clock.clone();
+        new_actor_clock.include(3, ClockData { max_op: 1, seq: 1 });
+
+        assert_eq!(
+            base_clock.partial_cmp(&new_actor_clock),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            new_actor_clock.partial_cmp(&base_clock),
+            Some(Ordering::Greater)
+        );
+
+        assert_eq!(after_clock.partial_cmp(&new_actor_clock), None);
+        assert_eq!(new_actor_clock.partial_cmp(&after_clock), None);
     }
 }

--- a/automerge/src/sync.rs
+++ b/automerge/src/sync.rs
@@ -199,9 +199,7 @@ impl Automerge {
 
             for h in have {
                 let Have { last_sync, bloom } = h;
-                for hash in last_sync {
-                    last_sync_hashes.insert(hash);
-                }
+                last_sync_hashes.extend(last_sync);
                 bloom_filters.push(bloom);
             }
             let last_sync_hashes = last_sync_hashes.into_iter().copied().collect::<Vec<_>>();

--- a/automerge/src/sync.rs
+++ b/automerge/src/sync.rs
@@ -137,7 +137,7 @@ impl Automerge {
         }
 
         // trim down the sent hashes to those that we know they haven't seen
-        self.filter_changes(&message_heads, &mut sync_state.sent_hashes);
+        self.filter_changes(&message_heads, &mut sync_state.sent_hashes)?;
 
         if changes_is_empty && message_heads == before_heads {
             sync_state.last_sent_heads = message_heads.clone();

--- a/automerge/src/sync.rs
+++ b/automerge/src/sync.rs
@@ -58,7 +58,7 @@ impl Automerge {
             sync_state.their_have.as_ref(),
             sync_state.their_need.as_ref(),
         ) {
-            self.get_changes_to_send(their_have.clone(), their_need)
+            self.get_changes_to_send(their_have, their_need)
                 .expect("Should have only used hashes that are in the document")
         } else {
             Vec::new()
@@ -176,7 +176,7 @@ impl Automerge {
 
     fn get_changes_to_send(
         &self,
-        have: Vec<Have>,
+        have: &[Have],
         need: &[ChangeHash],
     ) -> Result<Vec<&Change>, AutomergeError> {
         if have.is_empty() {
@@ -195,7 +195,7 @@ impl Automerge {
                 }
                 bloom_filters.push(bloom);
             }
-            let last_sync_hashes = last_sync_hashes.into_iter().collect::<Vec<_>>();
+            let last_sync_hashes = last_sync_hashes.into_iter().copied().collect::<Vec<_>>();
 
             let changes = self.get_changes(&last_sync_hashes)?;
 


### PR DESCRIPTION
Mainly changing `filter_changes` to use the `clock_at` mechanism rather than doing graph traversals every time.