### PR TITLE
insert query caching

### DIFF
--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -160,6 +160,30 @@ impl OpSetInternal {
         self.length
     }
 
+    pub(crate) fn hint_clear(&mut self, obj: &ObjId) {
+        if let Some(tree) = self.trees.get_mut(obj) {
+            tree.internal.cache.clear();
+        }
+    }
+
+    pub(crate) fn hint_delete(&mut self, pos: usize, obj: &ObjId) {
+        if let Some(tree) = self.trees.get_mut(obj) {
+            tree.internal.cache.delete(pos);
+        }
+    }
+
+    pub(crate) fn hint_shift(&mut self, index: Option<usize>, pos: usize, obj: &ObjId) {
+        if let Some(tree) = self.trees.get_mut(obj) {
+            tree.internal.cache.shift(index, pos);
+        }
+    }
+
+    pub(crate) fn hint_insert(&mut self, index: usize, pos: usize, obj: &ObjId, element: &Op) {
+        if let Some(tree) = self.trees.get_mut(obj) {
+            tree.internal.cache.insert(index, pos, element);
+        }
+    }
+
     pub(crate) fn insert(&mut self, index: usize, obj: &ObjId, element: Op) {
         if let OpType::Make(typ) = element.action {
             self.trees.insert(
@@ -180,6 +204,8 @@ impl OpSetInternal {
     }
 
     pub(crate) fn insert_op(&mut self, obj: &ObjId, op: Op) -> Op {
+        self.hint_clear(obj);
+
         let q = self.search(obj, query::SeekOp::new(&op));
 
         let succ = q.succ;
@@ -201,6 +227,9 @@ impl OpSetInternal {
         op: Op,
         observer: &mut Obs,
     ) -> Op {
+        // FIXME
+        self.hint_clear(obj);
+
         let q = self.search(obj, query::SeekOpWithPatch::new(&op));
 
         let query::SeekOpWithPatch {

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -1,4 +1,4 @@
-use crate::op_tree::{OpSetMetadata, OpTreeNode};
+use crate::op_tree::{OpSetMetadata, OpTreeNode, QueryCache};
 use crate::types::{Clock, Counter, Key, Op, OpId, OpType, ScalarValue};
 use fxhash::FxBuildHasher;
 use std::cmp::Ordering;
@@ -85,6 +85,12 @@ pub(crate) trait TreeQuery<'a> {
     fn query_element(&mut self, _element: &'a Op) -> QueryResult {
         panic!("invalid element query")
     }
+
+    fn read_cache(&mut self, _cache: &QueryCache) -> bool {
+        false
+    }
+
+    fn update_cache(&mut self, _cache: &mut QueryCache) {}
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -575,3 +575,12 @@ impl From<Prop> for wasm_bindgen::JsValue {
         }
     }
 }
+
+impl From<&Prop> for Option<usize> {
+    fn from(prop: &Prop) -> Self {
+        match prop {
+            Prop::Map(_) => None,
+            Prop::Seq(index) => Some(*index),
+        }
+    }
+}


### PR DESCRIPTION
This is a rough draft of insert query caching.  The idea being that I maintain a small `pos` <-> `index` cache attached to list object trees and check that before running a `InsertNth` query.  This is handy for splices and insert character runs since characters tend to follow the previous one.  

Running the edit trace in rust I had the following results. 

Processing all inputs on main `295ms`
Processing all inputs with query cache `177ms`

So, nearly a doubling of throughput.

Notes:

I played with different values of `n` where `n` is the number of indexes to store - and the ideal number seems to be between 1 and 8.  I chose 4.

The edit trace is mostly inserts with some deletes.  Deletes require more complex caching and when i implemented it it slowed the whole process down by about 5%.   So currently I only do cache lookups on insert.

When merging non-local ops I blow the cache (but it cloud be preserved)

The algorithm is finicky and hard to validate.  I would want aggressive fuzz testing before allowing this to be merged.

The speed up seems hard to ignore.   Reasons to dismiss this might be 

1. its overly fit to the edit trace data - id like to see more comprehensive performance numbers before getting too excited
2. alternatively i want to try preserving runs of characters as single leaves on the op_tree.  This optimization is more comprehensive and may overlap with and therefore remove much of the benefit this optimization provides 