### PR TITLE
Serialize Counter with it's current value instead of start value

### DIFF
--- a/automerge/src/value.rs
+++ b/automerge/src/value.rs
@@ -362,7 +362,7 @@ impl Serialize for Counter {
     where
         S: Serializer,
     {
-        serializer.serialize_i64(self.start)
+        serializer.serialize_i64(self.current)
     }
 }
 


### PR DESCRIPTION
I'm assuming this was a mistake. I think the right way to serialize a Counter is to return its current value, not its start value.