### PR TITLE
Simplify management of memory allocated by C API calls

### DIFF
--- a/automerge-c/cbindgen.toml
+++ b/automerge-c/cbindgen.toml
@@ -7,7 +7,7 @@ after_includes = """\n
 /**
  * \\memberof AMdoc
  * \\def AM_ROOT
- * \\brief The root object of an `AMdoc` struct.
+ * \\brief The root object of a document.
  */
 #define AM_ROOT NULL
 """

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -9,7 +9,8 @@ AMvalue test(AMresult*, AMvalueVariant const);
  *  Based on https://automerge.github.io/docs/quickstart
  */
 int main(int argc, char** argv) {
-    AMdoc* const doc1 = AMcreate();
+    AMresult* const doc1_result = AMcreate();
+    AMdoc* const doc1 = AMresultValue(doc1_result, 0).doc;
     if (doc1 == NULL) {
         fprintf(stderr, "`AMcreate()` failure.");
         exit(EXIT_FAILURE);
@@ -22,69 +23,71 @@ int main(int argc, char** argv) {
     AMobjId const* const card1 = value.obj_id;
     AMresult* result = AMmapPutStr(doc1, card1, "title", "Rewrite everything in Clojure");
     test(result, AM_VALUE_VOID);
-    AMresultFree(result);
+    AMfree(result);
     result = AMmapPutBool(doc1, card1, "done", false);
     test(result, AM_VALUE_VOID);
-    AMresultFree(result);
+    AMfree(result);
     AMresult* const card2_result = AMlistPutObject(doc1, cards, 0, true, AM_OBJ_TYPE_MAP);
     value = test(card2_result, AM_VALUE_OBJ_ID);
     AMobjId const* const card2 = value.obj_id;
     result = AMmapPutStr(doc1, card2, "title", "Rewrite everything in Haskell");
     test(result, AM_VALUE_VOID);
-    AMresultFree(result);
+    AMfree(result);
     result = AMmapPutBool(doc1, card2, "done", false);
     test(result, AM_VALUE_VOID);
-    AMresultFree(result);
-    AMresultFree(card2_result);
+    AMfree(result);
+    AMfree(card2_result);
     result = AMcommit(doc1, "Add card", NULL);
     test(result, AM_VALUE_CHANGE_HASHES);
-    AMresultFree(result);
+    AMfree(result);
 
-    AMdoc* doc2 = AMcreate();
+    AMresult* doc2_result = AMcreate();
+    AMdoc* doc2 = AMresultValue(doc2_result, 0).doc;
     if (doc2 == NULL) {
         fprintf(stderr, "`AMcreate()` failure.");
-        AMresultFree(card1_result);
-        AMresultFree(cards_result);
-        AMfree(doc1);
+        AMfree(card1_result);
+        AMfree(cards_result);
+        AMfree(doc1_result);
         exit(EXIT_FAILURE);
     }
     result = AMmerge(doc2, doc1);
     test(result, AM_VALUE_CHANGE_HASHES);
-    AMresultFree(result);
-    AMfree(doc2);
+    AMfree(result);
+    AMfree(doc2_result);
 
     AMresult* const save_result = AMsave(doc1);
     value = test(save_result, AM_VALUE_BYTES);
     AMbyteSpan binary = value.bytes;
-    doc2 = AMload(binary.src, binary.count);
-    AMresultFree(save_result);
+    doc2_result = AMload(binary.src, binary.count);
+    doc2 = AMresultValue(doc2_result, 0).doc;
+    AMfree(save_result);
     if (doc2 == NULL) {
         fprintf(stderr, "`AMload()` failure.");
-        AMresultFree(card1_result);
-        AMresultFree(cards_result);
-        AMfree(doc1);
+        AMfree(card1_result);
+        AMfree(cards_result);
+        AMfree(doc1_result);
         exit(EXIT_FAILURE);
     }
 
     result = AMmapPutBool(doc1, card1, "done", true);
     test(result, AM_VALUE_VOID);
-    AMresultFree(result);
+    AMfree(result);
     result = AMcommit(doc1, "Mark card as done", NULL);
     test(result, AM_VALUE_CHANGE_HASHES);
-    AMresultFree(result);
-    AMresultFree(card1_result);
+    AMfree(result);
+    AMfree(card1_result);
 
     result = AMlistDelete(doc2, cards, 0);
     test(result, AM_VALUE_VOID);
-    AMresultFree(result);
+    AMfree(result);
     result = AMcommit(doc2, "Delete card", NULL);
     test(result, AM_VALUE_CHANGE_HASHES);
-    AMresultFree(result);
+    AMfree(result);
 
     result = AMmerge(doc1, doc2);
     test(result, AM_VALUE_CHANGE_HASHES);
-    AMresultFree(result);
-    AMfree(doc2);
+    AMfree(result);
+    AMfree(doc2_result);
 
     result = AMgetChanges(doc1, NULL);
     value = test(result, AM_VALUE_CHANGES);
@@ -93,22 +96,22 @@ int main(int argc, char** argv) {
         size_t const size = AMobjSizeAt(doc1, cards, change);
         printf("%s %ld\n", AMchangeMessage(change), size);
     }
-    AMresultFree(result);
-    AMresultFree(cards_result);
-    AMfree(doc1);
+    AMfree(result);
+    AMfree(cards_result);
+    AMfree(doc1_result);
 }
 
 /**
- * \brief Extracts an `AMvalue` struct with discriminant \p value_tag
- *        from \p result or writes a message to `stderr`, frees \p result
- *        and terminates the program.
+ * \brief Extracts a value with the given discriminant from the given result
+ *        or writes a message to `stderr`, frees the given result and
+ *        terminates the program.
  *
 .* \param[in] result A pointer to an `AMresult` struct.
- * \param[in] value_tag An `AMvalue` struct discriminant.
+ * \param[in] discriminant An `AMvalueVariant` enum tag.
  * \return An `AMvalue` struct.
  * \pre \p result must be a valid address.
  */
-AMvalue test(AMresult* result, AMvalueVariant const value_tag) {
+AMvalue test(AMresult* result, AMvalueVariant const discriminant) {
     static char prelude[64];
 
     if (result == NULL) {
@@ -123,11 +126,11 @@ AMvalue test(AMresult* result, AMvalueVariant const value_tag) {
             default: sprintf(prelude, "Unknown `AMstatus` tag %d", status);
         }
         fprintf(stderr, "%s; %s.", prelude, AMerrorMessage(result));
-        AMresultFree(result);
+        AMfree(result);
         exit(EXIT_FAILURE);
     }
     AMvalue const value = AMresultValue(result, 0);
-    if (value.tag != value_tag) {
+    if (value.tag != discriminant) {
         char const* label = NULL;
         switch (value.tag) {
             case AM_VALUE_ACTOR_ID:      label = "AM_VALUE_ACTOR_ID";      break;
@@ -147,7 +150,7 @@ AMvalue test(AMresult* result, AMvalueVariant const value_tag) {
             default:                     label = "<unknown>";
         }
         fprintf(stderr, "Unexpected `AMvalueVariant` tag `%s` (%d).", label, value.tag);
-        AMresultFree(result);
+        AMfree(result);
         exit(EXIT_FAILURE);
     }
     return value;

--- a/automerge-c/src/byte_span.rs
+++ b/automerge-c/src/byte_span.rs
@@ -6,7 +6,7 @@ use automerge as am;
 #[repr(C)]
 pub struct AMbyteSpan {
     /// A pointer to an array of bytes.
-    /// \warning \p src is only valid until the `AMresultFree()` function is
+    /// \warning \p src is only valid until the `AMfree()` function is
     ///          called on the `AMresult` struct hosting the array of bytes to
     ///          which it points.
     src: *const u8,

--- a/automerge-c/src/change.rs
+++ b/automerge-c/src/change.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn AMchangeActorId(change: *const AMchange) -> AMbyteSpan 
 }
 
 /// \memberof AMchange
-/// \brief Compresses the raw bytes within an `AMchange` struct.
+/// \brief Compresses the raw bytes of a change.
 ///
 /// \param[in] change A pointer to an `AMchange` struct.
 /// \pre \p change must be a valid address.
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn AMchangeExtraBytes(change: *const AMchange) -> AMbyteSp
 }
 
 /// \memberof AMchange
-/// \brief Loads a change as bytes into an `AMchange` struct.
+/// \brief Loads a sequence of bytes into a change.
 ///
 /// \param[in] src A pointer to an array of bytes.
 /// \param[in] count The number of bytes in \p src to load.
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn AMchangeExtraBytes(change: *const AMchange) -> AMbyteSp
 /// \pre \p src must be a valid address.
 /// \pre `0 <=` \p count `<=` length of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -156,7 +156,7 @@ pub unsafe extern "C" fn AMchangeHash(change: *const AMchange) -> AMbyteSpan {
 }
 
 /// \memberof AMchange
-/// \brief Gets the emptiness of a change.
+/// \brief Tests the emptiness of a change.
 ///
 /// \param[in] change A pointer to an `AMchange` struct.
 /// \return A boolean.
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn AMchangeRawBytes(change: *const AMchange) -> AMbyteSpan
 }
 
 /// \memberof AMchange
-/// \brief Loads a document into a sequence of `AMchange` structs.
+/// \brief Loads a document into a sequence of changes.
 ///
 /// \param[in] src A pointer to an array of bytes.
 /// \param[in] count The number of bytes in \p src to load.
@@ -318,7 +318,7 @@ pub unsafe extern "C" fn AMchangeRawBytes(change: *const AMchange) -> AMbyteSpan
 /// \pre \p src must be a valid address.
 /// \pre `0 <=` \p count `<=` length of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety

--- a/automerge-c/src/change_hashes.rs
+++ b/automerge-c/src/change_hashes.rs
@@ -81,8 +81,8 @@ impl Default for AMchangeHashes {
 }
 
 /// \memberof AMchangeHashes
-/// \brief Advances/rewinds an `AMchangeHashes` struct by at most \p |n|
-/// positions.
+/// \brief Advances/rewinds an iterator over a sequence of change hashes by at
+///        most \p |n| positions.
 ///
 /// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
@@ -100,7 +100,8 @@ pub unsafe extern "C" fn AMchangeHashesAdvance(change_hashes: *mut AMchangeHashe
 }
 
 /// \memberof AMchangeHashes
-/// \brief Compares two change hash sequences.
+/// \brief Compares the sequences of change hashes underlying a pair of
+///        iterators.
 ///
 /// \param[in] change_hashes1 A pointer to an `AMchangeHashes` struct.
 /// \param[in] change_hashes2 A pointer to an `AMchangeHashes` struct.
@@ -134,15 +135,15 @@ pub unsafe extern "C" fn AMchangeHashesCmp(
 }
 
 /// \memberof AMchangeHashes
-/// \brief Gets the `AMbyteSpan` struct at the current position of an
-/// `AMchangeHashes`struct and then advances/rewinds it by at most \p |n|
-/// positions.
+/// \brief Gets the change hash at the current position of an iterator over
+///        a sequence of change hashes and then advances/rewinds it by at most
+///        \p |n| positions.
 ///
 /// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
 ///              number of positions to advance/rewind.
-/// \return An `AMbyteSpan` struct that's `NULL` when \p change_hashes was
-///         previously advanced/rewound past its forward/backward limit.
+/// \return An `AMbyteSpan` struct with `.src == NULL` when \p change_hashes
+///         was previously advanced/rewound past its forward/backward limit.
 /// \pre \p change_hashes must be a valid address.
 /// \internal
 ///
@@ -162,13 +163,14 @@ pub unsafe extern "C" fn AMchangeHashesNext(
 }
 
 /// \memberof AMchangeHashes
-/// \brief Advances/rewinds an `AMchangeHashes` struct by at most \p |n|
-/// positions and then gets the `AMbyteSpan` struct at its current position.
+/// \brief Advances/rewinds an iterator over a sequence of change hashes by at
+///        most \p |n| positions and then gets the change hash at its current
+///        position.
 ///
 /// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
 ///              number of positions to advance/rewind.
-/// \return An `AMbyteSpan` struct that's `NULL` when \p change_hashes is
+/// \return An `AMbyteSpan` struct that's null when \p change_hashes is
 ///         presently advanced/rewound past its forward/backward limit.
 /// \pre \p change_hashes must be a valid address.
 /// \internal
@@ -189,7 +191,8 @@ pub unsafe extern "C" fn AMchangeHashesPrev(
 }
 
 /// \memberof AMchangeHashes
-/// \brief Gets the size of an `AMchangeHashes` struct.
+/// \brief Gets the size of the sequence of change hashes underlying an
+///        iterator.
 ///
 /// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \return The count of values in \p change_hashes.

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -100,8 +100,8 @@ impl Default for AMchanges {
 }
 
 /// \memberof AMchanges
-/// \brief Advances/rewinds an `AMchanges` struct by at most \p |n|
-/// positions.
+/// \brief Advances/rewinds an iterator over a sequence of changes by at most
+///        \p |n| positions.
 ///
 /// \param[in] changes A pointer to an `AMchanges` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
@@ -119,7 +119,8 @@ pub unsafe extern "C" fn AMchangesAdvance(changes: *mut AMchanges, n: isize) {
 }
 
 /// \memberof AMchanges
-/// \brief Compares two change sequences for equality.
+/// \brief Tests the equality of two sequences of changes underlying a pair
+///        of iterators.
 ///
 /// \param[in] changes1 A pointer to an `AMchanges` struct.
 /// \param[in] changes2 A pointer to an `AMchanges` struct.
@@ -143,8 +144,8 @@ pub unsafe extern "C" fn AMchangesEqual(
 }
 
 /// \memberof AMchanges
-/// \brief Gets a pointer to the `AMchange` struct at the current position of
-///        an `AMchanges`struct and then advances/rewinds it by at most \p |n|
+/// \brief Gets the change at the current position of an iterator over a
+///        sequence of changes and then advances/rewinds it by at most \p |n|
 ///        positions.
 ///
 /// \param[in] changes A pointer to an `AMchanges` struct.
@@ -168,9 +169,8 @@ pub unsafe extern "C" fn AMchangesNext(changes: *mut AMchanges, n: isize) -> *co
 }
 
 /// \memberof AMchanges
-/// \brief Advances/rewinds an `AMchanges` struct by at most \p |n|
-///        positions and then gets a pointer to the `AMchange` struct at its
-///        current position.
+/// \brief Advances/rewinds an iterator over a sequence of changes by at most
+///        \p |n| positions and then gets the change at its current position.
 ///
 /// \param[in] changes A pointer to an `AMchanges` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
@@ -193,7 +193,7 @@ pub unsafe extern "C" fn AMchangesPrev(changes: *mut AMchanges, n: isize) -> *co
 }
 
 /// \memberof AMchanges
-/// \brief Gets the size of an `AMchanges` struct.
+/// \brief Gets the size of the sequence of changes underlying an iterator.
 ///
 /// \param[in] changes A pointer to an `AMchanges` struct.
 /// \return The count of values in \p changes.

--- a/automerge-c/src/doc/list.rs
+++ b/automerge-c/src/doc/list.rs
@@ -16,7 +16,7 @@ use crate::result::{to_result, AMresult};
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn AMlistDelete(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn AMlistGet(
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn AMlistPutBool(
 }
 
 /// \memberof AMdoc
-/// \brief Puts an array of bytes as the value at an index in a list object.
+/// \brief Puts a sequence of bytes as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn AMlistPutBool(
 /// \pre \p value must be a valid address.
 /// \pre `0 <=` \p count `<=` length of \p value.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn AMlistPutBytes(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn AMlistPutCounter(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn AMlistPutF64(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn AMlistPutInt(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn AMlistPutNull(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -332,7 +332,7 @@ pub unsafe extern "C" fn AMlistPutObject(
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \pre \p value must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -370,7 +370,7 @@ pub unsafe extern "C" fn AMlistPutStr(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -407,7 +407,7 @@ pub unsafe extern "C" fn AMlistPutTimestamp(
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety

--- a/automerge-c/src/doc/map.rs
+++ b/automerge-c/src/doc/map.rs
@@ -17,7 +17,7 @@ use crate::result::{to_result, AMresult};
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn AMmapDelete(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn AMmapGet(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn AMmapPutBool(
 }
 
 /// \memberof AMdoc
-/// \brief Puts an array of bytes as the value of a key in a map object.
+/// \brief Puts a sequence of bytes as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn AMmapPutBool(
 /// \pre \p value must be a valid address.
 /// \pre `0 <=` \p count `<=` length of \p value.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn AMmapPutBytes(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn AMmapPutCounter(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn AMmapPutNull(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn AMmapPutObject(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -255,7 +255,7 @@ pub unsafe extern "C" fn AMmapPutF64(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -285,7 +285,7 @@ pub unsafe extern "C" fn AMmapPutInt(
 /// \pre \p key must be a valid address.
 /// \pre \p value must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -315,7 +315,7 @@ pub unsafe extern "C" fn AMmapPutStr(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn AMmapPutTimestamp(
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -33,7 +33,7 @@ impl AMsyncHaves {
     pub fn advance(&mut self, n: isize) {
         let len = self.len as isize;
         if n != 0 && self.offset >= -len && self.offset < len {
-            // It's being advanced and it's hasn't stopped.
+            // It's being advanced and its hasn't stopped.
             self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
         };
     }
@@ -100,8 +100,8 @@ impl Default for AMsyncHaves {
 }
 
 /// \memberof AMsyncHaves
-/// \brief Advances/rewinds an `AMsyncHaves` struct by at most \p |n|
-/// positions.
+/// \brief Advances/rewinds an iterator over a sequence of synchronization
+///        haves by at most \p |n| positions.
 ///
 /// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
@@ -119,15 +119,40 @@ pub unsafe extern "C" fn AMsyncHavesAdvance(sync_haves: *mut AMsyncHaves, n: isi
 }
 
 /// \memberof AMsyncHaves
-/// \brief Gets a pointer to the `AMsyncHave` struct at the current position of
-///        an `AMsyncHaves`struct and then advances/rewinds it by at most \p |n|
-///        positions.
+/// \brief Tests the equality of two sequences of synchronization haves
+///        underlying a pair of iterators.
+///
+/// \param[in] sync_haves1 A pointer to an `AMsyncHaves` struct.
+/// \param[in] sync_haves2 A pointer to an `AMsyncHaves` struct.
+/// \return `true` if \p sync_haves1 `==` \p sync_haves2 and `false` otherwise.
+/// \pre \p sync_haves1 must be a valid address.
+/// \pre \p sync_haves2 must be a valid address.
+/// \internal
+///
+/// #Safety
+/// sync_haves1 must be a pointer to a valid AMsyncHaves
+/// sync_haves2 must be a pointer to a valid AMsyncHaves
+#[no_mangle]
+pub unsafe extern "C" fn AMsyncHavesEqual(
+    sync_haves1: *const AMsyncHaves,
+    sync_haves2: *const AMsyncHaves,
+) -> bool {
+    match (sync_haves1.as_ref(), sync_haves2.as_ref()) {
+        (Some(sync_haves1), Some(sync_haves2)) => sync_haves1.as_ref() == sync_haves2.as_ref(),
+        (None, Some(_)) | (Some(_), None) | (None, None) => false,
+    }
+}
+
+/// \memberof AMsyncHaves
+/// \brief Gets the synchronization have at the current position of an iterator
+///        over a sequence of synchronization haves and then advances/rewinds
+///        it by at most \p |n| positions.
 ///
 /// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
 ///              number of positions to advance/rewind.
-/// \return A pointer to an `AMsyncHave` struct that's `NULL` when \p sync_haves
-///         was previously advanced/rewound past its
+/// \return A pointer to an `AMsyncHave` struct that's `NULL` when
+///         \p sync_haves was previously advanced/rewound past its
 ///         forward/backward limit.
 /// \pre \p sync_haves must be a valid address.
 /// \internal
@@ -148,9 +173,9 @@ pub unsafe extern "C" fn AMsyncHavesNext(
 }
 
 /// \memberof AMsyncHaves
-/// \brief Advances/rewinds an `AMsyncHaves` struct by at most \p |n|
-///        positions and then gets a pointer to the `AMsyncHave` struct at its
-///        current position.
+/// \brief Advances/rewinds an iterator over a sequence of synchronization
+///        haves by at most \p |n| positions and then gets the synchronization
+///        have at its current position.
 ///
 /// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \param[in] n The direction (\p -n -> backward, \p +n -> forward) and maximum
@@ -177,7 +202,8 @@ pub unsafe extern "C" fn AMsyncHavesPrev(
 }
 
 /// \memberof AMsyncHaves
-/// \brief Gets the size of an `AMsyncHaves` struct.
+/// \brief Gets the size of the sequence of synchronization haves underlying an
+///        iterator.
 ///
 /// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \return The count of values in \p sync_haves.

--- a/automerge-c/src/sync/message.rs
+++ b/automerge-c/src/sync/message.rs
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn AMsyncMessageChanges(sync_message: *const AMsyncMessage
 }
 
 /// \memberof AMsyncMessage
-/// \brief Decodes an array of bytes into a synchronization message.
+/// \brief Decodes a sequence of bytes into a synchronization message.
 ///
 /// \param[in] src A pointer to an array of bytes.
 /// \param[in] count The number of bytes in \p src to decode.
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn AMsyncMessageChanges(sync_message: *const AMsyncMessage
 /// \pre \p src must be a valid address.
 /// \pre `0 <=` \p count `<=` length of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -90,14 +90,14 @@ pub unsafe extern "C" fn AMsyncMessageDecode(src: *const u8, count: usize) -> *m
 }
 
 /// \memberof AMsyncMessage
-/// \brief Encodes a synchronization message as an array of bytes.
+/// \brief Encodes a synchronization message as a sequence of bytes.
 ///
 /// \param[in] sync_message A pointer to an `AMsyncMessage` struct.
 /// \return A pointer to an `AMresult` struct containing an array of bytes as
 ///         an `AMbyteSpan` struct.
 /// \pre \p sync_message must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety

--- a/automerge-c/src/sync/state.rs
+++ b/automerge-c/src/sync/state.rs
@@ -54,7 +54,7 @@ impl From<AMsyncState> for *mut AMsyncState {
 }
 
 /// \memberof AMsyncState
-/// \brief Decodes an array of bytes into a synchronizaton state.
+/// \brief Decodes a sequence of bytes into a synchronizaton state.
 ///
 /// \param[in] src A pointer to an array of bytes.
 /// \param[in] count The number of bytes in \p src to decode.
@@ -63,7 +63,7 @@ impl From<AMsyncState> for *mut AMsyncState {
 /// \pre \p src must be a valid address.
 /// \pre `0 <=` \p count `<=` length of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -76,14 +76,14 @@ pub unsafe extern "C" fn AMsyncStateDecode(src: *const u8, count: usize) -> *mut
 }
 
 /// \memberof AMsyncState
-/// \brief Encodes a synchronizaton state as an array of bytes.
+/// \brief Encodes a synchronizaton state as a sequence of bytes.
 ///
 /// \param[in] sync_state A pointer to an `AMsyncState` struct.
 /// \return A pointer to an `AMresult` struct containing an array of bytes as
 ///         an `AMbyteSpan` struct.
 /// \pre \p sync_state must be a valid address.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
-///          deallocated with `AMresultFree()`.
+///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn AMsyncStateEncode(sync_state: *const AMsyncState) -> *m
 }
 
 /// \memberof AMsyncState
-/// \brief Compares two synchronization states for equality.
+/// \brief Tests the equality of two synchronization states.
 ///
 /// \param[in] sync_state1 A pointer to an `AMsyncState` struct.
 /// \param[in] sync_state2 A pointer to an `AMsyncState` struct.
@@ -119,33 +119,16 @@ pub unsafe extern "C" fn AMsyncStateEqual(
 }
 
 /// \memberof AMsyncState
-/// \brief Deallocates the storage for an `AMsyncState` struct previously
-///        allocated by `AMsyncStateInit()`.
-///
-/// \param[in] sync_state A pointer to an `AMsyncState` struct.
-/// \pre \p sync_state must be a valid address.
-/// \internal
-///
-/// # Safety
-/// sync_state must be a pointer to a valid AMsyncState
-#[no_mangle]
-pub unsafe extern "C" fn AMsyncStateFree(sync_state: *mut AMsyncState) {
-    if !sync_state.is_null() {
-        let sync_state: AMsyncState = *Box::from_raw(sync_state);
-        drop(sync_state)
-    }
-}
-
-/// \memberof AMsyncState
-/// \brief Allocates a new `AMsyncState` struct and initializes it with
+/// \brief Allocates a new synchronization state and initializes it with
 ///        defaults.
 ///
-/// \return A pointer to an `AMsyncState` struct.
-/// \warning To avoid a memory leak, the returned `AMsyncState` struct must be
-///          deallocated with `AMsyncStateFree()`.
+/// \return A pointer to an `AMresult` struct containing a pointer to an
+///         `AMsyncState` struct.
+/// \warning To avoid a memory leak, the returned `AMresult` struct must be
+///          deallocated with `AMfree()`.
 #[no_mangle]
-pub extern "C" fn AMsyncStateInit() -> *mut AMsyncState {
-    AMsyncState::new(am::sync::State::new()).into()
+pub extern "C" fn AMsyncStateInit() -> *mut AMresult {
+    to_result(am::sync::State::new())
 }
 
 /// \memberof AMsyncState

--- a/automerge-c/test/amdoc_property_tests.c
+++ b/automerge-c/test/amdoc_property_tests.c
@@ -61,7 +61,7 @@ static void test_AMputActor(void **state) {
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(res);
+    AMfree(res);
     res = AMgetActor(group_state->doc);
     if (AMresultStatus(res) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(res));
@@ -71,7 +71,7 @@ static void test_AMputActor(void **state) {
     assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
     assert_int_equal(value.actor_id.count, test_state->actor_id_size);
     assert_memory_equal(value.actor_id.src, test_state->actor_id_bytes, value.actor_id.count);
-    AMresultFree(res);
+    AMfree(res);
 }
 
 static void test_AMputActorHex(void **state) {
@@ -87,7 +87,7 @@ static void test_AMputActorHex(void **state) {
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(res);
+    AMfree(res);
     res = AMgetActorHex(group_state->doc);
     if (AMresultStatus(res) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(res));
@@ -97,7 +97,7 @@ static void test_AMputActorHex(void **state) {
     assert_int_equal(value.tag, AM_VALUE_STR);
     assert_int_equal(strlen(value.str), test_state->actor_id_size * 2);
     assert_string_equal(value.str, test_state->actor_id_str);
-    AMresultFree(res);
+    AMfree(res);
 }
 
 int run_AMdoc_property_tests(void) {

--- a/automerge-c/test/amlistput_tests.c
+++ b/automerge-c/test/amlistput_tests.c
@@ -27,7 +27,7 @@ static void test_AMlistPut ## suffix ## _ ## mode(void **state) {             \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
@@ -36,7 +36,7 @@ static void test_AMlistPut ## suffix ## _ ## mode(void **state) {             \
     value = AMresultValue(res, 0);                                            \
     assert_int_equal(value.tag, AMvalue_discriminant(#suffix));               \
     assert_true(value.member == scalar_value);                                \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 #define test_AMlistPutBytes(mode) test_AMlistPutBytes ## _ ## mode
@@ -60,7 +60,7 @@ static void test_AMlistPutBytes_ ## mode(void **state) {                      \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
@@ -70,7 +70,7 @@ static void test_AMlistPutBytes_ ## mode(void **state) {                      \
     assert_int_equal(value.tag, AM_VALUE_BYTES);                              \
     assert_int_equal(value.bytes.count, BYTES_SIZE);                          \
     assert_memory_equal(value.bytes.src, bytes_value, BYTES_SIZE);            \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 #define test_AMlistPutNull(mode) test_AMlistPutNull_ ## mode
@@ -86,7 +86,7 @@ static void test_AMlistPutNull_ ## mode(void **state) {                       \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
@@ -94,7 +94,7 @@ static void test_AMlistPutNull_ ## mode(void **state) {                       \
     assert_int_equal(AMresultSize(res), 1);                                   \
     value = AMresultValue(res, 0);                                            \
     assert_int_equal(value.tag, AM_VALUE_NULL);                               \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 #define test_AMlistPutObject(label, mode) test_AMlistPutObject_ ## label ## _ ## mode
@@ -117,7 +117,7 @@ static void test_AMlistPutObject_ ## label ## _ ## mode(void **state) {       \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
     assert_non_null(value.obj_id);                                            \
     assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 #define test_AMlistPutStr(mode) test_AMlistPutStr ## _ ## mode
@@ -140,7 +140,7 @@ static void test_AMlistPutStr_ ## mode(void **state) {                        \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
@@ -150,7 +150,7 @@ static void test_AMlistPutStr_ ## mode(void **state) {                        \
     assert_int_equal(value.tag, AM_VALUE_STR);                                \
     assert_int_equal(strlen(value.str), STR_LEN);                             \
     assert_memory_equal(value.str, str_value, STR_LEN + 1);                   \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 static_void_test_AMlistPut(Bool, insert, boolean, true)

--- a/automerge-c/test/ammapput_tests.c
+++ b/automerge-c/test/ammapput_tests.c
@@ -30,7 +30,7 @@ static void test_AMmapPut ## suffix(void **state) {                           \
     assert_int_equal(AMresultSize(res), 0);                                   \
     AMvalue value = AMresultValue(res, 0);                                    \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
     res = AMmapGet(group_state->doc, AM_ROOT, #suffix);                       \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
@@ -39,7 +39,7 @@ static void test_AMmapPut ## suffix(void **state) {                           \
     value = AMresultValue(res, 0);                                            \
     assert_int_equal(value.tag, AMvalue_discriminant(#suffix));               \
     assert_true(value.member == scalar_value);                                \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 #define test_AMmapPutObject(label) test_AMmapPutObject_ ## label
@@ -61,7 +61,7 @@ static void test_AMmapPutObject_ ## label(void **state) {                     \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
     assert_non_null(value.obj_id);                                            \
     assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
-    AMresultFree(res);                                                        \
+    AMfree(res);                                                        \
 }
 
 static_void_test_AMmapPut(Bool, boolean, true)
@@ -85,7 +85,7 @@ static void test_AMmapPutBytes(void **state) {
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(res);
+    AMfree(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
     if (AMresultStatus(res) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(res));
@@ -95,7 +95,7 @@ static void test_AMmapPutBytes(void **state) {
     assert_int_equal(value.tag, AM_VALUE_BYTES);
     assert_int_equal(value.bytes.count, BYTES_SIZE);
     assert_memory_equal(value.bytes.src, BYTES_VALUE, BYTES_SIZE);
-    AMresultFree(res);
+    AMfree(res);
 }
 
 static_void_test_AMmapPut(Counter, counter, INT64_MAX)
@@ -115,7 +115,7 @@ static void test_AMmapPutNull(void **state) {
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(res);
+    AMfree(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
     if (AMresultStatus(res) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(res));
@@ -123,7 +123,7 @@ static void test_AMmapPutNull(void **state) {
     assert_int_equal(AMresultSize(res), 1);
     value = AMresultValue(res, 0);
     assert_int_equal(value.tag, AM_VALUE_NULL);
-    AMresultFree(res);
+    AMfree(res);
 }
 
 static_void_test_AMmapPutObject(List)
@@ -150,7 +150,7 @@ static void test_AMmapPutStr(void **state) {
     assert_int_equal(AMresultSize(res), 0);
     AMvalue value = AMresultValue(res, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(res);
+    AMfree(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
     if (AMresultStatus(res) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(res));
@@ -160,7 +160,7 @@ static void test_AMmapPutStr(void **state) {
     assert_int_equal(value.tag, AM_VALUE_STR);
     assert_int_equal(strlen(value.str), STR_LEN);
     assert_memory_equal(value.str, STR_VALUE, STR_LEN + 1);
-    AMresultFree(res);
+    AMfree(res);
 }
 
 static_void_test_AMmapPut(Timestamp, timestamp, INT64_MAX)

--- a/automerge-c/test/group_state.c
+++ b/automerge-c/test/group_state.c
@@ -5,14 +5,15 @@
 
 int group_setup(void** state) {
     GroupState* group_state = calloc(1, sizeof(GroupState));
-    group_state->doc = AMcreate();
+    group_state->doc_result = AMcreate();
+    group_state->doc = AMresultValue(group_state->doc_result, 0).doc;
     *state = group_state;
     return 0;
 }
 
 int group_teardown(void** state) {
     GroupState* group_state = *state;
-    AMfree(group_state->doc);
+    AMfree(group_state->doc_result);
     free(group_state);
     return 0;
 }

--- a/automerge-c/test/group_state.h
+++ b/automerge-c/test/group_state.h
@@ -5,6 +5,7 @@
 #include "automerge.h"
 
 typedef struct {
+    AMresult* doc_result;
     AMdoc* doc;
 } GroupState;
 

--- a/automerge-c/test/macro_utils.h
+++ b/automerge-c/test/macro_utils.h
@@ -5,8 +5,8 @@
 #include "automerge.h"
 
 /**
- * \brief Gets the `AMvalue` struct discriminant corresponding to a function
- *        name suffix.
+ * \brief Gets the result value discriminant corresponding to a function name
+ *        suffix.
  *
  * \param[in] suffix A string.
  * \return An `AMvalue` struct discriminant.
@@ -14,7 +14,7 @@
 AMvalueVariant AMvalue_discriminant(char const* suffix);
 
 /**
- * \brief Gets the `AMobjType` enum tag corresponding to an object type label.
+ * \brief Gets the object type tag corresponding to an object type label.
  *
  * \param[in] obj_type_label A string.
  * \return An `AMobjType` enum tag.

--- a/automerge-c/test/sync_tests.c
+++ b/automerge-c/test/sync_tests.c
@@ -11,28 +11,36 @@
 #include "automerge.h"
 
 typedef struct {
+    AMresult* doc1_result;
     AMdoc* doc1;
+    AMresult* doc2_result;
     AMdoc* doc2;
+    AMresult* sync_state1_result;
     AMsyncState* sync_state1;
+    AMresult* sync_state2_result;
     AMsyncState* sync_state2;
 } TestState;
 
 static int setup(void** state) {
     TestState* test_state = calloc(1, sizeof(TestState));
-    test_state->doc1 = AMcreate();
-    test_state->doc2 = AMcreate();
-    test_state->sync_state1 = AMsyncStateInit();
-    test_state->sync_state2 = AMsyncStateInit();
+    test_state->doc1_result = AMcreate();
+    test_state->doc1 = AMresultValue(test_state->doc1_result, 0).doc;
+    test_state->doc2_result = AMcreate();
+    test_state->doc2 = AMresultValue(test_state->doc2_result, 0).doc;
+    test_state->sync_state1_result = AMsyncStateInit();
+    test_state->sync_state1 = AMresultValue(test_state->sync_state1_result, 0).sync_state;
+    test_state->sync_state2_result = AMsyncStateInit();
+    test_state->sync_state2 = AMresultValue(test_state->sync_state2_result, 0).sync_state;
     *state = test_state;
     return 0;
 }
 
 static int teardown(void** state) {
     TestState* test_state = *state;
-    AMfree(test_state->doc1);
-    AMfree(test_state->doc2);
-    AMsyncStateFree(test_state->sync_state1);
-    AMsyncStateFree(test_state->sync_state2);
+    AMfree(test_state->doc1_result);
+    AMfree(test_state->doc2_result);
+    AMfree(test_state->sync_state1_result);
+    AMfree(test_state->sync_state2_result);
     free(test_state);
     return 0;
 }
@@ -53,7 +61,7 @@ static void sync(AMdoc* a,
         switch (value.tag) {
             case AM_VALUE_SYNC_MESSAGE: {
                 a2b_msg = value.sync_message;
-                AMresultFree(AMreceiveSyncMessage(b, b_sync_state, a2b_msg));
+                AMfree(AMreceiveSyncMessage(b, b_sync_state, a2b_msg));
             }
             break;
             case AM_VALUE_VOID: a2b_msg = NULL; break;
@@ -62,7 +70,7 @@ static void sync(AMdoc* a,
         switch (value.tag) {
             case AM_VALUE_SYNC_MESSAGE: {
                 b2a_msg = value.sync_message;
-                AMresultFree(AMreceiveSyncMessage(a, a_sync_state, b2a_msg));
+                AMfree(AMreceiveSyncMessage(a, a_sync_state, b2a_msg));
             }
             break;
             case AM_VALUE_VOID: b2a_msg = NULL; break;
@@ -101,7 +109,7 @@ static void test_converged_empty_local_doc_reply_no_local_data(void **state) {
     assert_int_equal(AMchangeHashesSize(&last_sync), 0);
     AMchanges changes = AMsyncMessageChanges(sync_message);
     assert_int_equal(AMchangesSize(&changes), 0);
-    AMresultFree(sync_message_result);
+    AMfree(sync_message_result);
 }
 
 /**
@@ -110,14 +118,14 @@ static void test_converged_empty_local_doc_reply_no_local_data(void **state) {
  */
 static void test_converged_empty_local_doc_no_reply(void **state) {
     TestState* test_state = *state;
-    AMresult* sync_message_result1 = AMgenerateSyncMessage(
+    AMresult* sync_message1_result = AMgenerateSyncMessage(
         test_state->doc1, test_state->sync_state1
     );
-    if (AMresultStatus(sync_message_result1) != AM_STATUS_OK) {
-        fail_msg("%s", AMerrorMessage(sync_message_result1));
+    if (AMresultStatus(sync_message1_result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(sync_message1_result));
     }
-    assert_int_equal(AMresultSize(sync_message_result1), 1);
-    AMvalue value = AMresultValue(sync_message_result1, 0);
+    assert_int_equal(AMresultSize(sync_message1_result), 1);
+    AMvalue value = AMresultValue(sync_message1_result, 0);
     assert_int_equal(value.tag, AM_VALUE_SYNC_MESSAGE);
     AMsyncMessage const* sync_message1 = value.sync_message;
     AMresult* result = AMreceiveSyncMessage(
@@ -129,18 +137,18 @@ static void test_converged_empty_local_doc_no_reply(void **state) {
     assert_int_equal(AMresultSize(result), 0);
     value = AMresultValue(result, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(result);
-    AMresult* sync_message_result2 = AMgenerateSyncMessage(
+    AMfree(result);
+    AMresult* sync_message2_result = AMgenerateSyncMessage(
         test_state->doc2, test_state->sync_state2
     );
-    if (AMresultStatus(sync_message_result2) != AM_STATUS_OK) {
-        fail_msg("%s", AMerrorMessage(sync_message_result2));
+    if (AMresultStatus(sync_message2_result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(sync_message2_result));
     }
-    assert_int_equal(AMresultSize(sync_message_result2), 0);
-    value = AMresultValue(sync_message_result2, 0);
+    assert_int_equal(AMresultSize(sync_message2_result), 0);
+    value = AMresultValue(sync_message2_result, 0);
     assert_int_equal(value.tag, AM_VALUE_VOID);
-    AMresultFree(sync_message_result2);
-    AMresultFree(sync_message_result1);
+    AMfree(sync_message2_result);
+    AMfree(sync_message1_result);
 }
 
 /**
@@ -153,37 +161,37 @@ static void test_converged_equal_heads_no_reply(void **state) {
     /* Make two nodes with the same changes. */
     time_t const time = 0;
     for (size_t index = 0; index != 10; ++index) {
-        AMresultFree(AMlistPutUint(test_state->doc1, AM_ROOT, index, true, index));
+        AMfree(AMlistPutUint(test_state->doc1, AM_ROOT, index, true, index));
         AMcommit(test_state->doc1, NULL, &time);
     }
     AMresult* changes_result = AMgetChanges(test_state->doc1, NULL);
     AMvalue value = AMresultValue(changes_result, 0);
-    AMresultFree(AMapplyChanges(test_state->doc2, &value.changes));
-    AMresultFree(changes_result);
+    AMfree(AMapplyChanges(test_state->doc2, &value.changes));
+    AMfree(changes_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 
     /* Generate a naive sync message. */
-    AMresult* sync_message_result1 = AMgenerateSyncMessage(
+    AMresult* sync_message1_result = AMgenerateSyncMessage(
         test_state->doc1,
         test_state->sync_state1
     );
-    AMsyncMessage const* sync_message1 = AMresultValue(sync_message_result1, 0).sync_message;
+    AMsyncMessage const* sync_message1 = AMresultValue(sync_message1_result, 0).sync_message;
     AMchangeHashes last_sent_heads = AMsyncStateLastSentHeads(test_state->sync_state1);
     AMresult* heads_result = AMgetHeads(test_state->doc1);
     AMchangeHashes heads = AMresultValue(heads_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&last_sent_heads, &heads), 0);
-    AMresultFree(heads_result);
+    AMfree(heads_result);
 
     /* Heads are equal so this message should be void. */
-    AMresultFree(AMreceiveSyncMessage(
+    AMfree(AMreceiveSyncMessage(
         test_state->doc2, test_state->sync_state2, sync_message1
     ));
-    AMresultFree(sync_message_result1);
-    AMresult* sync_message_result2 = AMgenerateSyncMessage(
+    AMfree(sync_message1_result);
+    AMresult* sync_message2_result = AMgenerateSyncMessage(
         test_state->doc2, test_state->sync_state2
     );
-    assert_int_equal(AMresultValue(sync_message_result2, 0).tag, AM_VALUE_VOID);
-    AMresultFree(sync_message_result2);
+    assert_int_equal(AMresultValue(sync_message2_result, 0).tag, AM_VALUE_VOID);
+    AMfree(sync_message2_result);
 }
 
 /**
@@ -197,7 +205,7 @@ static void test_converged_offer_all_changes_from_nothing(void **state) {
     /* Make changes for the first node that the second node should request. */
     time_t const time = 0;
     for (size_t index = 0; index != 10; ++index) {
-        AMresultFree(AMlistPutUint(test_state->doc1, AM_ROOT, index, true, index));
+        AMfree(AMlistPutUint(test_state->doc1, AM_ROOT, index, true, index));
         AMcommit(test_state->doc1, NULL, &time);
     }
 
@@ -219,7 +227,7 @@ static void test_converged_sync_peers_with_uneven_commits(void **state) {
     /* Make changes for the first node that the second node should request. */
     time_t const time = 0;
     for (size_t index = 0; index != 10; ++index) {
-        AMresultFree(AMlistPutUint(test_state->doc1, AM_ROOT, index, true, index));
+        AMfree(AMlistPutUint(test_state->doc1, AM_ROOT, index, true, index));
         AMcommit(test_state->doc1, NULL, &time);
     }
 
@@ -241,7 +249,7 @@ static void test_converged_works_with_prior_sync_state(void **state) {
 
     time_t const time = 0;
     for (size_t value = 0; value != 5; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -251,7 +259,7 @@ static void test_converged_works_with_prior_sync_state(void **state) {
 
     /* Modify the first node further. */
     for (size_t value = 5; value != 10; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
 
@@ -270,14 +278,14 @@ static void test_converged_works_with_prior_sync_state(void **state) {
 static void test_converged_no_message_once_synced(void **state) {
     /* Create & synchronize two nodes. */
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "abc123"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "def456"));
+    AMfree(AMsetActorHex(test_state->doc1, "abc123"));
+    AMfree(AMsetActorHex(test_state->doc2, "def456"));
 
     time_t const time = 0;
     for (size_t value = 0; value != 5; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
-        AMresultFree(AMmapPutUint(test_state->doc2, AM_ROOT, "y", value));
+        AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "y", value));
         AMcommit(test_state->doc2, NULL, &time);
     }
 
@@ -288,10 +296,10 @@ static void test_converged_no_message_once_synced(void **state) {
 
     /* The second node receives that message and sends changes along with what
      * it has. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc2,
+    AMfree(AMreceiveSyncMessage(test_state->doc2,
                                       test_state->sync_state2,
                                       message));
-    AMresultFree(message_result);
+    AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
     message = AMresultValue(message_result, 0).sync_message;
@@ -300,10 +308,10 @@ static void test_converged_no_message_once_synced(void **state) {
 
     /* The first node receives the changes and replies with the changes it now
      * knows that the second node needs. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc1,
+    AMfree(AMreceiveSyncMessage(test_state->doc1,
                                       test_state->sync_state1,
                                       message));
-    AMresultFree(message_result);
+    AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
     message = AMresultValue(message_result, 0).sync_message;
@@ -312,29 +320,29 @@ static void test_converged_no_message_once_synced(void **state) {
 
     /* The second node applies the changes and sends confirmation ending the
      * exchange. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc2,
+    AMfree(AMreceiveSyncMessage(test_state->doc2,
                                       test_state->sync_state2,
                                       message));
-    AMresultFree(message_result);
+    AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
     message = AMresultValue(message_result, 0).sync_message;
 
     /* The first node receives the message and has nothing more to say. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc1,
+    AMfree(AMreceiveSyncMessage(test_state->doc1,
                                       test_state->sync_state1,
                                       message));
-    AMresultFree(message_result);
+    AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
     assert_int_equal(AMresultValue(message_result, 0).tag, AM_VALUE_VOID);
-    AMresultFree(message_result);
+    AMfree(message_result);
 
     /* The second node also has nothing left to say. */
     message_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
     assert_int_equal(AMresultValue(message_result, 0).tag, AM_VALUE_VOID);
-    AMresultFree(message_result);
+    AMfree(message_result);
 }
 
 /**
@@ -344,21 +352,21 @@ static void test_converged_no_message_once_synced(void **state) {
 static void test_converged_allow_simultaneous_messages(void **state) {
     /* Create & synchronize two nodes. */
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "abc123"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "def456"));
+    AMfree(AMsetActorHex(test_state->doc1, "abc123"));
+    AMfree(AMsetActorHex(test_state->doc2, "def456"));
 
     time_t const time = 0;
     for (size_t value = 0; value != 5; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
-        AMresultFree(AMmapPutUint(test_state->doc2, AM_ROOT, "y", value));
+        AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "y", value));
         AMcommit(test_state->doc2, NULL, &time);
     }
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
     AMbyteSpan head1 = AMchangeHashesNext(&heads1, 1);
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     AMbyteSpan head2 = AMchangeHashesNext(&heads2, 1);
 
     /* Both sides report what they have but have no shared peer state. */
@@ -383,14 +391,14 @@ static void test_converged_allow_simultaneous_messages(void **state) {
 
     /* Both nodes receive messages from each other and update their
      * synchronization states. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc1,
+    AMfree(AMreceiveSyncMessage(test_state->doc1,
                                       test_state->sync_state1,
                                       msg2to1));
-    AMresultFree(msg2to1_result);
-    AMresultFree(AMreceiveSyncMessage(test_state->doc2,
+    AMfree(msg2to1_result);
+    AMfree(AMreceiveSyncMessage(test_state->doc2,
                                       test_state->sync_state2,
                                       msg1to2));
-    AMresultFree(msg1to2_result);
+    AMfree(msg1to2_result);
 
     /* Now both reply with their local changes that the other lacks
      * (standard warning that 1% of the time this will result in a "needs"
@@ -407,35 +415,35 @@ static void test_converged_allow_simultaneous_messages(void **state) {
     assert_int_equal(AMchangesSize(&msg2to1_changes), 5);
 
     /* Both should now apply the changes. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc1,
+    AMfree(AMreceiveSyncMessage(test_state->doc1,
                                       test_state->sync_state1,
                                       msg2to1));
-    AMresultFree(msg2to1_result);
+    AMfree(msg2to1_result);
     AMresult* missing_deps_result = AMgetMissingDeps(test_state->doc1, NULL);
     AMchangeHashes missing_deps = AMresultValue(missing_deps_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesSize(&missing_deps), 0);
-    AMresultFree(missing_deps_result);
+    AMfree(missing_deps_result);
     AMresult* map_value_result = AMmapGet(test_state->doc1, AM_ROOT, "x");
     assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
-    AMresultFree(map_value_result);
+    AMfree(map_value_result);
     map_value_result = AMmapGet(test_state->doc1, AM_ROOT, "y");
     assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
-    AMresultFree(map_value_result);
+    AMfree(map_value_result);
 
-    AMresultFree(AMreceiveSyncMessage(test_state->doc2,
+    AMfree(AMreceiveSyncMessage(test_state->doc2,
                                       test_state->sync_state2,
                                       msg1to2));
-    AMresultFree(msg1to2_result);
+    AMfree(msg1to2_result);
     missing_deps_result = AMgetMissingDeps(test_state->doc2, NULL);
     missing_deps = AMresultValue(missing_deps_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesSize(&missing_deps), 0);
-    AMresultFree(missing_deps_result);
+    AMfree(missing_deps_result);
     map_value_result = AMmapGet(test_state->doc2, AM_ROOT, "x");
     assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
-    AMresultFree(map_value_result);
+    AMfree(map_value_result);
     map_value_result = AMmapGet(test_state->doc2, AM_ROOT, "y");
     assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
-    AMresultFree(map_value_result);
+    AMfree(map_value_result);
 
     /* The response acknowledges that the changes were received and sends no
      * further changes. */
@@ -451,28 +459,28 @@ static void test_converged_allow_simultaneous_messages(void **state) {
     assert_int_equal(AMchangesSize(&msg2to1_changes), 0);
 
     /* After receiving acknowledgements their shared heads should be equal. */
-    AMresultFree(AMreceiveSyncMessage(test_state->doc1,
+    AMfree(AMreceiveSyncMessage(test_state->doc1,
                                       test_state->sync_state1,
                                       msg2to1));
-    AMresultFree(msg2to1_result);
-    AMresultFree(AMreceiveSyncMessage(test_state->doc2,
+    AMfree(msg2to1_result);
+    AMfree(AMreceiveSyncMessage(test_state->doc2,
                                       test_state->sync_state2,
                                       msg1to2));
-    AMresultFree(msg1to2_result);
+    AMfree(msg1to2_result);
 
     /* They're synchronized so no more messages are required. */
     msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
     assert_int_equal(AMresultValue(msg1to2_result, 0).tag, AM_VALUE_VOID);
-    AMresultFree(msg1to2_result);
+    AMfree(msg1to2_result);
     msg2to1_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
     assert_int_equal(AMresultValue(msg2to1_result, 0).tag, AM_VALUE_VOID);
-    AMresultFree(msg2to1_result);
+    AMfree(msg2to1_result);
 
     /* If we make one more change and start synchronizing then its "last
      * sync" property should be updated. */
-    AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 5));
+    AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 5));
     AMcommit(test_state->doc1, NULL, &time);
     msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
@@ -486,9 +494,9 @@ static void test_converged_allow_simultaneous_messages(void **state) {
     msg1to2_last_sync_next = AMchangeHashesNext(&msg1to2_last_sync, 1);
     assert_int_equal(msg1to2_last_sync_next.count, head2.count);
     assert_memory_equal(msg1to2_last_sync_next.src, head2.src, head2.count);
-    AMresultFree(heads_result1);
-    AMresultFree(heads_result2);
-    AMresultFree(msg1to2_result);
+    AMfree(heads1_result);
+    AMfree(heads2_result);
+    AMfree(msg1to2_result);
 }
 
 /**
@@ -497,8 +505,8 @@ static void test_converged_allow_simultaneous_messages(void **state) {
  */
 static void test_converged_assume_sent_changes_were_received(void **state) {
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
 
     AMresult* items_result = AMmapPutObject(test_state->doc1,
                                             AM_ROOT,
@@ -512,34 +520,34 @@ static void test_converged_assume_sent_changes_were_received(void **state) {
          test_state->sync_state1,
          test_state->sync_state2);
 
-    AMresultFree(AMlistPutStr(test_state->doc1, items, 0, true, "x"));
+    AMfree(AMlistPutStr(test_state->doc1, items, 0, true, "x"));
     AMcommit(test_state->doc1, NULL, &time);
     AMresult* message_result = AMgenerateSyncMessage(test_state->doc1,
                                                      test_state->sync_state1);
     AMsyncMessage const* message = AMresultValue(message_result, 0).sync_message;
     AMchanges message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 1);
-    AMresultFree(message_result);
+    AMfree(message_result);
 
-    AMresultFree(AMlistPutStr(test_state->doc1, items, 1, true, "y"));
+    AMfree(AMlistPutStr(test_state->doc1, items, 1, true, "y"));
     AMcommit(test_state->doc1, NULL, &time);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
     message = AMresultValue(message_result, 0).sync_message;
     message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 1);
-    AMresultFree(message_result);
+    AMfree(message_result);
 
-    AMresultFree(AMlistPutStr(test_state->doc1, items, 2, true, "z"));
+    AMfree(AMlistPutStr(test_state->doc1, items, 2, true, "z"));
     AMcommit(test_state->doc1, NULL, &time);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
     message = AMresultValue(message_result, 0).sync_message;
     message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 1);
-    AMresultFree(message_result);
+    AMfree(message_result);
 
-    AMresultFree(items_result);
+    AMfree(items_result);
 }
 
 /**
@@ -552,7 +560,7 @@ static void test_converged_works_regardless_of_who_initiates(void **state) {
 
     time_t const time = 0;
     for (size_t value = 0; value != 5; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -562,7 +570,7 @@ static void test_converged_works_regardless_of_who_initiates(void **state) {
 
     /* Modify the first node further. */
     for (size_t value = 5; value != 10; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
 
@@ -587,11 +595,11 @@ static void test_diverged_works_without_prior_sync_state(void **state) {
 
     /* Create two peers both with divergent commits. */
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
     time_t const time = 0;
     for (size_t value = 0; value != 10; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
 
@@ -601,11 +609,11 @@ static void test_diverged_works_without_prior_sync_state(void **state) {
          test_state->sync_state2);
 
     for (size_t value = 10; value != 15; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     for (size_t value = 15; value != 18; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc2, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "x", value));
         AMcommit(test_state->doc2, NULL, &time);
     }
 
@@ -614,13 +622,13 @@ static void test_diverged_works_without_prior_sync_state(void **state) {
          test_state->doc2,
          test_state->sync_state1,
          test_state->sync_state2);
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 }
 
@@ -637,11 +645,11 @@ static void test_diverged_works_with_prior_sync_state(void **state) {
 
     /* Create two peers both with divergent commits. */
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
     time_t const time = 0;
     for (size_t value = 0; value != 10; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -650,35 +658,35 @@ static void test_diverged_works_with_prior_sync_state(void **state) {
          test_state->sync_state2);
 
     for (size_t value = 10; value != 15; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     for (size_t value = 15; value != 18; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc2, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "x", value));
         AMcommit(test_state->doc2, NULL, &time);
     }
     AMresult* encoded_result = AMsyncStateEncode(test_state->sync_state1);
     AMbyteSpan encoded = AMresultValue(encoded_result, 0).bytes;
-    AMresult* sync_state_result1 = AMsyncStateDecode(encoded.src, encoded.count);
-    AMresultFree(encoded_result);
-    AMsyncState* sync_state1 = AMresultValue(sync_state_result1, 0).sync_state;
+    AMresult* sync_state1_result = AMsyncStateDecode(encoded.src, encoded.count);
+    AMfree(encoded_result);
+    AMsyncState* sync_state1 = AMresultValue(sync_state1_result, 0).sync_state;
     encoded_result = AMsyncStateEncode(test_state->sync_state2);
     encoded = AMresultValue(encoded_result, 0).bytes;
-    AMresult* sync_state_result2 = AMsyncStateDecode(encoded.src, encoded.count);
-    AMresultFree(encoded_result);
-    AMsyncState* sync_state2 = AMresultValue(sync_state_result2, 0).sync_state;
+    AMresult* sync_state2_result = AMsyncStateDecode(encoded.src, encoded.count);
+    AMfree(encoded_result);
+    AMsyncState* sync_state2 = AMresultValue(sync_state2_result, 0).sync_state;
 
     assert_false(AMequal(test_state->doc1, test_state->doc2));
     sync(test_state->doc1, test_state->doc2, sync_state1, sync_state2);
-    AMresultFree(sync_state_result2);
-    AMresultFree(sync_state_result1);
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMfree(sync_state2_result);
+    AMfree(sync_state1_result);
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 }
 
@@ -688,12 +696,12 @@ static void test_diverged_works_with_prior_sync_state(void **state) {
  */
 static void test_diverged_ensure_not_empty_after_sync(void **state) {
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
 
     time_t const time = 0;
     for (size_t value = 0; value != 3; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -701,13 +709,13 @@ static void test_diverged_ensure_not_empty_after_sync(void **state) {
          test_state->sync_state1,
          test_state->sync_state2);
 
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
     AMchangeHashes shared_heads1 = AMsyncStateSharedHeads(test_state->sync_state1);
     assert_int_equal(AMchangeHashesCmp(&shared_heads1, &heads1), 0);
     AMchangeHashes shared_heads2 = AMsyncStateSharedHeads(test_state->sync_state2);
     assert_int_equal(AMchangeHashesCmp(&shared_heads2, &heads1), 0);
-    AMresultFree(heads_result1);
+    AMfree(heads1_result);
 }
 
 /**
@@ -723,13 +731,13 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
        * We want to successfully sync (n1) with (r), even though (n1) believes
        * it's talking to (n2). */
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
 
     /* n1 makes three changes which we synchronize to n2. */
     time_t const time = 0;
     for (size_t value = 0; value != 3; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -738,15 +746,16 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
          test_state->sync_state2);
 
     /* Save a copy of n2 as "r" to simulate recovering from a crash. */
-    AMdoc* r = AMdup(test_state->doc2);
+    AMresult* r_result = AMdup(test_state->doc2);
+    AMdoc* r = AMresultValue(r_result, 0).doc;
     AMresult* encoded_result = AMsyncStateEncode(test_state->sync_state2);
     AMbyteSpan encoded = AMresultValue(encoded_result, 0).bytes;
     AMresult* sync_state_resultr = AMsyncStateDecode(encoded.src, encoded.count);
-    AMresultFree(encoded_result);
+    AMfree(encoded_result);
     AMsyncState* sync_stater = AMresultValue(sync_state_resultr, 0).sync_state;
     /* Synchronize another few commits. */
     for (size_t value = 3; value != 6; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -754,49 +763,49 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
          test_state->sync_state1,
          test_state->sync_state2);
     /* Everyone should be on the same page here. */
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 
     /* Now make a few more changes and then attempt to synchronize the
      * fully-up-to-date n1 with with the confused r. */
     for (size_t value = 6; value != 9; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
-    heads_result1 = AMgetHeads(test_state->doc1);
-    heads1 = AMresultValue(heads_result1, 0).change_hashes;
+    heads1_result = AMgetHeads(test_state->doc1);
+    heads1 = AMresultValue(heads1_result, 0).change_hashes;
     AMresult* heads_resultr = AMgetHeads(r);
     AMchangeHashes headsr = AMresultValue(heads_resultr, 0).change_hashes;
     assert_int_not_equal(AMchangeHashesCmp(&heads1, &headsr), 0);
-    AMresultFree(heads_resultr);
-    AMresultFree(heads_result1);
+    AMfree(heads_resultr);
+    AMfree(heads1_result);
     assert_false(AMequal(test_state->doc1, r));
     AMresult* map_value_result = AMmapGet(test_state->doc1, AM_ROOT, "x");
     assert_int_equal(AMresultValue(map_value_result, 0).uint, 8);
-    AMresultFree(map_value_result);
+    AMfree(map_value_result);
     map_value_result = AMmapGet(r, AM_ROOT, "x");
     assert_int_equal(AMresultValue(map_value_result, 0).uint, 2);
-    AMresultFree(map_value_result);
+    AMfree(map_value_result);
     sync(test_state->doc1,
          r,
          test_state->sync_state1,
          sync_stater);
-    AMresultFree(sync_state_resultr);
-    heads_result1 = AMgetHeads(test_state->doc1);
-    heads1 = AMresultValue(heads_result1, 0).change_hashes;
+    AMfree(sync_state_resultr);
+    heads1_result = AMgetHeads(test_state->doc1);
+    heads1 = AMresultValue(heads1_result, 0).change_hashes;
     heads_resultr = AMgetHeads(r);
     headsr = AMresultValue(heads_resultr, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &headsr), 0);
-    AMresultFree(heads_resultr);
-    AMresultFree(heads_result1);
+    AMfree(heads_resultr);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, r));
-    AMfree(r);
+    AMfree(r_result);
 }
 
 /**
@@ -805,13 +814,13 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
  */
 static void test_diverged_resync_after_data_loss_without_disconnection(void **state) {
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
 
     /* n1 makes three changes which we synchronize to n2. */
     time_t const time = 0;
     for (size_t value = 0; value != 3; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
         AMcommit(test_state->doc1, NULL, &time);
     }
     sync(test_state->doc1,
@@ -819,36 +828,38 @@ static void test_diverged_resync_after_data_loss_without_disconnection(void **st
          test_state->sync_state1,
          test_state->sync_state2);
 
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 
-    AMdoc* doc2_after_data_loss = AMcreate();
-    AMresultFree(AMsetActorHex(doc2_after_data_loss, "89abcdef"));
+    AMresult* doc2_after_data_loss_result = AMcreate();
+    AMdoc* doc2_after_data_loss = AMresultValue(doc2_after_data_loss_result, 0).doc;
+    AMfree(AMsetActorHex(doc2_after_data_loss, "89abcdef"));
 
     /* "n2" now has no data, but n1 still thinks it does. Note we don't do
      * decodeSyncState(encodeSyncState(s1)) in order to simulate data loss
      * without disconnecting. */
-    AMsyncState* sync_state2_after_data_loss = AMsyncStateInit();
+    AMresult* sync_state2_after_data_loss_result = AMsyncStateInit();
+    AMsyncState* sync_state2_after_data_loss = AMresultValue(sync_state2_after_data_loss_result, 0).sync_state;
     sync(test_state->doc1,
          doc2_after_data_loss,
          test_state->sync_state1,
          sync_state2_after_data_loss);
-    heads_result1 = AMgetHeads(test_state->doc1);
-    heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    heads_result2 = AMgetHeads(doc2_after_data_loss);
-    heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    heads1_result = AMgetHeads(test_state->doc1);
+    heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    heads2_result = AMgetHeads(doc2_after_data_loss);
+    heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, doc2_after_data_loss));
-    AMsyncStateFree(sync_state2_after_data_loss);
-    AMfree(doc2_after_data_loss);
+    AMfree(sync_state2_after_data_loss_result);
+    AMfree(doc2_after_data_loss_result);
 }
 
 /**
@@ -857,56 +868,59 @@ static void test_diverged_resync_after_data_loss_without_disconnection(void **st
  */
 static void test_diverged_handles_concurrent_changes(void **state) {
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
-    AMdoc* doc3 = AMcreate();
-    AMresultFree(AMsetActorHex(doc3, "fedcba98"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* doc3_result = AMcreate();
+    AMdoc* doc3 = AMresultValue(doc3_result, 0).doc;
+    AMfree(AMsetActorHex(doc3, "fedcba98"));
     AMsyncState* sync_state12 = test_state->sync_state1;
     AMsyncState* sync_state21 = test_state->sync_state2;
-    AMsyncState* sync_state23 = AMsyncStateInit();
-    AMsyncState* sync_state32 = AMsyncStateInit();
+    AMresult* sync_state23_result = AMsyncStateInit();
+    AMsyncState* sync_state23 = AMresultValue(sync_state23_result, 0).sync_state;
+    AMresult* sync_state32_result = AMsyncStateInit();
+    AMsyncState* sync_state32 = AMresultValue(sync_state32_result, 0).sync_state;
 
     /* Change 1 is known to all three nodes. */
     time_t const time = 0;
-    AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 1));
+    AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 1));
     AMcommit(test_state->doc1, NULL, &time);
     sync(test_state->doc1, test_state->doc2, sync_state12, sync_state21);
     sync(test_state->doc2, doc3, sync_state23, sync_state32);
 
     /* Change 2 is known to n1 and n2. */
-    AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 2));
+    AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 2));
     AMcommit(test_state->doc1, NULL, &time);
     sync(test_state->doc1, test_state->doc2, sync_state12, sync_state21);
 
     /* Each of the three nodes makes one change (changes 3, 4, 5). */
-    AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 3));
+    AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 3));
     AMcommit(test_state->doc1, NULL, &time);
-    AMresultFree(AMmapPutUint(test_state->doc2, AM_ROOT, "x", 4));
+    AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "x", 4));
     AMcommit(test_state->doc2, NULL, &time);
-    AMresultFree(AMmapPutUint(doc3, AM_ROOT, "x", 5));
+    AMfree(AMmapPutUint(doc3, AM_ROOT, "x", 5));
     AMcommit(doc3, NULL, &time);
 
     /* Apply n3's latest change to n2. */
     AMresult* changes_result = AMgetLastLocalChange(doc3);
     AMchanges changes = AMresultValue(changes_result, 0).changes;
-    AMresultFree(AMapplyChanges(test_state->doc2, &changes));
-    AMresultFree(changes_result);
+    AMfree(AMapplyChanges(test_state->doc2, &changes));
+    AMfree(changes_result);
 
     /* Now sync n1 and n2. n3's change is concurrent to n1 and n2's last sync
      * heads. */
     sync(test_state->doc1, test_state->doc2, sync_state12, sync_state21);
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 
-    AMsyncStateFree(sync_state32);
-    AMsyncStateFree(sync_state23);
-    AMfree(doc3);
+    AMfree(sync_state32_result);
+    AMfree(sync_state23_result);
+    AMfree(doc3_result);
 }
 
 /**
@@ -915,19 +929,20 @@ static void test_diverged_handles_concurrent_changes(void **state) {
  */
 static void test_diverged_handles_histories_of_branching_and_merging(void **state) {
     TestState* test_state = *state;
-    AMresultFree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMresultFree(AMsetActorHex(test_state->doc2, "89abcdef"));
-    AMdoc* doc3 = AMcreate();
-    AMresultFree(AMsetActorHex(doc3, "fedcba98"));
+    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
+    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* doc3_result = AMcreate();
+    AMdoc* doc3 = AMresultValue(doc3_result, 0).doc;
+    AMfree(AMsetActorHex(doc3, "fedcba98"));
     time_t const time = 0;
-    AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 0));
+    AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 0));
     AMcommit(test_state->doc1, NULL, &time);
     AMresult* changes_result = AMgetLastLocalChange(test_state->doc1);
     AMchanges changes = AMresultValue(changes_result, 0).changes;
-    AMresultFree(AMapplyChanges(test_state->doc2, &changes));
-    AMresultFree(AMapplyChanges(doc3, &changes));
-    AMresultFree(changes_result);
-    AMresultFree(AMmapPutUint(doc3, AM_ROOT, "x", 1));
+    AMfree(AMapplyChanges(test_state->doc2, &changes));
+    AMfree(AMapplyChanges(doc3, &changes));
+    AMfree(changes_result);
+    AMfree(AMmapPutUint(doc3, AM_ROOT, "x", 1));
     AMcommit(doc3, NULL, &time);
 
     /*        - n1c1 <------ n1c2 <------ n1c3 <-- etc. <-- n1c20 <------ n1c21
@@ -938,18 +953,18 @@ static void test_diverged_handles_histories_of_branching_and_merging(void **stat
      *       ---------------------------------------------- n3c1 <-----
      */
     for (size_t value = 1; value != 20; ++value) {
-        AMresultFree(AMmapPutUint(test_state->doc1, AM_ROOT, "n1", value));
+        AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "n1", value));
         AMcommit(test_state->doc1, NULL, &time);
-        AMresultFree(AMmapPutUint(test_state->doc2, AM_ROOT, "n2", value));
+        AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "n2", value));
         AMcommit(test_state->doc2, NULL, &time);
-        AMresult* changes_result1 = AMgetLastLocalChange(test_state->doc1);
-        AMchanges changes1 = AMresultValue(changes_result1, 0).changes;
-        AMresult* changes_result2 = AMgetLastLocalChange(test_state->doc2);
-        AMchanges changes2 = AMresultValue(changes_result2, 0).changes;
-        AMresultFree(AMapplyChanges(test_state->doc1, &changes2));
-        AMresultFree(changes_result2);
-        AMresultFree(AMapplyChanges(test_state->doc2, &changes1));
-        AMresultFree(changes_result1);
+        AMresult* changes1_result = AMgetLastLocalChange(test_state->doc1);
+        AMchanges changes1 = AMresultValue(changes1_result, 0).changes;
+        AMresult* changes2_result = AMgetLastLocalChange(test_state->doc2);
+        AMchanges changes2 = AMresultValue(changes2_result, 0).changes;
+        AMfree(AMapplyChanges(test_state->doc1, &changes2));
+        AMfree(changes2_result);
+        AMfree(AMapplyChanges(test_state->doc2, &changes1));
+        AMfree(changes1_result);
     }
 
     sync(test_state->doc1,
@@ -959,29 +974,29 @@ static void test_diverged_handles_histories_of_branching_and_merging(void **stat
 
     /* Having n3's last change concurrent to the last sync heads forces us into
      * the slower code path. */
-    AMresult* changes_result3 = AMgetLastLocalChange(doc3);
-    AMchanges changes3 = AMresultValue(changes_result3, 0).changes;
-    AMresultFree(AMapplyChanges(test_state->doc2, &changes3));
-    AMresultFree(changes_result3);
-    AMresultFree(AMmapPutStr(test_state->doc1, AM_ROOT, "n1", "final"));
+    AMresult* changes3_result = AMgetLastLocalChange(doc3);
+    AMchanges changes3 = AMresultValue(changes3_result, 0).changes;
+    AMfree(AMapplyChanges(test_state->doc2, &changes3));
+    AMfree(changes3_result);
+    AMfree(AMmapPutStr(test_state->doc1, AM_ROOT, "n1", "final"));
     AMcommit(test_state->doc1, NULL, &time);
-    AMresultFree(AMmapPutStr(test_state->doc2, AM_ROOT, "n2", "final"));
+    AMfree(AMmapPutStr(test_state->doc2, AM_ROOT, "n2", "final"));
     AMcommit(test_state->doc2, NULL, &time);
 
     sync(test_state->doc1,
          test_state->doc2,
          test_state->sync_state1,
          test_state->sync_state2);
-    AMresult* heads_result1 = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads_result1, 0).change_hashes;
-    AMresult* heads_result2 = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads_result2, 0).change_hashes;
+    AMresult* heads1_result = AMgetHeads(test_state->doc1);
+    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMresult* heads2_result = AMgetHeads(test_state->doc2);
+    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
-    AMresultFree(heads_result2);
-    AMresultFree(heads_result1);
+    AMfree(heads2_result);
+    AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 
-    AMfree(doc3);
+    AMfree(doc3_result);
 }
 
 int run_sync_tests(void) {


### PR DESCRIPTION
@orionz, I've simplified the management of memory allocated by C API calls by reducing the `AMfree()`, `AMresultFree()` and `AMsyncStateFree()` functions to a single `AMfree()` function and making all functions that allocate memory return an `AMresult*`.