### PR TITLE
Add `AMactorId` to the C API

### DIFF
--- a/automerge-c/src/CMakeLists.txt
+++ b/automerge-c/src/CMakeLists.txt
@@ -51,6 +51,7 @@ add_custom_command(
     MAIN_DEPENDENCY
         lib.rs
     DEPENDS
+        actor_id.rs
         byte_span.rs
         change_hashes.rs
         change.rs

--- a/automerge-c/src/actor_id.rs
+++ b/automerge-c/src/actor_id.rs
@@ -1,0 +1,132 @@
+use automerge as am;
+use std::cell::RefCell;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::str::FromStr;
+
+use crate::byte_span::AMbyteSpan;
+use crate::result::{to_result, AMresult};
+
+/// \struct AMactorId
+/// \brief An actor's unique identifier.
+pub struct AMactorId {
+    body: am::ActorId,
+    c_str: RefCell<Option<CString>>,
+}
+
+impl AMactorId {
+    pub fn new(body: am::ActorId) -> Self {
+        Self {
+            body,
+            c_str: RefCell::<Option<CString>>::default(),
+        }
+    }
+
+    pub fn as_c_str(&self) -> *const c_char {
+        let mut c_str = self.c_str.borrow_mut();
+        match c_str.as_mut() {
+            None => {
+                let hex_str = self.body.to_hex_string();
+                c_str.insert(CString::new(hex_str).unwrap()).as_ptr()
+            }
+            Some(value) => value.as_ptr(),
+        }
+    }
+}
+
+impl AsRef<am::ActorId> for AMactorId {
+    fn as_ref(&self) -> &am::ActorId {
+        &self.body
+    }
+}
+
+/// \memberof AMactorId
+/// \brief Gets the value of an actor ID as a sequence of bytes.
+///
+/// \param[in] actor_id A pointer to an `AMactorId` struct.
+/// \pre \p actor_id must be a valid address.
+/// \return An `AMbyteSpan` struct.
+/// \internal
+///
+/// # Safety
+/// actor_id must be a pointer to a valid AMactorId
+#[no_mangle]
+pub unsafe extern "C" fn AMactorIdBytes(actor_id: *const AMactorId) -> AMbyteSpan {
+    match actor_id.as_ref() {
+        Some(actor_id) => actor_id.as_ref().into(),
+        None => AMbyteSpan::default(),
+    }
+}
+
+/// \memberof AMactorId
+/// \brief Allocates a new actor ID and initializes it with a random UUID.
+///
+/// \return A pointer to an `AMresult` struct containing a pointer to an
+///         `AMactorId` struct.
+/// \warning To avoid a memory leak, the returned `AMresult` struct must be
+///          deallocated with `AMfree()`.
+#[no_mangle]
+pub unsafe extern "C" fn AMactorIdInit() -> *mut AMresult {
+    to_result(Ok::<am::ActorId, am::AutomergeError>(am::ActorId::random()))
+}
+
+/// \memberof AMactorId
+/// \brief Allocates a new actor ID and initializes it from a sequence of
+///        bytes.
+///
+/// \param[in] src A pointer to a contiguous sequence of bytes.
+/// \param[in] count The number of bytes to copy from \p src.
+/// \pre `0 <=` \p count `<=` length of \p src.
+/// \return A pointer to an `AMresult` struct containing a pointer to an
+///         `AMactorId` struct.
+/// \warning To avoid a memory leak, the returned `AMresult` struct must be
+///          deallocated with `AMfree()`.
+/// \internal
+///
+/// # Safety
+/// src must be a byte array of length `>= count`
+#[no_mangle]
+pub unsafe extern "C" fn AMactorIdInitBytes(src: *const u8, count: usize) -> *mut AMresult {
+    let slice = std::slice::from_raw_parts(src, count);
+    to_result(Ok::<am::ActorId, am::InvalidActorId>(am::ActorId::from(
+        slice,
+    )))
+}
+
+/// \memberof AMactorId
+/// \brief Allocates a new actor ID and initializes it from a hexadecimal
+///        string.
+///
+/// \param[in] hex_str A UTF-8 string.
+/// \return A pointer to an `AMresult` struct containing a pointer to an
+///         `AMactorId` struct.
+/// \warning To avoid a memory leak, the returned `AMresult` struct must be
+///          deallocated with `AMfree()`.
+/// \internal
+///
+/// # Safety
+/// hex_str must be a null-terminated array of `c_char`
+#[no_mangle]
+pub unsafe extern "C" fn AMactorIdInitStr(hex_str: *const c_char) -> *mut AMresult {
+    to_result(am::ActorId::from_str(
+        CStr::from_ptr(hex_str).to_str().unwrap(),
+    ))
+}
+
+/// \memberof AMactorId
+/// \brief Gets the value of an actor ID as a hexadecimal string.
+///
+/// \param[in] actor_id A pointer to an `AMactorId` struct.
+/// \pre \p actor_id must be a valid address.
+/// \return A UTF-8 string.
+/// \internal
+///
+/// # Safety
+/// actor_id must be a pointer to a valid AMactorId
+#[no_mangle]
+pub unsafe extern "C" fn AMactorIdStr(actor_id: *const AMactorId) -> *const c_char {
+    match actor_id.as_ref() {
+        Some(actor_id) => actor_id.as_c_str(),
+        None => std::ptr::null::<c_char>(),
+    }
+}

--- a/automerge-c/src/doc/utils.rs
+++ b/automerge-c/src/doc/utils.rs
@@ -1,6 +1,18 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+macro_rules! to_actor_id {
+    ($handle:expr) => {{
+        let handle = $handle.as_ref();
+        match handle {
+            Some(b) => b,
+            None => return AMresult::err("Invalid AMactorId pointer").into(),
+        }
+    }};
+}
+
+pub(crate) use to_actor_id;
+
 macro_rules! to_doc {
     ($handle:expr) => {{
         let handle = $handle.as_mut();

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -1,3 +1,4 @@
+mod actor_id;
 mod byte_span;
 mod change;
 mod change_hashes;

--- a/automerge-c/test/CMakeLists.txt
+++ b/automerge-c/test/CMakeLists.txt
@@ -4,12 +4,14 @@ find_package(cmocka REQUIRED)
 
 add_executable(
     test_${LIBRARY_NAME}
-        group_state.c
+        actor_id_tests.c
         doc_tests.c
+        group_state.c
         list_tests.c
-        map_tests.c
         macro_utils.c
         main.c
+        map_tests.c
+        str_utils.c
         sync_tests.c
 )
 

--- a/automerge-c/test/actor_id_tests.c
+++ b/automerge-c/test/actor_id_tests.c
@@ -17,27 +17,26 @@ typedef struct {
     uint8_t* src;
     char const* str;
     size_t count;
-} TestState;
+} GroupState;
 
-static int setup(void** state) {
-    TestState* test_state = calloc(1, sizeof(TestState));
-    test_state->str = "000102030405060708090a0b0c0d0e0f";
-    test_state->count = strlen(test_state->str) / 2;
-    test_state->src = malloc(test_state->count);
-    hex_to_bytes(test_state->str, test_state->src, test_state->count);
-    *state = test_state;
+static int group_setup(void** state) {
+    GroupState* group_state = calloc(1, sizeof(GroupState));
+    group_state->str = "000102030405060708090a0b0c0d0e0f";
+    group_state->count = strlen(group_state->str) / 2;
+    group_state->src = malloc(group_state->count);
+    hex_to_bytes(group_state->str, group_state->src, group_state->count);
+    *state = group_state;
     return 0;
 }
 
-static int teardown(void** state) {
-    TestState* test_state = *state;
-    free(test_state->src);
-    free(test_state);
+static int group_teardown(void** state) {
+    GroupState* group_state = *state;
+    free(group_state->src);
+    free(group_state);
     return 0;
 }
 
 static void test_AMactorIdInit(void **state) {
-    TestState* test_state = *state;
     AMresult* prior_result = NULL;
     AMbyteSpan prior_bytes;
     char const* prior_str = NULL;
@@ -66,8 +65,8 @@ static void test_AMactorIdInit(void **state) {
 }
 
 static void test_AMactorIdInitBytes(void **state) {
-    TestState* test_state = *state;
-    AMresult* const result = AMactorIdInitBytes(test_state->src, test_state->count);
+    GroupState* group_state = *state;
+    AMresult* const result = AMactorIdInitBytes(group_state->src, group_state->count);
     if (AMresultStatus(result) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(result));
     }
@@ -75,14 +74,14 @@ static void test_AMactorIdInitBytes(void **state) {
     AMvalue const value = AMresultValue(result);
     assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
     AMbyteSpan const bytes = AMactorIdBytes(value.actor_id);
-    assert_int_equal(bytes.count, test_state->count);
-    assert_memory_equal(bytes.src, test_state->src, bytes.count);
+    assert_int_equal(bytes.count, group_state->count);
+    assert_memory_equal(bytes.src, group_state->src, bytes.count);
     AMfree(result);
 }
 
 static void test_AMactorIdInitStr(void **state) {
-    TestState* test_state = *state;
-    AMresult* const result = AMactorIdInitStr(test_state->str);
+    GroupState* group_state = *state;
+    AMresult* const result = AMactorIdInitStr(group_state->str);
     if (AMresultStatus(result) != AM_STATUS_OK) {
         fail_msg("%s", AMerrorMessage(result));
     }
@@ -90,17 +89,17 @@ static void test_AMactorIdInitStr(void **state) {
     AMvalue const value = AMresultValue(result);
     assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
     char const* const str = AMactorIdStr(value.actor_id);
-    assert_int_equal(strlen(str), test_state->count * 2);
-    assert_string_equal(str, test_state->str);
+    assert_int_equal(strlen(str), group_state->count * 2);
+    assert_string_equal(str, group_state->str);
     AMfree(result);
 }
 
 int run_actor_id_tests(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(test_AMactorIdInit, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_AMactorIdInitBytes, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_AMactorIdInitStr, setup, teardown),
+        cmocka_unit_test(test_AMactorIdInit),
+        cmocka_unit_test(test_AMactorIdInitBytes),
+        cmocka_unit_test(test_AMactorIdInitStr),
     };
 
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
 }

--- a/automerge-c/test/actor_id_tests.c
+++ b/automerge-c/test/actor_id_tests.c
@@ -40,6 +40,7 @@ static void test_AMactorIdInit(void **state) {
     TestState* test_state = *state;
     AMresult* prior_result = NULL;
     AMbyteSpan prior_bytes;
+    char const* prior_str = NULL;
     AMresult* result = NULL;
     for (size_t i = 0; i != 11; ++i) {
         result = AMactorIdInit();
@@ -50,13 +51,16 @@ static void test_AMactorIdInit(void **state) {
         AMvalue const value = AMresultValue(result);
         assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
         AMbyteSpan const bytes = AMactorIdBytes(value.actor_id);
+        char const* const str = AMactorIdStr(value.actor_id);
         if (prior_result) {
             size_t const min_count = fmax(bytes.count, prior_bytes.count);
             assert_memory_not_equal(bytes.src, prior_bytes.src, min_count);
+            assert_string_not_equal(str, prior_str);
             AMfree(prior_result);
         }
         prior_result = result;
         prior_bytes = bytes;
+        prior_str = str;
     }
     AMfree(result);
 }

--- a/automerge-c/test/actor_id_tests.c
+++ b/automerge-c/test/actor_id_tests.c
@@ -1,0 +1,102 @@
+#include <math.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* third-party */
+#include <cmocka.h>
+
+/* local */
+#include "automerge.h"
+#include "str_utils.h"
+
+typedef struct {
+    uint8_t* src;
+    char const* str;
+    size_t count;
+} TestState;
+
+static int setup(void** state) {
+    TestState* test_state = calloc(1, sizeof(TestState));
+    test_state->str = "000102030405060708090a0b0c0d0e0f";
+    test_state->count = strlen(test_state->str) / 2;
+    test_state->src = malloc(test_state->count);
+    hex_to_bytes(test_state->str, test_state->src, test_state->count);
+    *state = test_state;
+    return 0;
+}
+
+static int teardown(void** state) {
+    TestState* test_state = *state;
+    free(test_state->src);
+    free(test_state);
+    return 0;
+}
+
+static void test_AMactorIdInit(void **state) {
+    TestState* test_state = *state;
+    AMresult* prior_result = NULL;
+    AMbyteSpan prior_bytes;
+    AMresult* result = NULL;
+    for (size_t i = 0; i != 11; ++i) {
+        result = AMactorIdInit();
+        if (AMresultStatus(result) != AM_STATUS_OK) {
+            fail_msg("%s", AMerrorMessage(result));
+        }
+        assert_int_equal(AMresultSize(result), 1);
+        AMvalue const value = AMresultValue(result);
+        assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
+        AMbyteSpan const bytes = AMactorIdBytes(value.actor_id);
+        if (prior_result) {
+            size_t const min_count = fmax(bytes.count, prior_bytes.count);
+            assert_memory_not_equal(bytes.src, prior_bytes.src, min_count);
+            AMfree(prior_result);
+        }
+        prior_result = result;
+        prior_bytes = bytes;
+    }
+    AMfree(result);
+}
+
+static void test_AMactorIdInitBytes(void **state) {
+    TestState* test_state = *state;
+    AMresult* const result = AMactorIdInitBytes(test_state->src, test_state->count);
+    if (AMresultStatus(result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(result));
+    }
+    assert_int_equal(AMresultSize(result), 1);
+    AMvalue const value = AMresultValue(result);
+    assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
+    AMbyteSpan const bytes = AMactorIdBytes(value.actor_id);
+    assert_int_equal(bytes.count, test_state->count);
+    assert_memory_equal(bytes.src, test_state->src, bytes.count);
+    AMfree(result);
+}
+
+static void test_AMactorIdInitStr(void **state) {
+    TestState* test_state = *state;
+    AMresult* const result = AMactorIdInitStr(test_state->str);
+    if (AMresultStatus(result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(result));
+    }
+    assert_int_equal(AMresultSize(result), 1);
+    AMvalue const value = AMresultValue(result);
+    assert_int_equal(value.tag, AM_VALUE_ACTOR_ID);
+    char const* const str = AMactorIdStr(value.actor_id);
+    assert_int_equal(strlen(str), test_state->count * 2);
+    assert_string_equal(str, test_state->str);
+    AMfree(result);
+}
+
+int run_actor_id_tests(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_AMactorIdInit, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_AMactorIdInitBytes, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_AMactorIdInitStr, setup, teardown),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/automerge-c/test/main.c
+++ b/automerge-c/test/main.c
@@ -6,6 +6,8 @@
 /* third-party */
 #include <cmocka.h>
 
+extern int run_actor_id_tests(void);
+
 extern int run_doc_tests(void);
 
 extern int run_list_tests(void);
@@ -16,6 +18,7 @@ extern int run_sync_tests(void);
 
 int main(void) {
     return (
+        run_actor_id_tests() +
         run_doc_tests() +
         run_list_tests() +
         run_map_tests() +

--- a/automerge-c/test/str_utils.c
+++ b/automerge-c/test/str_utils.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdint.h>
+
+/* local */
+#include "str_utils.h"
+
+void hex_to_bytes(char const* hex_str, uint8_t* src, size_t const count) {
+    unsigned int byte;
+    char const* next = hex_str;
+    for (size_t index = 0; *next && index != count; next += 2, ++index) {
+        if (sscanf(next, "%02x", &byte) == 1) {
+            src[index] = (uint8_t)byte;
+        }
+    }
+}

--- a/automerge-c/test/str_utils.h
+++ b/automerge-c/test/str_utils.h
@@ -1,0 +1,14 @@
+#ifndef STR_UTILS_INCLUDED
+#define STR_UTILS_INCLUDED
+
+/**
+ * \brief Converts a hexadecimal string into a sequence of bytes.
+ *
+ * \param[in] hex_str A string.
+ * \param[in] src A pointer to a contiguous sequence of bytes.
+ * \param[in] count The number of bytes to copy to \p src.
+ * \pre \p count `<=` length of \p src.
+ */
+void hex_to_bytes(char const* hex_str, uint8_t* src, size_t const count);
+
+#endif

--- a/automerge-c/test/sync_tests.c
+++ b/automerge-c/test/sync_tests.c
@@ -278,8 +278,12 @@ static void test_converged_works_with_prior_sync_state(void **state) {
 static void test_converged_no_message_once_synced(void **state) {
     /* Create & synchronize two nodes. */
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "abc123"));
-    AMfree(AMsetActorHex(test_state->doc2, "def456"));
+    AMresult* actor_id_result = AMactorIdInitStr("abc123");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("def456");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     time_t const time = 0;
     for (size_t value = 0; value != 5; ++value) {
@@ -352,8 +356,12 @@ static void test_converged_no_message_once_synced(void **state) {
 static void test_converged_allow_simultaneous_messages(void **state) {
     /* Create & synchronize two nodes. */
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "abc123"));
-    AMfree(AMsetActorHex(test_state->doc2, "def456"));
+    AMresult* actor_id_result = AMactorIdInitStr("abc123");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("def456");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     time_t const time = 0;
     for (size_t value = 0; value != 5; ++value) {
@@ -505,8 +513,12 @@ static void test_converged_allow_simultaneous_messages(void **state) {
  */
 static void test_converged_assume_sent_changes_were_received(void **state) {
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     AMresult* items_result = AMmapPutObject(test_state->doc1,
                                             AM_ROOT,
@@ -595,8 +607,12 @@ static void test_diverged_works_without_prior_sync_state(void **state) {
 
     /* Create two peers both with divergent commits. */
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
     time_t const time = 0;
     for (size_t value = 0; value != 10; ++value) {
         AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
@@ -645,8 +661,12 @@ static void test_diverged_works_with_prior_sync_state(void **state) {
 
     /* Create two peers both with divergent commits. */
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
     time_t const time = 0;
     for (size_t value = 0; value != 10; ++value) {
         AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", value));
@@ -696,8 +716,12 @@ static void test_diverged_works_with_prior_sync_state(void **state) {
  */
 static void test_diverged_ensure_not_empty_after_sync(void **state) {
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     time_t const time = 0;
     for (size_t value = 0; value != 3; ++value) {
@@ -731,8 +755,12 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
        * We want to successfully sync (n1) with (r), even though (n1) believes
        * it's talking to (n2). */
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     /* n1 makes three changes which we synchronize to n2. */
     time_t const time = 0;
@@ -814,8 +842,12 @@ static void test_diverged_resync_after_node_crash_with_data_loss(void **state) {
  */
 static void test_diverged_resync_after_data_loss_without_disconnection(void **state) {
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     /* n1 makes three changes which we synchronize to n2. */
     time_t const time = 0;
@@ -839,7 +871,9 @@ static void test_diverged_resync_after_data_loss_without_disconnection(void **st
 
     AMresult* doc2_after_data_loss_result = AMcreate();
     AMdoc* doc2_after_data_loss = AMresultValue(doc2_after_data_loss_result).doc;
-    AMfree(AMsetActorHex(doc2_after_data_loss, "89abcdef"));
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(doc2_after_data_loss, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
 
     /* "n2" now has no data, but n1 still thinks it does. Note we don't do
      * decodeSyncState(encodeSyncState(s1)) in order to simulate data loss
@@ -868,11 +902,17 @@ static void test_diverged_resync_after_data_loss_without_disconnection(void **st
  */
 static void test_diverged_handles_concurrent_changes(void **state) {
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
     AMresult* doc3_result = AMcreate();
     AMdoc* doc3 = AMresultValue(doc3_result).doc;
-    AMfree(AMsetActorHex(doc3, "fedcba98"));
+    actor_id_result = AMactorIdInitStr("fedcba98");
+    AMfree(AMsetActor(doc3, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
     AMsyncState* sync_state12 = test_state->sync_state1;
     AMsyncState* sync_state21 = test_state->sync_state2;
     AMresult* sync_state23_result = AMsyncStateInit();
@@ -929,11 +969,17 @@ static void test_diverged_handles_concurrent_changes(void **state) {
  */
 static void test_diverged_handles_histories_of_branching_and_merging(void **state) {
     TestState* test_state = *state;
-    AMfree(AMsetActorHex(test_state->doc1, "01234567"));
-    AMfree(AMsetActorHex(test_state->doc2, "89abcdef"));
+    AMresult* actor_id_result = AMactorIdInitStr("01234567");
+    AMfree(AMsetActor(test_state->doc1, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
+    actor_id_result = AMactorIdInitStr("89abcdef");
+    AMfree(AMsetActor(test_state->doc2, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
     AMresult* doc3_result = AMcreate();
     AMdoc* doc3 = AMresultValue(doc3_result).doc;
-    AMfree(AMsetActorHex(doc3, "fedcba98"));
+    actor_id_result = AMactorIdInitStr("fedcba98");
+    AMfree(AMsetActor(doc3, AMresultValue(actor_id_result).actor_id));
+    AMfree(actor_id_result);
     time_t const time = 0;
     AMfree(AMmapPutUint(test_state->doc1, AM_ROOT, "x", 0));
     AMcommit(test_state->doc1, NULL, &time);

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -29,8 +29,6 @@ pub enum AutomergeError {
     MissingCounter,
     #[error("general failure")]
     Fail,
-    #[error(transparent)]
-    HexDecode(#[from] hex::FromHexError),
 }
 
 #[cfg(feature = "wasm")]

--- a/automerge/src/lib.rs
+++ b/automerge/src/lib.rs
@@ -92,6 +92,7 @@ pub use decoding::Error as DecodingError;
 pub use decoding::InvalidChangeError;
 pub use encoding::Error as EncodingError;
 pub use error::AutomergeError;
+pub use error::InvalidActorId;
 pub use exid::ExId as ObjId;
 pub use keys::Keys;
 pub use keys_at::KeysAt;


### PR DESCRIPTION
@orionz, I've exposed the `automerge::ActorId` struct to C so that the logic to convert from a hexadecimal string to bytes and _vice versa_ wouldn't be repeated for multiple structs and so that a client application/library can synthesize a conforming actor identifier without guesswork.

@lightsprint09, this PR removes `AMgetActorHex()`, `AMsetActorHex()` and updates `AMgetActor()`, `AMsetActor()` and `AMchangeActorId()`.