### PR TITLE
Fix TypeScript syntax error in `automerge-wasm` definitions

### DIFF
--- a/automerge-wasm/index.d.ts
+++ b/automerge-wasm/index.d.ts
@@ -1,2 +1,2 @@
 export * from "automerge-types"
-export default from "automerge-types"
+export { default } from "automerge-types"


### PR DESCRIPTION
I'm not sure if there are some configurations under which this works,
but I get

    index.d.ts:2:21 - error TS1005: ';' expected.

    2 export default from "automerge-types"
                          ~~~~~~~~~~~~~~~~~

both in my project that depends on `automerge-wasm` and when I run `tsc`
in this repo.

It seems like `export default from` is still a Stage 1 proposal, so I
wouldn't expect it to be supported by TS, although I couldn't really
find hard evidence one way or the other. It does seem like this syntax
should be exactly equivalent based on the proposal doc though.