### PR TITLE
Remove artificial iteration from the C API

### DIFF
--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -10,7 +10,7 @@ AMvalue test(AMresult*, AMvalueVariant const);
  */
 int main(int argc, char** argv) {
     AMresult* const doc1_result = AMcreate();
-    AMdoc* const doc1 = AMresultValue(doc1_result, 0).doc;
+    AMdoc* const doc1 = AMresultValue(doc1_result).doc;
     if (doc1 == NULL) {
         fprintf(stderr, "`AMcreate()` failure.");
         exit(EXIT_FAILURE);
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
     AMfree(result);
 
     AMresult* doc2_result = AMcreate();
-    AMdoc* doc2 = AMresultValue(doc2_result, 0).doc;
+    AMdoc* doc2 = AMresultValue(doc2_result).doc;
     if (doc2 == NULL) {
         fprintf(stderr, "`AMcreate()` failure.");
         AMfree(card1_result);
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
     value = test(save_result, AM_VALUE_BYTES);
     AMbyteSpan binary = value.bytes;
     doc2_result = AMload(binary.src, binary.count);
-    doc2 = AMresultValue(doc2_result, 0).doc;
+    doc2 = AMresultValue(doc2_result).doc;
     AMfree(save_result);
     if (doc2 == NULL) {
         fprintf(stderr, "`AMload()` failure.");
@@ -129,7 +129,7 @@ AMvalue test(AMresult* result, AMvalueVariant const discriminant) {
         AMfree(result);
         exit(EXIT_FAILURE);
     }
-    AMvalue const value = AMresultValue(result, 0);
+    AMvalue const value = AMresultValue(result);
     if (value.tag != discriminant) {
         char const* label = NULL;
         switch (value.tag) {

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     result = AMgetChanges(doc1, NULL);
     value = test(result, AM_VALUE_CHANGES);
     AMchange const* change = NULL;
-    while (value.changes.ptr && (change = AMchangesNext(&value.changes, 1))) {
+    while ((change = AMchangesNext(&value.changes, 1)) != NULL) {
         size_t const size = AMobjSizeAt(doc1, cards, change);
         printf("%s %ld\n", AMchangeMessage(change), size);
     }

--- a/automerge-c/src/CMakeLists.txt
+++ b/automerge-c/src/CMakeLists.txt
@@ -39,7 +39,8 @@ if(WIN32)
 endif()
 
 add_custom_command(
-    OUTPUT ${CARGO_OUTPUT}
+    OUTPUT
+        ${CARGO_OUTPUT}
     COMMAND
         # \note cbindgen won't regenerate its output header file after it's
         #       been removed but it will after its configuration file has been
@@ -80,7 +81,8 @@ add_custom_target(
     DEPENDS ${CARGO_OUTPUT}
 )
 
-# \note cbindgen's naming behavior isn't fully configurable.
+# \note cbindgen's naming behavior isn't fully configurable and it ignores
+#       `const fn` calls (https://github.com/eqrion/cbindgen/issues/252).
 add_custom_command(
     TARGET ${LIBRARY_NAME}_artifacts
     POST_BUILD
@@ -93,10 +95,13 @@ add_custom_command(
     COMMAND
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
         ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
+    COMMAND
+        # Compensate for cbindgen ignoring `std:mem::size_of<T>()` calls.
+        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
     WORKING_DIRECTORY
         ${CMAKE_SOURCE_DIR}
     COMMENT
-        "Compensating for hard-coded cbindgen naming behaviors..."
+        "Compensating for cbindgen deficits..."
     VERBATIM
 )
 

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -1,53 +1,89 @@
 use automerge as am;
 use std::collections::BTreeMap;
 use std::ffi::c_void;
+use std::mem::size_of;
 
 use crate::sync::have::AMsyncHave;
+
+#[repr(C)]
+struct Detail {
+    len: usize,
+    offset: isize,
+    storage: *mut c_void,
+}
+
+/// \note cbindgen won't propagate the value of a `std::mem::size_of<T>()` call
+///       (https://github.com/eqrion/cbindgen/issues/252) but it will
+///       propagate the name of a constant initialized from it so if the
+///       constant's name is a symbolic representation of the value it can be
+///       converted into a number by post-processing the header it generated.
+pub const USIZE_USIZE_USIZE_: usize = size_of::<Detail>();
+
+impl Detail {
+    fn new(len: usize, offset: isize, storage: &mut BTreeMap<usize, AMsyncHave>) -> Self {
+        let storage: *mut BTreeMap<usize, AMsyncHave> = storage;
+        Self {
+            len,
+            offset,
+            storage: storage as *mut c_void,
+        }
+    }
+}
+
+impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
+    fn from(detail: Detail) -> Self {
+        unsafe {
+            std::slice::from_raw_parts((&detail as *const Detail) as *const u8, USIZE_USIZE_USIZE_)
+                .try_into()
+                .unwrap()
+        }
+    }
+}
 
 /// \struct AMsyncHaves
 /// \brief A bidirectional iterator over a sequence of synchronization haves.
 #[repr(C)]
 pub struct AMsyncHaves {
-    /// The length of the sequence.
-    len: usize,
-    /// The offset from \p ptr, \p +offset -> forward direction,
-    /// \p -offset -> reverse direction.
-    offset: isize,
     /// A pointer to the first synchronization have or `NULL`.
     ptr: *const c_void,
     /// Reserved.
-    storage: *mut c_void,
+    detail: [u8; USIZE_USIZE_USIZE_],
 }
 
 impl AMsyncHaves {
-    pub fn new(sync_haves: &[am::sync::Have], storage: &mut BTreeMap<usize, AMsyncHave>) -> Self {
-        let storage: *mut BTreeMap<usize, AMsyncHave> = storage;
+    pub fn new(haves: &[am::sync::Have], storage: &mut BTreeMap<usize, AMsyncHave>) -> Self {
         Self {
-            len: sync_haves.len(),
-            offset: 0,
-            ptr: sync_haves.as_ptr() as *const c_void,
-            storage: storage as *mut c_void,
+            ptr: haves.as_ptr() as *const c_void,
+            detail: Detail::new(haves.len(), 0, storage).into(),
         }
     }
 
     pub fn advance(&mut self, n: isize) {
-        let len = self.len as isize;
-        if n != 0 && self.offset >= -len && self.offset < len {
-            // It's being advanced and its hasn't stopped.
-            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
+        let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
+        let len = detail.len as isize;
+        if n != 0 && detail.offset >= -len && detail.offset < len {
+            // It's being advanced and it hasn't stopped.
+            detail.offset = std::cmp::max(-(len + 1), std::cmp::min(detail.offset + n, len));
         };
     }
 
+    pub fn len(&self) -> usize {
+        let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
+        detail.len
+    }
+
     pub fn next(&mut self, n: isize) -> Option<*const AMsyncHave> {
-        let len = self.len as isize;
-        if self.offset < -len || self.offset == len {
+        let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
+        let len = detail.len as isize;
+        if detail.offset < -len || detail.offset == len {
             // It's stopped.
             None
         } else {
-            let slice: &[am::sync::Have] =
-                unsafe { std::slice::from_raw_parts(self.ptr as *const am::sync::Have, self.len) };
-            let index = (self.offset + if self.offset < 0 { len } else { 0 }) as usize;
-            let storage = unsafe { &mut *(self.storage as *mut BTreeMap<usize, AMsyncHave>) };
+            let slice: &[am::sync::Have] = unsafe {
+                std::slice::from_raw_parts(self.ptr as *const am::sync::Have, detail.len)
+            };
+            let index = (detail.offset + if detail.offset < 0 { len } else { 0 }) as usize;
+            let storage = unsafe { &mut *(detail.storage as *mut BTreeMap<usize, AMsyncHave>) };
             let value = match storage.get_mut(&index) {
                 Some(value) => value,
                 None => {
@@ -62,15 +98,17 @@ impl AMsyncHaves {
 
     pub fn prev(&mut self, n: isize) -> Option<*const AMsyncHave> {
         self.advance(n);
-        let len = self.len as isize;
-        if self.offset < -len || self.offset == len {
+        let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
+        let len = detail.len as isize;
+        if detail.offset < -len || detail.offset == len {
             // It's stopped.
             None
         } else {
-            let slice: &[am::sync::Have] =
-                unsafe { std::slice::from_raw_parts(self.ptr as *const am::sync::Have, self.len) };
-            let index = (self.offset + if self.offset < 0 { len } else { 0 }) as usize;
-            let storage = unsafe { &mut *(self.storage as *mut BTreeMap<usize, AMsyncHave>) };
+            let slice: &[am::sync::Have] = unsafe {
+                std::slice::from_raw_parts(self.ptr as *const am::sync::Have, detail.len)
+            };
+            let index = (detail.offset + if detail.offset < 0 { len } else { 0 }) as usize;
+            let storage = unsafe { &mut *(detail.storage as *mut BTreeMap<usize, AMsyncHave>) };
             Some(match storage.get_mut(&index) {
                 Some(value) => value,
                 None => {
@@ -80,21 +118,29 @@ impl AMsyncHaves {
             })
         }
     }
+
+    pub fn reverse(&self) -> Self {
+        let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
+        let storage = unsafe { &mut *(detail.storage as *mut BTreeMap<usize, AMsyncHave>) };
+        Self {
+            ptr: self.ptr,
+            detail: Detail::new(detail.len, -(detail.offset + 1), storage).into(),
+        }
+    }
 }
 
 impl AsRef<[am::sync::Have]> for AMsyncHaves {
     fn as_ref(&self) -> &[am::sync::Have] {
-        unsafe { std::slice::from_raw_parts(self.ptr as *const am::sync::Have, self.len) }
+        let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
+        unsafe { std::slice::from_raw_parts(self.ptr as *const am::sync::Have, detail.len) }
     }
 }
 
 impl Default for AMsyncHaves {
     fn default() -> Self {
         Self {
-            len: 0,
-            offset: 0,
             ptr: std::ptr::null(),
-            storage: std::ptr::null_mut(),
+            detail: [0; USIZE_USIZE_USIZE_],
         }
     }
 }
@@ -215,8 +261,27 @@ pub unsafe extern "C" fn AMsyncHavesPrev(
 #[no_mangle]
 pub unsafe extern "C" fn AMsyncHavesSize(sync_haves: *const AMsyncHaves) -> usize {
     if let Some(sync_haves) = sync_haves.as_ref() {
-        sync_haves.len
+        sync_haves.len()
     } else {
         0
+    }
+}
+
+/// \memberof AMsyncHaves
+/// \brief Creates a reversed copy of a synchronization haves iterator.
+///
+/// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
+/// \return An `AMsyncHaves` struct
+/// \pre \p sync_haves must be a valid address.
+/// \internal
+///
+/// #Safety
+/// sync_haves must be a pointer to a valid AMsyncHaves
+#[no_mangle]
+pub unsafe extern "C" fn AMsyncHavesReverse(sync_haves: *const AMsyncHaves) -> AMsyncHaves {
+    if let Some(sync_haves) = sync_haves.as_ref() {
+        sync_haves.reverse()
+    } else {
+        AMsyncHaves::default()
     }
 }

--- a/automerge-c/test/amdoc_property_tests.c
+++ b/automerge-c/test/amdoc_property_tests.c
@@ -59,7 +59,7 @@ static void test_AMputActor(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 0);
-    AMvalue value = AMresultValue(res, 0);
+    AMvalue value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(res);
     res = AMgetActor(group_state->doc);
@@ -67,7 +67,7 @@ static void test_AMputActor(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 1);
-    value = AMresultValue(res, 0);
+    value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
     assert_int_equal(value.actor_id.count, test_state->actor_id_size);
     assert_memory_equal(value.actor_id.src, test_state->actor_id_bytes, value.actor_id.count);
@@ -85,7 +85,7 @@ static void test_AMputActorHex(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 0);
-    AMvalue value = AMresultValue(res, 0);
+    AMvalue value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(res);
     res = AMgetActorHex(group_state->doc);
@@ -93,7 +93,7 @@ static void test_AMputActorHex(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 1);
-    value = AMresultValue(res, 0);
+    value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_STR);
     assert_int_equal(strlen(value.str), test_state->actor_id_size * 2);
     assert_string_equal(value.str, test_state->actor_id_str);

--- a/automerge-c/test/amlistput_tests.c
+++ b/automerge-c/test/amlistput_tests.c
@@ -25,18 +25,18 @@ static void test_AMlistPut ## suffix ## _ ## mode(void **state) {             \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    value = AMresultValue(res, 0);                                            \
+    value = AMresultValue(res);                                               \
     assert_int_equal(value.tag, AMvalue_discriminant(#suffix));               \
     assert_true(value.member == scalar_value);                                \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 #define test_AMlistPutBytes(mode) test_AMlistPutBytes ## _ ## mode
@@ -58,19 +58,19 @@ static void test_AMlistPutBytes_ ## mode(void **state) {                      \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    value = AMresultValue(res, 0);                                            \
+    value = AMresultValue(res);                                               \
     assert_int_equal(value.tag, AM_VALUE_BYTES);                              \
     assert_int_equal(value.bytes.count, BYTES_SIZE);                          \
     assert_memory_equal(value.bytes.src, bytes_value, BYTES_SIZE);            \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 #define test_AMlistPutNull(mode) test_AMlistPutNull_ ## mode
@@ -84,17 +84,17 @@ static void test_AMlistPutNull_ ## mode(void **state) {                       \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    value = AMresultValue(res, 0);                                            \
+    value = AMresultValue(res);                                               \
     assert_int_equal(value.tag, AM_VALUE_NULL);                               \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 #define test_AMlistPutObject(label, mode) test_AMlistPutObject_ ## label ## _ ## mode
@@ -113,11 +113,11 @@ static void test_AMlistPutObject_ ## label ## _ ## mode(void **state) {       \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
     assert_non_null(value.obj_id);                                            \
     assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 #define test_AMlistPutStr(mode) test_AMlistPutStr ## _ ## mode
@@ -138,19 +138,19 @@ static void test_AMlistPutStr_ ## mode(void **state) {                        \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
     res = AMlistGet(group_state->doc, AM_ROOT, 0);                            \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    value = AMresultValue(res, 0);                                            \
+    value = AMresultValue(res);                                               \
     assert_int_equal(value.tag, AM_VALUE_STR);                                \
     assert_int_equal(strlen(value.str), STR_LEN);                             \
     assert_memory_equal(value.str, str_value, STR_LEN + 1);                   \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 static_void_test_AMlistPut(Bool, insert, boolean, true)

--- a/automerge-c/test/ammapput_tests.c
+++ b/automerge-c/test/ammapput_tests.c
@@ -28,18 +28,18 @@ static void test_AMmapPut ## suffix(void **state) {                           \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 0);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_VOID);                               \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
     res = AMmapGet(group_state->doc, AM_ROOT, #suffix);                       \
     if (AMresultStatus(res) != AM_STATUS_OK) {                                \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    value = AMresultValue(res, 0);                                            \
+    value = AMresultValue(res);                                               \
     assert_int_equal(value.tag, AMvalue_discriminant(#suffix));               \
     assert_true(value.member == scalar_value);                                \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 #define test_AMmapPutObject(label) test_AMmapPutObject_ ## label
@@ -57,11 +57,11 @@ static void test_AMmapPutObject_ ## label(void **state) {                     \
         fail_msg("%s", AMerrorMessage(res));                                  \
     }                                                                         \
     assert_int_equal(AMresultSize(res), 1);                                   \
-    AMvalue value = AMresultValue(res, 0);                                    \
+    AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
     assert_non_null(value.obj_id);                                            \
     assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
-    AMfree(res);                                                        \
+    AMfree(res);                                                              \
 }
 
 static_void_test_AMmapPut(Bool, boolean, true)
@@ -83,7 +83,7 @@ static void test_AMmapPutBytes(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 0);
-    AMvalue value = AMresultValue(res, 0);
+    AMvalue value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
@@ -91,7 +91,7 @@ static void test_AMmapPutBytes(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 1);
-    value = AMresultValue(res, 0);
+    value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_BYTES);
     assert_int_equal(value.bytes.count, BYTES_SIZE);
     assert_memory_equal(value.bytes.src, BYTES_VALUE, BYTES_SIZE);
@@ -113,7 +113,7 @@ static void test_AMmapPutNull(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 0);
-    AMvalue value = AMresultValue(res, 0);
+    AMvalue value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
@@ -121,7 +121,7 @@ static void test_AMmapPutNull(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 1);
-    value = AMresultValue(res, 0);
+    value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_NULL);
     AMfree(res);
 }
@@ -148,7 +148,7 @@ static void test_AMmapPutStr(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 0);
-    AMvalue value = AMresultValue(res, 0);
+    AMvalue value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(res);
     res = AMmapGet(group_state->doc, AM_ROOT, KEY);
@@ -156,7 +156,7 @@ static void test_AMmapPutStr(void **state) {
         fail_msg("%s", AMerrorMessage(res));
     }
     assert_int_equal(AMresultSize(res), 1);
-    value = AMresultValue(res, 0);
+    value = AMresultValue(res);
     assert_int_equal(value.tag, AM_VALUE_STR);
     assert_int_equal(strlen(value.str), STR_LEN);
     assert_memory_equal(value.str, STR_VALUE, STR_LEN + 1);

--- a/automerge-c/test/group_state.c
+++ b/automerge-c/test/group_state.c
@@ -6,7 +6,7 @@
 int group_setup(void** state) {
     GroupState* group_state = calloc(1, sizeof(GroupState));
     group_state->doc_result = AMcreate();
-    group_state->doc = AMresultValue(group_state->doc_result, 0).doc;
+    group_state->doc = AMresultValue(group_state->doc_result).doc;
     *state = group_state;
     return 0;
 }

--- a/automerge-c/test/sync_tests.c
+++ b/automerge-c/test/sync_tests.c
@@ -24,13 +24,13 @@ typedef struct {
 static int setup(void** state) {
     TestState* test_state = calloc(1, sizeof(TestState));
     test_state->doc1_result = AMcreate();
-    test_state->doc1 = AMresultValue(test_state->doc1_result, 0).doc;
+    test_state->doc1 = AMresultValue(test_state->doc1_result).doc;
     test_state->doc2_result = AMcreate();
-    test_state->doc2 = AMresultValue(test_state->doc2_result, 0).doc;
+    test_state->doc2 = AMresultValue(test_state->doc2_result).doc;
     test_state->sync_state1_result = AMsyncStateInit();
-    test_state->sync_state1 = AMresultValue(test_state->sync_state1_result, 0).sync_state;
+    test_state->sync_state1 = AMresultValue(test_state->sync_state1_result).sync_state;
     test_state->sync_state2_result = AMsyncStateInit();
-    test_state->sync_state2 = AMresultValue(test_state->sync_state2_result, 0).sync_state;
+    test_state->sync_state2 = AMresultValue(test_state->sync_state2_result).sync_state;
     *state = test_state;
     return 0;
 }
@@ -57,7 +57,7 @@ static void sync(AMdoc* a,
     do {
         AMresult* a2b_msg_result = AMgenerateSyncMessage(a, a_sync_state);
         AMresult* b2a_msg_result = AMgenerateSyncMessage(b, b_sync_state);
-        AMvalue value = AMresultValue(a2b_msg_result, 0);
+        AMvalue value = AMresultValue(a2b_msg_result);
         switch (value.tag) {
             case AM_VALUE_SYNC_MESSAGE: {
                 a2b_msg = value.sync_message;
@@ -66,7 +66,7 @@ static void sync(AMdoc* a,
             break;
             case AM_VALUE_VOID: a2b_msg = NULL; break;
         }
-        value = AMresultValue(b2a_msg_result, 0);
+        value = AMresultValue(b2a_msg_result);
         switch (value.tag) {
             case AM_VALUE_SYNC_MESSAGE: {
                 b2a_msg = value.sync_message;
@@ -95,7 +95,7 @@ static void test_converged_empty_local_doc_reply_no_local_data(void **state) {
         fail_msg("%s", AMerrorMessage(sync_message_result));
     }
     assert_int_equal(AMresultSize(sync_message_result), 1);
-    AMvalue value = AMresultValue(sync_message_result, 0);
+    AMvalue value = AMresultValue(sync_message_result);
     assert_int_equal(value.tag, AM_VALUE_SYNC_MESSAGE);
     AMsyncMessage const* sync_message = value.sync_message;
     AMchangeHashes heads = AMsyncMessageHeads(sync_message);
@@ -125,7 +125,7 @@ static void test_converged_empty_local_doc_no_reply(void **state) {
         fail_msg("%s", AMerrorMessage(sync_message1_result));
     }
     assert_int_equal(AMresultSize(sync_message1_result), 1);
-    AMvalue value = AMresultValue(sync_message1_result, 0);
+    AMvalue value = AMresultValue(sync_message1_result);
     assert_int_equal(value.tag, AM_VALUE_SYNC_MESSAGE);
     AMsyncMessage const* sync_message1 = value.sync_message;
     AMresult* result = AMreceiveSyncMessage(
@@ -135,7 +135,7 @@ static void test_converged_empty_local_doc_no_reply(void **state) {
         fail_msg("%s", AMerrorMessage(result));
     }
     assert_int_equal(AMresultSize(result), 0);
-    value = AMresultValue(result, 0);
+    value = AMresultValue(result);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(result);
     AMresult* sync_message2_result = AMgenerateSyncMessage(
@@ -145,7 +145,7 @@ static void test_converged_empty_local_doc_no_reply(void **state) {
         fail_msg("%s", AMerrorMessage(sync_message2_result));
     }
     assert_int_equal(AMresultSize(sync_message2_result), 0);
-    value = AMresultValue(sync_message2_result, 0);
+    value = AMresultValue(sync_message2_result);
     assert_int_equal(value.tag, AM_VALUE_VOID);
     AMfree(sync_message2_result);
     AMfree(sync_message1_result);
@@ -165,7 +165,7 @@ static void test_converged_equal_heads_no_reply(void **state) {
         AMcommit(test_state->doc1, NULL, &time);
     }
     AMresult* changes_result = AMgetChanges(test_state->doc1, NULL);
-    AMvalue value = AMresultValue(changes_result, 0);
+    AMvalue value = AMresultValue(changes_result);
     AMfree(AMapplyChanges(test_state->doc2, &value.changes));
     AMfree(changes_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
@@ -175,10 +175,10 @@ static void test_converged_equal_heads_no_reply(void **state) {
         test_state->doc1,
         test_state->sync_state1
     );
-    AMsyncMessage const* sync_message1 = AMresultValue(sync_message1_result, 0).sync_message;
+    AMsyncMessage const* sync_message1 = AMresultValue(sync_message1_result).sync_message;
     AMchangeHashes last_sent_heads = AMsyncStateLastSentHeads(test_state->sync_state1);
     AMresult* heads_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads = AMresultValue(heads_result, 0).change_hashes;
+    AMchangeHashes heads = AMresultValue(heads_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&last_sent_heads, &heads), 0);
     AMfree(heads_result);
 
@@ -190,7 +190,7 @@ static void test_converged_equal_heads_no_reply(void **state) {
     AMresult* sync_message2_result = AMgenerateSyncMessage(
         test_state->doc2, test_state->sync_state2
     );
-    assert_int_equal(AMresultValue(sync_message2_result, 0).tag, AM_VALUE_VOID);
+    assert_int_equal(AMresultValue(sync_message2_result).tag, AM_VALUE_VOID);
     AMfree(sync_message2_result);
 }
 
@@ -292,7 +292,7 @@ static void test_converged_no_message_once_synced(void **state) {
     /* The first node reports what it has. */
     AMresult* message_result = AMgenerateSyncMessage(test_state->doc1,
                                                      test_state->sync_state1);
-    AMsyncMessage const* message = AMresultValue(message_result, 0).sync_message;
+    AMsyncMessage const* message = AMresultValue(message_result).sync_message;
 
     /* The second node receives that message and sends changes along with what
      * it has. */
@@ -302,7 +302,7 @@ static void test_converged_no_message_once_synced(void **state) {
     AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
-    message = AMresultValue(message_result, 0).sync_message;
+    message = AMresultValue(message_result).sync_message;
     AMchanges message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 5);
 
@@ -314,7 +314,7 @@ static void test_converged_no_message_once_synced(void **state) {
     AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    message = AMresultValue(message_result, 0).sync_message;
+    message = AMresultValue(message_result).sync_message;
     message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 5);
 
@@ -326,7 +326,7 @@ static void test_converged_no_message_once_synced(void **state) {
     AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
-    message = AMresultValue(message_result, 0).sync_message;
+    message = AMresultValue(message_result).sync_message;
 
     /* The first node receives the message and has nothing more to say. */
     AMfree(AMreceiveSyncMessage(test_state->doc1,
@@ -335,13 +335,13 @@ static void test_converged_no_message_once_synced(void **state) {
     AMfree(message_result);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    assert_int_equal(AMresultValue(message_result, 0).tag, AM_VALUE_VOID);
+    assert_int_equal(AMresultValue(message_result).tag, AM_VALUE_VOID);
     AMfree(message_result);
 
     /* The second node also has nothing left to say. */
     message_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
-    assert_int_equal(AMresultValue(message_result, 0).tag, AM_VALUE_VOID);
+    assert_int_equal(AMresultValue(message_result).tag, AM_VALUE_VOID);
     AMfree(message_result);
 }
 
@@ -363,19 +363,19 @@ static void test_converged_allow_simultaneous_messages(void **state) {
         AMcommit(test_state->doc2, NULL, &time);
     }
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMbyteSpan head1 = AMchangeHashesNext(&heads1, 1);
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     AMbyteSpan head2 = AMchangeHashesNext(&heads2, 1);
 
     /* Both sides report what they have but have no shared peer state. */
     AMresult* msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                                      test_state->sync_state1);
-    AMsyncMessage const* msg1to2 = AMresultValue(msg1to2_result, 0).sync_message;
+    AMsyncMessage const* msg1to2 = AMresultValue(msg1to2_result).sync_message;
     AMresult* msg2to1_result = AMgenerateSyncMessage(test_state->doc2,
                                                      test_state->sync_state2);
-    AMsyncMessage const* msg2to1 = AMresultValue(msg2to1_result, 0).sync_message;
+    AMsyncMessage const* msg2to1 = AMresultValue(msg2to1_result).sync_message;
     AMchanges msg1to2_changes = AMsyncMessageChanges(msg1to2);
     assert_int_equal(AMchangesSize(&msg1to2_changes), 0);
     AMsyncHaves msg1to2_haves = AMsyncMessageHaves(msg1to2);
@@ -405,12 +405,12 @@ static void test_converged_allow_simultaneous_messages(void **state) {
      * message). */
     msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    msg1to2 = AMresultValue(msg1to2_result, 0).sync_message;
+    msg1to2 = AMresultValue(msg1to2_result).sync_message;
     msg1to2_changes = AMsyncMessageChanges(msg1to2);
     assert_int_equal(AMchangesSize(&msg1to2_changes), 5);
     msg2to1_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
-    msg2to1 = AMresultValue(msg2to1_result, 0).sync_message;
+    msg2to1 = AMresultValue(msg2to1_result).sync_message;
     msg2to1_changes = AMsyncMessageChanges(msg2to1);
     assert_int_equal(AMchangesSize(&msg2to1_changes), 5);
 
@@ -420,14 +420,14 @@ static void test_converged_allow_simultaneous_messages(void **state) {
                                       msg2to1));
     AMfree(msg2to1_result);
     AMresult* missing_deps_result = AMgetMissingDeps(test_state->doc1, NULL);
-    AMchangeHashes missing_deps = AMresultValue(missing_deps_result, 0).change_hashes;
+    AMchangeHashes missing_deps = AMresultValue(missing_deps_result).change_hashes;
     assert_int_equal(AMchangeHashesSize(&missing_deps), 0);
     AMfree(missing_deps_result);
     AMresult* map_value_result = AMmapGet(test_state->doc1, AM_ROOT, "x");
-    assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
+    assert_int_equal(AMresultValue(map_value_result).uint, 4);
     AMfree(map_value_result);
     map_value_result = AMmapGet(test_state->doc1, AM_ROOT, "y");
-    assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
+    assert_int_equal(AMresultValue(map_value_result).uint, 4);
     AMfree(map_value_result);
 
     AMfree(AMreceiveSyncMessage(test_state->doc2,
@@ -435,26 +435,26 @@ static void test_converged_allow_simultaneous_messages(void **state) {
                                       msg1to2));
     AMfree(msg1to2_result);
     missing_deps_result = AMgetMissingDeps(test_state->doc2, NULL);
-    missing_deps = AMresultValue(missing_deps_result, 0).change_hashes;
+    missing_deps = AMresultValue(missing_deps_result).change_hashes;
     assert_int_equal(AMchangeHashesSize(&missing_deps), 0);
     AMfree(missing_deps_result);
     map_value_result = AMmapGet(test_state->doc2, AM_ROOT, "x");
-    assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
+    assert_int_equal(AMresultValue(map_value_result).uint, 4);
     AMfree(map_value_result);
     map_value_result = AMmapGet(test_state->doc2, AM_ROOT, "y");
-    assert_int_equal(AMresultValue(map_value_result, 0).uint, 4);
+    assert_int_equal(AMresultValue(map_value_result).uint, 4);
     AMfree(map_value_result);
 
     /* The response acknowledges that the changes were received and sends no
      * further changes. */
     msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    msg1to2 = AMresultValue(msg1to2_result, 0).sync_message;
+    msg1to2 = AMresultValue(msg1to2_result).sync_message;
     msg1to2_changes = AMsyncMessageChanges(msg1to2);
     assert_int_equal(AMchangesSize(&msg1to2_changes), 0);
     msg2to1_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
-    msg2to1 = AMresultValue(msg2to1_result, 0).sync_message;
+    msg2to1 = AMresultValue(msg2to1_result).sync_message;
     msg2to1_changes = AMsyncMessageChanges(msg2to1);
     assert_int_equal(AMchangesSize(&msg2to1_changes), 0);
 
@@ -471,11 +471,11 @@ static void test_converged_allow_simultaneous_messages(void **state) {
     /* They're synchronized so no more messages are required. */
     msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    assert_int_equal(AMresultValue(msg1to2_result, 0).tag, AM_VALUE_VOID);
+    assert_int_equal(AMresultValue(msg1to2_result).tag, AM_VALUE_VOID);
     AMfree(msg1to2_result);
     msg2to1_result = AMgenerateSyncMessage(test_state->doc2,
                                            test_state->sync_state2);
-    assert_int_equal(AMresultValue(msg2to1_result, 0).tag, AM_VALUE_VOID);
+    assert_int_equal(AMresultValue(msg2to1_result).tag, AM_VALUE_VOID);
     AMfree(msg2to1_result);
 
     /* If we make one more change and start synchronizing then its "last
@@ -484,7 +484,7 @@ static void test_converged_allow_simultaneous_messages(void **state) {
     AMcommit(test_state->doc1, NULL, &time);
     msg1to2_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    msg1to2 = AMresultValue(msg1to2_result, 0).sync_message;
+    msg1to2 = AMresultValue(msg1to2_result).sync_message;
     msg1to2_haves = AMsyncMessageHaves(msg1to2);
     msg1to2_have = AMsyncHavesNext(&msg1to2_haves, 1);
     msg1to2_last_sync = AMsyncHaveLastSync(msg1to2_have);
@@ -512,7 +512,7 @@ static void test_converged_assume_sent_changes_were_received(void **state) {
                                             AM_ROOT,
                                             "items",
                                             AM_OBJ_TYPE_LIST);
-    AMobjId const* items = AMresultValue(items_result, 0).obj_id;
+    AMobjId const* items = AMresultValue(items_result).obj_id;
     time_t const time = 0;
     AMcommit(test_state->doc1, NULL, &time);
     sync(test_state->doc1,
@@ -524,7 +524,7 @@ static void test_converged_assume_sent_changes_were_received(void **state) {
     AMcommit(test_state->doc1, NULL, &time);
     AMresult* message_result = AMgenerateSyncMessage(test_state->doc1,
                                                      test_state->sync_state1);
-    AMsyncMessage const* message = AMresultValue(message_result, 0).sync_message;
+    AMsyncMessage const* message = AMresultValue(message_result).sync_message;
     AMchanges message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 1);
     AMfree(message_result);
@@ -533,7 +533,7 @@ static void test_converged_assume_sent_changes_were_received(void **state) {
     AMcommit(test_state->doc1, NULL, &time);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    message = AMresultValue(message_result, 0).sync_message;
+    message = AMresultValue(message_result).sync_message;
     message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 1);
     AMfree(message_result);
@@ -542,7 +542,7 @@ static void test_converged_assume_sent_changes_were_received(void **state) {
     AMcommit(test_state->doc1, NULL, &time);
     message_result = AMgenerateSyncMessage(test_state->doc1,
                                            test_state->sync_state1);
-    message = AMresultValue(message_result, 0).sync_message;
+    message = AMresultValue(message_result).sync_message;
     message_changes = AMsyncMessageChanges(message);
     assert_int_equal(AMchangesSize(&message_changes), 1);
     AMfree(message_result);
@@ -623,9 +623,9 @@ static void test_diverged_works_without_prior_sync_state(void **state) {
          test_state->sync_state1,
          test_state->sync_state2);
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);
@@ -666,24 +666,24 @@ static void test_diverged_works_with_prior_sync_state(void **state) {
         AMcommit(test_state->doc2, NULL, &time);
     }
     AMresult* encoded_result = AMsyncStateEncode(test_state->sync_state1);
-    AMbyteSpan encoded = AMresultValue(encoded_result, 0).bytes;
+    AMbyteSpan encoded = AMresultValue(encoded_result).bytes;
     AMresult* sync_state1_result = AMsyncStateDecode(encoded.src, encoded.count);
     AMfree(encoded_result);
-    AMsyncState* sync_state1 = AMresultValue(sync_state1_result, 0).sync_state;
+    AMsyncState* sync_state1 = AMresultValue(sync_state1_result).sync_state;
     encoded_result = AMsyncStateEncode(test_state->sync_state2);
-    encoded = AMresultValue(encoded_result, 0).bytes;
+    encoded = AMresultValue(encoded_result).bytes;
     AMresult* sync_state2_result = AMsyncStateDecode(encoded.src, encoded.count);
     AMfree(encoded_result);
-    AMsyncState* sync_state2 = AMresultValue(sync_state2_result, 0).sync_state;
+    AMsyncState* sync_state2 = AMresultValue(sync_state2_result).sync_state;
 
     assert_false(AMequal(test_state->doc1, test_state->doc2));
     sync(test_state->doc1, test_state->doc2, sync_state1, sync_state2);
     AMfree(sync_state2_result);
     AMfree(sync_state1_result);
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);
@@ -710,7 +710,7 @@ static void test_diverged_ensure_not_empty_after_sync(void **state) {
          test_state->sync_state2);
 
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMchangeHashes shared_heads1 = AMsyncStateSharedHeads(test_state->sync_state1);
     assert_int_equal(AMchangeHashesCmp(&shared_heads1, &heads1), 0);
     AMchangeHashes shared_heads2 = AMsyncStateSharedHeads(test_state->sync_state2);
@@ -747,12 +747,12 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
 
     /* Save a copy of n2 as "r" to simulate recovering from a crash. */
     AMresult* r_result = AMdup(test_state->doc2);
-    AMdoc* r = AMresultValue(r_result, 0).doc;
+    AMdoc* r = AMresultValue(r_result).doc;
     AMresult* encoded_result = AMsyncStateEncode(test_state->sync_state2);
-    AMbyteSpan encoded = AMresultValue(encoded_result, 0).bytes;
+    AMbyteSpan encoded = AMresultValue(encoded_result).bytes;
     AMresult* sync_state_resultr = AMsyncStateDecode(encoded.src, encoded.count);
     AMfree(encoded_result);
-    AMsyncState* sync_stater = AMresultValue(sync_state_resultr, 0).sync_state;
+    AMsyncState* sync_stater = AMresultValue(sync_state_resultr).sync_state;
     /* Synchronize another few commits. */
     for (size_t value = 3; value != 6; ++value) {
         AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
@@ -764,9 +764,9 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
          test_state->sync_state2);
     /* Everyone should be on the same page here. */
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);
@@ -779,18 +779,18 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
         AMcommit(test_state->doc1, NULL, &time);
     }
     heads1_result = AMgetHeads(test_state->doc1);
-    heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads_resultr = AMgetHeads(r);
-    AMchangeHashes headsr = AMresultValue(heads_resultr, 0).change_hashes;
+    AMchangeHashes headsr = AMresultValue(heads_resultr).change_hashes;
     assert_int_not_equal(AMchangeHashesCmp(&heads1, &headsr), 0);
     AMfree(heads_resultr);
     AMfree(heads1_result);
     assert_false(AMequal(test_state->doc1, r));
     AMresult* map_value_result = AMmapGet(test_state->doc1, AM_ROOT, "x");
-    assert_int_equal(AMresultValue(map_value_result, 0).uint, 8);
+    assert_int_equal(AMresultValue(map_value_result).uint, 8);
     AMfree(map_value_result);
     map_value_result = AMmapGet(r, AM_ROOT, "x");
-    assert_int_equal(AMresultValue(map_value_result, 0).uint, 2);
+    assert_int_equal(AMresultValue(map_value_result).uint, 2);
     AMfree(map_value_result);
     sync(test_state->doc1,
          r,
@@ -798,9 +798,9 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
          sync_stater);
     AMfree(sync_state_resultr);
     heads1_result = AMgetHeads(test_state->doc1);
-    heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    heads1 = AMresultValue(heads1_result).change_hashes;
     heads_resultr = AMgetHeads(r);
-    headsr = AMresultValue(heads_resultr, 0).change_hashes;
+    headsr = AMresultValue(heads_resultr).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &headsr), 0);
     AMfree(heads_resultr);
     AMfree(heads1_result);
@@ -829,31 +829,31 @@ static void test_diverged_resync_after_data_loss_without_disconnection(void **st
          test_state->sync_state2);
 
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);
     assert_true(AMequal(test_state->doc1, test_state->doc2));
 
     AMresult* doc2_after_data_loss_result = AMcreate();
-    AMdoc* doc2_after_data_loss = AMresultValue(doc2_after_data_loss_result, 0).doc;
+    AMdoc* doc2_after_data_loss = AMresultValue(doc2_after_data_loss_result).doc;
     AMfree(AMsetActorHex(doc2_after_data_loss, "89abcdef"));
 
     /* "n2" now has no data, but n1 still thinks it does. Note we don't do
      * decodeSyncState(encodeSyncState(s1)) in order to simulate data loss
      * without disconnecting. */
     AMresult* sync_state2_after_data_loss_result = AMsyncStateInit();
-    AMsyncState* sync_state2_after_data_loss = AMresultValue(sync_state2_after_data_loss_result, 0).sync_state;
+    AMsyncState* sync_state2_after_data_loss = AMresultValue(sync_state2_after_data_loss_result).sync_state;
     sync(test_state->doc1,
          doc2_after_data_loss,
          test_state->sync_state1,
          sync_state2_after_data_loss);
     heads1_result = AMgetHeads(test_state->doc1);
-    heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    heads1 = AMresultValue(heads1_result).change_hashes;
     heads2_result = AMgetHeads(doc2_after_data_loss);
-    heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);
@@ -871,14 +871,14 @@ static void test_diverged_handles_concurrent_changes(void **state) {
     AMfree(AMsetActorHex(test_state->doc1, "01234567"));
     AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
     AMresult* doc3_result = AMcreate();
-    AMdoc* doc3 = AMresultValue(doc3_result, 0).doc;
+    AMdoc* doc3 = AMresultValue(doc3_result).doc;
     AMfree(AMsetActorHex(doc3, "fedcba98"));
     AMsyncState* sync_state12 = test_state->sync_state1;
     AMsyncState* sync_state21 = test_state->sync_state2;
     AMresult* sync_state23_result = AMsyncStateInit();
-    AMsyncState* sync_state23 = AMresultValue(sync_state23_result, 0).sync_state;
+    AMsyncState* sync_state23 = AMresultValue(sync_state23_result).sync_state;
     AMresult* sync_state32_result = AMsyncStateInit();
-    AMsyncState* sync_state32 = AMresultValue(sync_state32_result, 0).sync_state;
+    AMsyncState* sync_state32 = AMresultValue(sync_state32_result).sync_state;
 
     /* Change 1 is known to all three nodes. */
     time_t const time = 0;
@@ -902,7 +902,7 @@ static void test_diverged_handles_concurrent_changes(void **state) {
 
     /* Apply n3's latest change to n2. */
     AMresult* changes_result = AMgetLastLocalChange(doc3);
-    AMchanges changes = AMresultValue(changes_result, 0).changes;
+    AMchanges changes = AMresultValue(changes_result).changes;
     AMfree(AMapplyChanges(test_state->doc2, &changes));
     AMfree(changes_result);
 
@@ -910,9 +910,9 @@ static void test_diverged_handles_concurrent_changes(void **state) {
      * heads. */
     sync(test_state->doc1, test_state->doc2, sync_state12, sync_state21);
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);
@@ -932,13 +932,13 @@ static void test_diverged_handles_histories_of_branching_and_merging(void **stat
     AMfree(AMsetActorHex(test_state->doc1, "01234567"));
     AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
     AMresult* doc3_result = AMcreate();
-    AMdoc* doc3 = AMresultValue(doc3_result, 0).doc;
+    AMdoc* doc3 = AMresultValue(doc3_result).doc;
     AMfree(AMsetActorHex(doc3, "fedcba98"));
     time_t const time = 0;
     AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 0));
     AMcommit(test_state->doc1, NULL, &time);
     AMresult* changes_result = AMgetLastLocalChange(test_state->doc1);
-    AMchanges changes = AMresultValue(changes_result, 0).changes;
+    AMchanges changes = AMresultValue(changes_result).changes;
     AMfree(AMapplyChanges(test_state->doc2, &changes));
     AMfree(AMapplyChanges(doc3, &changes));
     AMfree(changes_result);
@@ -958,9 +958,9 @@ static void test_diverged_handles_histories_of_branching_and_merging(void **stat
         AMfree(AMmapPutUint(test_state->doc2, AM_ROOT, "n2", value));
         AMcommit(test_state->doc2, NULL, &time);
         AMresult* changes1_result = AMgetLastLocalChange(test_state->doc1);
-        AMchanges changes1 = AMresultValue(changes1_result, 0).changes;
+        AMchanges changes1 = AMresultValue(changes1_result).changes;
         AMresult* changes2_result = AMgetLastLocalChange(test_state->doc2);
-        AMchanges changes2 = AMresultValue(changes2_result, 0).changes;
+        AMchanges changes2 = AMresultValue(changes2_result).changes;
         AMfree(AMapplyChanges(test_state->doc1, &changes2));
         AMfree(changes2_result);
         AMfree(AMapplyChanges(test_state->doc2, &changes1));
@@ -975,7 +975,7 @@ static void test_diverged_handles_histories_of_branching_and_merging(void **stat
     /* Having n3's last change concurrent to the last sync heads forces us into
      * the slower code path. */
     AMresult* changes3_result = AMgetLastLocalChange(doc3);
-    AMchanges changes3 = AMresultValue(changes3_result, 0).changes;
+    AMchanges changes3 = AMresultValue(changes3_result).changes;
     AMfree(AMapplyChanges(test_state->doc2, &changes3));
     AMfree(changes3_result);
     AMfree(AMmapPutStr(test_state->doc1, AM_ROOT, "n1", "final"));
@@ -988,9 +988,9 @@ static void test_diverged_handles_histories_of_branching_and_merging(void **stat
          test_state->sync_state1,
          test_state->sync_state2);
     AMresult* heads1_result = AMgetHeads(test_state->doc1);
-    AMchangeHashes heads1 = AMresultValue(heads1_result, 0).change_hashes;
+    AMchangeHashes heads1 = AMresultValue(heads1_result).change_hashes;
     AMresult* heads2_result = AMgetHeads(test_state->doc2);
-    AMchangeHashes heads2 = AMresultValue(heads2_result, 0).change_hashes;
+    AMchangeHashes heads2 = AMresultValue(heads2_result).change_hashes;
     assert_int_equal(AMchangeHashesCmp(&heads1, &heads2), 0);
     AMfree(heads2_result);
     AMfree(heads1_result);


### PR DESCRIPTION
@orionz, I've made the following changes to the C API:
* Removed the artificial `index` argument from `AMresultValue()`.
* Added `AMchangeHashesReversed()`, `AMchangesReversed()` and `AMsyncHavesReversed()` to enable the creation of reverse iterators.
* Changed the interpretation of the `n` argument in `AM{changeHashes,changes,syncHaves}Advance()`, `AM{changeHashes,changes,syncHaves}Next()` and `AM{changeHashes,changes,syncHaves}Prev()` to apply their `n` arguments relatively instead of absolutely i.e. `AMchangesNext(&changes, 1)` advances `changes` one position regardless of whether its current direction is forward or reverse.
*  Obfuscated the members within the `AMchangeHashes`,  `AMchanges` and `AMsyncHaves` structs for safety and to permit their structures to change independently of the C API.