### PR TITLE
Add AMkeys() to the C API

### DIFF
--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -61,10 +61,10 @@ struct StackNode {
 };
 
 /**
- * \brief Pushes the given result onto the given stack and then either gets a
- *        value with the given discriminant from the result or writes a message
- *        to `stderr`, frees all results in the stack and terminates the
- *        program.
+ * \brief Pushes the given result onto the given stack and then either gets the
+ *        value matching the given discriminant from that result or, failing
+ *        that, prints an error message to `stderr`, frees all results in that
+ *        stack and aborts.
  *
  * \param[in] stack A pointer to a pointer to a `ResultStack` struct.
 .* \param[in] result A pointer to an `AMresult` struct.
@@ -92,7 +92,6 @@ AMvalue push(ResultStack** stack, AMresult* result, AMvalueVariant const discrim
     top->result = result;
     top->next = *stack;
     *stack = top;
-
     AMstatus const status = AMresultStatus(result);
     if (status != AM_STATUS_OK) {
         switch (status) {
@@ -108,27 +107,27 @@ AMvalue push(ResultStack** stack, AMresult* result, AMvalueVariant const discrim
     if (value.tag != discriminant) {
         char const* label = NULL;
         switch (value.tag) {
-            case AM_VALUE_ACTOR_ID:      label = "AM_VALUE_ACTOR_ID";      break;
-            case AM_VALUE_BOOLEAN:       label = "AM_VALUE_BOOLEAN";       break;
-            case AM_VALUE_BYTES:         label = "AM_VALUE_BYTES";         break;
-            case AM_VALUE_CHANGE_HASHES: label = "AM_VALUE_CHANGE_HASHES"; break;
-            case AM_VALUE_CHANGES:       label = "AM_VALUE_CHANGES";       break;
-            case AM_VALUE_COUNTER:       label = "AM_VALUE_COUNTER";       break;
-            case AM_VALUE_DOC:           label = "AM_VALUE_DOC";           break;
-            case AM_VALUE_F64:           label = "AM_VALUE_F64";           break;
-            case AM_VALUE_INT:           label = "AM_VALUE_INT";           break;
-            case AM_VALUE_NULL:          label = "AM_VALUE_NULL";          break;
-            case AM_VALUE_OBJ_ID:        label = "AM_VALUE_OBJ_ID";        break;
-            case AM_VALUE_STR:           label = "AM_VALUE_STR";           break;
-            case AM_VALUE_STRINGS:       label = "AM_VALUE_STRINGS";       break;
-            case AM_VALUE_TIMESTAMP:     label = "AM_VALUE_TIMESTAMP";     break;
-            case AM_VALUE_UINT:          label = "AM_VALUE_UINT";          break;
-            case AM_VALUE_SYNC_MESSAGE:  label = "AM_VALUE_SYNC_MESSAGE";  break;
-            case AM_VALUE_SYNC_STATE:    label = "AM_VALUE_SYNC_STATE";    break;
-            case AM_VALUE_VOID:          label = "AM_VALUE_VOID";          break;
-            default:                     label = "<unknown>";
+            case AM_VALUE_ACTOR_ID:      label = "ACTOR_ID";      break;
+            case AM_VALUE_BOOLEAN:       label = "BOOLEAN";       break;
+            case AM_VALUE_BYTES:         label = "BYTES";         break;
+            case AM_VALUE_CHANGE_HASHES: label = "CHANGE_HASHES"; break;
+            case AM_VALUE_CHANGES:       label = "CHANGES";       break;
+            case AM_VALUE_COUNTER:       label = "COUNTER";       break;
+            case AM_VALUE_DOC:           label = "DOC";           break;
+            case AM_VALUE_F64:           label = "F64";           break;
+            case AM_VALUE_INT:           label = "INT";           break;
+            case AM_VALUE_NULL:          label = "NULL";          break;
+            case AM_VALUE_OBJ_ID:        label = "OBJ_ID";        break;
+            case AM_VALUE_STR:           label = "STR";           break;
+            case AM_VALUE_STRINGS:       label = "STRINGS";       break;
+            case AM_VALUE_TIMESTAMP:     label = "TIMESTAMP";     break;
+            case AM_VALUE_UINT:          label = "UINT";          break;
+            case AM_VALUE_SYNC_MESSAGE:  label = "SYNC_MESSAGE";  break;
+            case AM_VALUE_SYNC_STATE:    label = "SYNC_STATE";    break;
+            case AM_VALUE_VOID:          label = "VOID";          break;
+            default:                     label = "...";
         }
-        fprintf(stderr, "Unexpected `AMvalueVariant` tag `%s` (%d).", label, value.tag);
+        fprintf(stderr, "Unexpected `AMvalueVariant` tag `AM_VALUE_%s` (%d).", label, value.tag);
         free_results(*stack);
         exit(EXIT_FAILURE);
     }

--- a/automerge-c/src/CMakeLists.txt
+++ b/automerge-c/src/CMakeLists.txt
@@ -62,6 +62,7 @@ add_custom_command(
         doc/utils.rs
         obj.rs
         result.rs
+        strings.rs
         sync.rs
         sync/have.rs
         sync/haves.rs
@@ -97,7 +98,7 @@ add_custom_command(
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
         ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
     COMMAND
-        # Compensate for cbindgen ignoring `std:mem::size_of<T>()` calls.
+        # Compensate for cbindgen ignoring `std:mem::size_of<usize>()` calls.
         ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
     WORKING_DIRECTORY
         ${CMAKE_SOURCE_DIR}

--- a/automerge-c/src/actor_id.rs
+++ b/automerge-c/src/actor_id.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn AMactorIdInit() -> *mut AMresult {
 ///
 /// \param[in] src A pointer to a contiguous sequence of bytes.
 /// \param[in] count The number of bytes to copy from \p src.
-/// \pre `0 <=` \p count `<=` length of \p src.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \return A pointer to an `AMresult` struct containing a pointer to an
 ///         `AMactorId` struct.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn AMactorIdInit() -> *mut AMresult {
 /// \internal
 ///
 /// # Safety
-/// src must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMactorIdInitBytes(src: *const u8, count: usize) -> *mut AMresult {
     let slice = std::slice::from_raw_parts(src, count);

--- a/automerge-c/src/byte_span.rs
+++ b/automerge-c/src/byte_span.rs
@@ -9,9 +9,9 @@ pub struct AMbyteSpan {
     /// \warning \p src is only valid until the `AMfree()` function is
     ///          called on the `AMresult` struct hosting the array of bytes to
     ///          which it points.
-    src: *const u8,
+    pub src: *const u8,
     /// The number of bytes in the array.
-    count: usize,
+    pub count: usize,
 }
 
 impl Default for AMbyteSpan {

--- a/automerge-c/src/change.rs
+++ b/automerge-c/src/change.rs
@@ -133,13 +133,13 @@ pub unsafe extern "C" fn AMchangeExtraBytes(change: *const AMchange) -> AMbyteSp
 /// \param[in] count The number of bytes in \p src to load.
 /// \return A pointer to an `AMresult` struct containing an `AMchange` struct.
 /// \pre \p src must be a valid address.
-/// \pre `0 <=` \p count `<=` length of \p src.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
 ///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
-/// src must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMchangeFromBytes(src: *const u8, count: usize) -> *mut AMresult {
     let mut data = Vec::new();
@@ -329,13 +329,13 @@ pub unsafe extern "C" fn AMchangeRawBytes(change: *const AMchange) -> AMbyteSpan
 /// \return A pointer to an `AMresult` struct containing a sequence of
 ///         `AMchange` structs.
 /// \pre \p src must be a valid address.
-/// \pre `0 <=` \p count `<=` length of \p src.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
 ///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
-/// src must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMchangeLoadDocument(src: *const u8, count: usize) -> *mut AMresult {
     let mut data = Vec::new();

--- a/automerge-c/src/change.rs
+++ b/automerge-c/src/change.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn AMchangeActorId(change: *const AMchange) -> *mut AMresu
 /// \memberof AMchange
 /// \brief Compresses the raw bytes of a change.
 ///
-/// \param[in] change A pointer to an `AMchange` struct.
+/// \param[in,out] change A pointer to an `AMchange` struct.
 /// \pre \p change must be a valid address.
 /// \internal
 ///

--- a/automerge-c/src/change_hashes.rs
+++ b/automerge-c/src/change_hashes.rs
@@ -164,7 +164,7 @@ impl Default for AMchangeHashes {
 ///        \p |n| positions where the sign of \p n is relative to the
 ///        iterator's direction.
 ///
-/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \param[in,out] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \pre \p change_hashes must be a valid address.
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn AMchangeHashesInit(src: *const AMbyteSpan, count: usize
 ///        positions where the sign of \p n is relative to the iterator's
 ///        direction.
 ///
-/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \param[in,out] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return An `AMbyteSpan` struct with `.src == NULL` when \p change_hashes
@@ -285,7 +285,7 @@ pub unsafe extern "C" fn AMchangeHashesNext(
 ///        iterator's direction and then gets the change hash at its new
 ///        position.
 ///
-/// \param[in] change_hashes A pointer to an `AMchangeHashes` struct.
+/// \param[in,out] change_hashes A pointer to an `AMchangeHashes` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return An `AMbyteSpan` struct with `.src == NULL` when \p change_hashes is

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -186,7 +186,7 @@ impl Default for AMchanges {
 ///        positions where the sign of \p n is relative to the iterator's
 ///        direction.
 ///
-/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \param[in,out] changes A pointer to an `AMchanges` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \pre \p changes must be a valid address.
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn AMchangesEqual(
 ///        sequence of changes and then advances it by at most \p |n| positions
 ///        where the sign of \p n is relative to the iterator's direction.
 ///
-/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \param[in,out] changes A pointer to an `AMchanges` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return A pointer to an `AMchange` struct that's `NULL` when \p changes was
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn AMchangesNext(changes: *mut AMchanges, n: isize) -> *co
 ///        positions where the sign of \p n is relative to the iterator's
 ///        direction and then gets the change at its new position.
 ///
-/// \param[in] changes A pointer to an `AMchanges` struct.
+/// \param[in,out] changes A pointer to an `AMchanges` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return A pointer to an `AMchange` struct that's `NULL` when \p changes is

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -32,11 +32,16 @@ impl Detail {
     }
 
     pub fn advance(&mut self, n: isize) {
-        if n != 0 && !self.is_stopped() {
-            let n = if self.offset < 0 { -n } else { n };
-            let len = self.len as isize;
-            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
-        };
+        if n == 0 {
+            return;
+        }
+        let len = self.len as isize;
+        self.offset = if self.offset < 0 {
+            /* It's reversed. */
+            std::cmp::max(-(len + 1), std::cmp::min(self.offset - n, -1))
+        } else {
+            std::cmp::max(0, std::cmp::min(self.offset + n, len))
+        }
     }
 
     pub fn get_index(&self) -> usize {
@@ -49,7 +54,7 @@ impl Detail {
     }
 
     pub fn next(&mut self, n: isize) -> Option<*const AMchange> {
-        if n == 0 || self.is_stopped() {
+        if self.is_stopped() {
             return None;
         }
         let slice: &mut [am::Change] =
@@ -73,8 +78,10 @@ impl Detail {
     }
 
     pub fn prev(&mut self, n: isize) -> Option<*const AMchange> {
-        self.advance(n);
-        if n == 0 || self.is_stopped() {
+        /* Check for rewinding. */
+        let prior_offset = self.offset;
+        self.advance(-n);
+        if (self.offset == prior_offset) || self.is_stopped() {
             return None;
         }
         let slice: &mut [am::Change] =

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -49,7 +49,7 @@ impl Detail {
     }
 
     pub fn next(&mut self, n: isize) -> Option<*const AMchange> {
-        if self.is_stopped() {
+        if n == 0 || self.is_stopped() {
             return None;
         }
         let slice: &mut [am::Change] =
@@ -74,7 +74,7 @@ impl Detail {
 
     pub fn prev(&mut self, n: isize) -> Option<*const AMchange> {
         self.advance(n);
-        if self.is_stopped() {
+        if n == 0 || self.is_stopped() {
             return None;
         }
         let slice: &mut [am::Change] =
@@ -117,7 +117,10 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
 /// \brief A random-access iterator over a sequence of changes.
 #[repr(C)]
 pub struct AMchanges {
-    /// Reserved.
+    /// An implementation detail that is intentionally opaque.
+    /// \warning Modifying \p detail will cause undefined behavior.
+    /// \note The actual size of \p detail will vary by platform, this is just
+    ///       the one for the platform this documentation was built on.
     detail: [u8; USIZE_USIZE_USIZE_USIZE_],
 }
 

--- a/automerge-c/src/doc.rs
+++ b/automerge-c/src/doc.rs
@@ -15,7 +15,7 @@ mod utils;
 
 use crate::changes::AMchanges;
 use crate::doc::utils::to_str;
-use crate::doc::utils::{to_actor_id, to_doc, to_obj_id};
+use crate::doc::utils::{to_actor_id, to_doc, to_doc_const, to_obj_id};
 
 macro_rules! to_changes {
     ($handle:expr) => {{
@@ -71,7 +71,7 @@ impl DerefMut for AMdoc {
 /// \memberof AMdoc
 /// \brief Applies a sequence of changes to a document.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] changes A pointer to an `AMchanges` struct.
 /// \pre \p doc must be a valid address.
 /// \pre \p changes must be a valid address.
@@ -109,7 +109,7 @@ pub extern "C" fn AMcreate() -> *mut AMresult {
 /// \brief Commits the current operations on a document with an optional
 ///        message and/or time override as seconds since the epoch.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] message A UTF-8 string or `NULL`.
 /// \param[in] time A pointer to a `time_t` value or `NULL`.
 /// \return A pointer to an `AMresult` struct containing a change hash as an
@@ -142,7 +142,7 @@ pub unsafe extern "C" fn AMcommit(
 /// \brief Allocates storage for a document and initializes it by duplicating
 ///        the given document.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing a pointer to an
 ///         `AMdoc` struct.
 /// \pre \p doc must be a valid address.
@@ -153,8 +153,8 @@ pub unsafe extern "C" fn AMcommit(
 /// # Safety
 /// doc must be a pointer to a valid AMdoc
 #[no_mangle]
-pub unsafe extern "C" fn AMdup(doc: *mut AMdoc) -> *mut AMresult {
-    let doc = to_doc!(doc);
+pub unsafe extern "C" fn AMdup(doc: *const AMdoc) -> *mut AMresult {
+    let doc = to_doc_const!(doc);
     to_result(doc.as_ref().clone())
 }
 
@@ -162,8 +162,8 @@ pub unsafe extern "C" fn AMdup(doc: *mut AMdoc) -> *mut AMresult {
 /// \brief Tests the equality of two documents after closing their respective
 ///        transactions.
 ///
-/// \param[in] doc1 An `AMdoc` struct.
-/// \param[in] doc2 An `AMdoc` struct.
+/// \param[in,out] doc1 An `AMdoc` struct.
+/// \param[in,out] doc2 An `AMdoc` struct.
 /// \return `true` if \p doc1 `==` \p doc2 and `false` otherwise.
 /// \pre \p doc1 must be a valid address.
 /// \pre \p doc2 must be a valid address.
@@ -184,8 +184,8 @@ pub unsafe extern "C" fn AMequal(doc1: *mut AMdoc, doc2: *mut AMdoc) -> bool {
 /// \brief Generates a synchronization message for a peer based upon the given
 ///        synchronization state.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] sync_state A pointer to an `AMsyncState` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] sync_state A pointer to an `AMsyncState` struct.
 /// \return A pointer to an `AMresult` struct containing either a pointer to an
 ///         `AMsyncMessage` struct or a void.
 /// \pre \p doc must b e a valid address.
@@ -221,8 +221,8 @@ pub unsafe extern "C" fn AMgenerateSyncMessage(
 /// # Safety
 /// doc must be a pointer to a valid AMdoc
 #[no_mangle]
-pub unsafe extern "C" fn AMgetActor(doc: *mut AMdoc) -> *mut AMresult {
-    let doc = to_doc!(doc);
+pub unsafe extern "C" fn AMgetActor(doc: *const AMdoc) -> *mut AMresult {
+    let doc = to_doc_const!(doc);
     to_result(Ok::<am::ActorId, am::AutomergeError>(
         doc.get_actor().clone(),
     ))
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn AMgetActor(doc: *mut AMdoc) -> *mut AMresult {
 /// \memberof AMdoc
 /// \brief Gets the changes added to a document by their respective hashes.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] have_deps A pointer to an `AMchangeHashes` struct or `NULL`.
 /// \return A pointer to an `AMresult` struct containing an `AMchanges` struct.
 /// \pre \p doc must be a valid address.
@@ -259,8 +259,8 @@ pub unsafe extern "C" fn AMgetChanges(
 /// \brief Gets the changes added to a second document that weren't added to
 ///        a first document.
 ///
-/// \param[in] doc1 An `AMdoc` struct.
-/// \param[in] doc2 An `AMdoc` struct.
+/// \param[in,out] doc1 An `AMdoc` struct.
+/// \param[in,out] doc2 An `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing an `AMchanges` struct.
 /// \pre \p doc1 must be a valid address.
 /// \pre \p doc2 must be a valid address.
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn AMgetChangesAdded(doc1: *mut AMdoc, doc2: *mut AMdoc) -
 /// \memberof AMdoc
 /// \brief Gets the current heads of a document.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing an `AMchangeHashes`
 ///         struct.
 /// \pre \p doc must be a valid address.
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn AMgetHeads(doc: *mut AMdoc) -> *mut AMresult {
 /// \brief Gets the hashes of the changes in a document that aren't transitive
 ///        dependencies of the given hashes of changes.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] heads A pointer to an `AMchangeHashes` struct or `NULL`.
 /// \return A pointer to an `AMresult` struct containing an `AMchangeHashes`
 ///         struct.
@@ -332,7 +332,7 @@ pub unsafe extern "C" fn AMgetMissingDeps(
 /// \memberof AMdoc
 /// \brief Gets the last change made to a document.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing either an `AMchange`
 ///         struct or a void.
 /// \pre \p doc must be a valid address.
@@ -367,11 +367,11 @@ pub unsafe extern "C" fn AMgetLastLocalChange(doc: *mut AMdoc) -> *mut AMresult 
 /// heads must be a pointer to a valid AMchangeHashes or NULL
 #[no_mangle]
 pub unsafe extern "C" fn AMkeys(
-    doc: *mut AMdoc,
+    doc: *const AMdoc,
     obj_id: *const AMobjId,
     heads: *const AMchangeHashes,
 ) -> *mut AMresult {
-    let doc = to_doc!(doc);
+    let doc = to_doc_const!(doc);
     let obj_id = to_obj_id!(obj_id);
     match heads.as_ref() {
         None => to_result(doc.keys(obj_id)),
@@ -405,7 +405,7 @@ pub unsafe extern "C" fn AMload(src: *const u8, count: usize) -> *mut AMresult {
 /// \memberof AMdoc
 /// \brief Loads the compact form of an incremental save into a document.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] src A pointer to an array of bytes.
 /// \param[in] count The number of bytes in \p src to load.
 /// \return A pointer to an `AMresult` struct containing the number of
@@ -436,8 +436,8 @@ pub unsafe extern "C" fn AMloadIncremental(
 /// \brief Applies all of the changes in \p src which are not in \p dest to
 ///        \p dest.
 ///
-/// \param[in] dest A pointer to an `AMdoc` struct.
-/// \param[in] src A pointer to an `AMdoc` struct.
+/// \param[in,out] dest A pointer to an `AMdoc` struct.
+/// \param[in,out] src A pointer to an `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing an `AMchangeHashes`
 ///         struct.
 /// \pre \p dest must be a valid address.
@@ -499,8 +499,8 @@ pub unsafe extern "C" fn AMobjSize(
 /// # Safety
 /// doc must be a pointer to a valid AMdoc
 #[no_mangle]
-pub unsafe extern "C" fn AMpendingOps(doc: *mut AMdoc) -> usize {
-    if let Some(doc) = doc.as_mut() {
+pub unsafe extern "C" fn AMpendingOps(doc: *const AMdoc) -> usize {
+    if let Some(doc) = doc.as_ref() {
         doc.pending_ops()
     } else {
         0
@@ -511,8 +511,8 @@ pub unsafe extern "C" fn AMpendingOps(doc: *mut AMdoc) -> usize {
 /// \brief Receives a synchronization message from a peer based upon a given
 ///        synchronization state.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] sync_state A pointer to an `AMsyncState` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] sync_state A pointer to an `AMsyncState` struct.
 /// \param[in] sync_message A pointer to an `AMsyncMessage` struct.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
@@ -540,7 +540,7 @@ pub unsafe extern "C" fn AMreceiveSyncMessage(
 /// \brief Cancels the pending operations added during a document's current
 ///        transaction and gets the number of cancellations.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \return The count of pending operations for \p doc that were cancelled.
 /// \pre \p doc must be a valid address.
 /// \internal
@@ -559,7 +559,7 @@ pub unsafe extern "C" fn AMrollback(doc: *mut AMdoc) -> usize {
 /// \memberof AMdoc
 /// \brief Saves the entirety of a document into a compact form.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing an array of bytes as
 ///         an `AMbyteSpan` struct.
 /// \pre \p doc must be a valid address.
@@ -579,7 +579,7 @@ pub unsafe extern "C" fn AMsave(doc: *mut AMdoc) -> *mut AMresult {
 /// \brief Saves the changes to a document since its last save into a compact
 ///        form.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \return A pointer to an `AMresult` struct containing an array of bytes as
 ///         an `AMbyteSpan` struct.
 /// \pre \p doc must be a valid address.
@@ -598,7 +598,7 @@ pub unsafe extern "C" fn AMsaveIncremental(doc: *mut AMdoc) -> *mut AMresult {
 /// \memberof AMdoc
 /// \brief Puts the actor ID value of a document.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] actor_id A pointer to an `AMactorId` struct.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
@@ -616,4 +616,68 @@ pub unsafe extern "C" fn AMsetActor(doc: *mut AMdoc, actor_id: *const AMactorId)
     let actor_id = to_actor_id!(actor_id);
     doc.set_actor(actor_id.as_ref().clone());
     to_result(Ok(()))
+}
+
+/// \memberof AMdoc
+/// \brief Splices new characters into the identified text object at a given
+///        index.
+///
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
+/// \param[in] index An index in the text object identified by \p obj_id.
+/// \param[in] del The number of characters to delete.
+/// \param[in] text A UTF-8 string.
+/// \return A pointer to an `AMresult` struct containing a void.
+/// \pre \p doc must be a valid address.
+/// \pre `0 <=` \p index `<=` length of the text object identified by \p obj_id.
+/// \pre \p text must be a valid address.
+/// \warning To avoid a memory leak, the returned `AMresult` struct must be
+///          deallocated with `AMfree()`.
+/// \internal
+///
+/// # Safety
+/// doc must be a pointer to a valid AMdoc
+/// obj_id must be a pointer to a valid AMobjId or NULL
+/// text must be a null-terminated array of `c_char`
+#[no_mangle]
+pub unsafe extern "C" fn AMspliceText(
+    doc: *mut AMdoc,
+    obj_id: *const AMobjId,
+    index: usize,
+    del: usize,
+    text: *const c_char,
+) -> *mut AMresult {
+    let doc = to_doc!(doc);
+    to_result(doc.splice_text(to_obj_id!(obj_id), index, del, &to_str(text)))
+}
+
+/// \memberof AMdoc
+/// \brief Gets the current or historical string represented by a text object.
+///
+/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
+/// \param[in] heads A pointer to an `AMchangeHashes` struct for historical
+///                  keys or `NULL` for current keys.
+/// \return A pointer to an `AMresult` struct containing a UTF-8 string.
+/// \pre \p doc must be a valid address.
+/// \warning To avoid a memory leak, the returned `AMresult` struct must be
+///          deallocated with `AMfree()`.
+/// \internal
+///
+/// # Safety
+/// doc must be a pointer to a valid AMdoc
+/// obj_id must be a pointer to a valid AMobjId or NULL
+/// heads must be a pointer to a valid AMchangeHashes or NULL
+#[no_mangle]
+pub unsafe extern "C" fn AMtext(
+    doc: *const AMdoc,
+    obj_id: *const AMobjId,
+    heads: *const AMchangeHashes,
+) -> *mut AMresult {
+    let doc = to_doc_const!(doc);
+    let obj_id = to_obj_id!(obj_id);
+    match heads.as_ref() {
+        None => to_result(doc.text(obj_id)),
+        Some(heads) => to_result(doc.text_at(obj_id, heads.as_ref())),
+    }
 }

--- a/automerge-c/src/doc/list.rs
+++ b/automerge-c/src/doc/list.rs
@@ -10,7 +10,7 @@ use crate::result::{to_result, AMresult};
 /// \brief Deletes an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn AMlistDelete(
 /// \brief Gets the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index within the list object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct.
 /// \pre \p doc must be a valid address.
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn AMlistGet(
 ///        value.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn AMlistIncrement(
 /// \brief Puts a boolean as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -127,17 +127,17 @@ pub unsafe extern "C" fn AMlistPutBool(
 /// \brief Puts a sequence of bytes as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
-/// \param[in] insert A flag to insert \p value before \p index instead of
-///            writing \p value over \p index.
-/// \param[in] value A pointer to an array of bytes.
-/// \param[in] count The number of bytes to copy from \p value.
+/// \param[in] insert A flag to insert \p src before \p index instead of
+///            writing \p src over \p index.
+/// \param[in] src A pointer to an array of bytes.
+/// \param[in] count The number of bytes to copy from \p src.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
 /// \pre `0 <=` \p index `<=` length of the list object identified by \p obj_id.
-/// \pre \p value must be a valid address.
-/// \pre `0 <=` \p count `<=` length of \p value.
+/// \pre \p src must be a valid address.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
 ///          deallocated with `AMfree()`.
 /// \internal
@@ -145,20 +145,20 @@ pub unsafe extern "C" fn AMlistPutBool(
 /// # Safety
 /// doc must be a pointer to a valid AMdoc
 /// obj_id must be a pointer to a valid AMobjId or NULL
-/// value must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMlistPutBytes(
     doc: *mut AMdoc,
     obj_id: *const AMobjId,
     index: usize,
     insert: bool,
-    value: *const u8,
+    src: *const u8,
     count: usize,
 ) -> *mut AMresult {
     let doc = to_doc!(doc);
     let obj_id = to_obj_id!(obj_id);
     let mut vec = Vec::new();
-    vec.extend_from_slice(std::slice::from_raw_parts(value, count));
+    vec.extend_from_slice(std::slice::from_raw_parts(src, count));
     to_result(if insert {
         doc.insert(obj_id, index, vec)
     } else {
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn AMlistPutBytes(
 /// \brief Puts a CRDT counter as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -207,7 +207,7 @@ pub unsafe extern "C" fn AMlistPutCounter(
 /// \brief Puts a float as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn AMlistPutF64(
 /// \brief Puts a signed integer as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -279,7 +279,7 @@ pub unsafe extern "C" fn AMlistPutInt(
 /// \brief Puts null as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -314,7 +314,7 @@ pub unsafe extern "C" fn AMlistPutNull(
 /// \brief Puts an empty object as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -351,7 +351,7 @@ pub unsafe extern "C" fn AMlistPutObject(
 /// \brief Puts a UTF-8 string as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -390,7 +390,7 @@ pub unsafe extern "C" fn AMlistPutStr(
 /// \brief Puts a Lamport timestamp as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn AMlistPutTimestamp(
 /// \brief Puts an unsigned integer as the value at an index in a list object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
 ///            writing \p value over \p index.

--- a/automerge-c/src/doc/list.rs
+++ b/automerge-c/src/doc/list.rs
@@ -2,14 +2,14 @@ use automerge as am;
 use automerge::transaction::Transactable;
 use std::os::raw::c_char;
 
-use crate::doc::{to_doc, to_obj_id, to_str, AMdoc};
+use crate::doc::{to_doc, to_doc_const, to_obj_id, to_str, AMdoc};
 use crate::obj::{AMobjId, AMobjType};
 use crate::result::{to_result, AMresult};
 
 /// \memberof AMdoc
 /// \brief Deletes an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -50,11 +50,11 @@ pub unsafe extern "C" fn AMlistDelete(
 /// obj_id must be a pointer to a valid AMobjId or NULL
 #[no_mangle]
 pub unsafe extern "C" fn AMlistGet(
-    doc: *mut AMdoc,
+    doc: *const AMdoc,
     obj_id: *const AMobjId,
     index: usize,
 ) -> *mut AMresult {
-    let doc = to_doc!(doc);
+    let doc = to_doc_const!(doc);
     to_result(doc.get(to_obj_id!(obj_id), index))
 }
 
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn AMlistGet(
 /// \brief Increments a counter at an index in a list object by the given
 ///        value.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn AMlistIncrement(
 /// \memberof AMdoc
 /// \brief Puts a boolean as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn AMlistPutBool(
 /// \memberof AMdoc
 /// \brief Puts a sequence of bytes as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p src before \p index instead of
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn AMlistPutBytes(
 /// \memberof AMdoc
 /// \brief Puts a CRDT counter as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn AMlistPutCounter(
 /// \memberof AMdoc
 /// \brief Puts a float as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -242,7 +242,7 @@ pub unsafe extern "C" fn AMlistPutF64(
 /// \memberof AMdoc
 /// \brief Puts a signed integer as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -278,7 +278,7 @@ pub unsafe extern "C" fn AMlistPutInt(
 /// \memberof AMdoc
 /// \brief Puts null as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn AMlistPutNull(
 /// \memberof AMdoc
 /// \brief Puts an empty object as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn AMlistPutObject(
 /// \memberof AMdoc
 /// \brief Puts a UTF-8 string as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -389,7 +389,7 @@ pub unsafe extern "C" fn AMlistPutStr(
 /// \memberof AMdoc
 /// \brief Puts a Lamport timestamp as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of
@@ -426,7 +426,7 @@ pub unsafe extern "C" fn AMlistPutTimestamp(
 /// \memberof AMdoc
 /// \brief Puts an unsigned integer as the value at an index in a list object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] index An index in the list object identified by \p obj_id.
 /// \param[in] insert A flag to insert \p value before \p index instead of

--- a/automerge-c/src/doc/map.rs
+++ b/automerge-c/src/doc/map.rs
@@ -3,14 +3,14 @@ use automerge::transaction::Transactable;
 use std::os::raw::c_char;
 
 use crate::doc::utils::to_str;
-use crate::doc::{to_doc, to_obj_id, AMdoc};
+use crate::doc::{to_doc, to_doc_const, to_obj_id, AMdoc};
 use crate::obj::{AMobjId, AMobjType};
 use crate::result::{to_result, AMresult};
 
 /// \memberof AMdoc
 /// \brief Deletes a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -53,18 +53,18 @@ pub unsafe extern "C" fn AMmapDelete(
 /// key must be a c string of the map key to be used
 #[no_mangle]
 pub unsafe extern "C" fn AMmapGet(
-    doc: *mut AMdoc,
+    doc: *const AMdoc,
     obj_id: *const AMobjId,
     key: *const c_char,
 ) -> *mut AMresult {
-    let doc = to_doc!(doc);
+    let doc = to_doc_const!(doc);
     to_result(doc.get(to_obj_id!(obj_id), to_str(key)))
 }
 
 /// \memberof AMdoc
 /// \brief Increments a counter for a key in a map object by the given value.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn AMmapIncrement(
 /// \memberof AMdoc
 /// \brief Puts a boolean as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A boolean.
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn AMmapPutBool(
 /// \memberof AMdoc
 /// \brief Puts a sequence of bytes as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] src A pointer to an array of bytes.
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn AMmapPutBytes(
 /// \memberof AMdoc
 /// \brief Puts a CRDT counter as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn AMmapPutCounter(
 /// \memberof AMdoc
 /// \brief Puts null as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn AMmapPutNull(
 /// \memberof AMdoc
 /// \brief Puts an empty object as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] obj_type An `AMobjIdType` enum tag.
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn AMmapPutObject(
 /// \memberof AMdoc
 /// \brief Puts a float as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit float.
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn AMmapPutF64(
 /// \memberof AMdoc
 /// \brief Puts a signed integer as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
@@ -305,7 +305,7 @@ pub unsafe extern "C" fn AMmapPutInt(
 /// \memberof AMdoc
 /// \brief Puts a UTF-8 string as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A UTF-8 string.
@@ -336,7 +336,7 @@ pub unsafe extern "C" fn AMmapPutStr(
 /// \memberof AMdoc
 /// \brief Puts a Lamport timestamp as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn AMmapPutTimestamp(
 /// \memberof AMdoc
 /// \brief Puts an unsigned integer as the value of a key in a map object.
 ///
-/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit unsigned integer.

--- a/automerge-c/src/doc/map.rs
+++ b/automerge-c/src/doc/map.rs
@@ -11,7 +11,7 @@ use crate::result::{to_result, AMresult};
 /// \brief Deletes a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn AMmapDelete(
 /// \brief Gets the value for a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct.
 /// \pre \p doc must be a valid address.
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn AMmapGet(
 /// \brief Increments a counter for a key in a map object by the given value.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn AMmapIncrement(
 /// \brief Puts a boolean as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A boolean.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -123,15 +123,15 @@ pub unsafe extern "C" fn AMmapPutBool(
 /// \brief Puts a sequence of bytes as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
-/// \param[in] value A pointer to an array of bytes.
-/// \param[in] count The number of bytes to copy from \p value.
+/// \param[in] src A pointer to an array of bytes.
+/// \param[in] count The number of bytes to copy from \p src.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
 /// \pre \p key must be a valid address.
-/// \pre \p value must be a valid address.
-/// \pre `0 <=` \p count `<=` length of \p value.
+/// \pre \p src must be a valid address.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
 ///          deallocated with `AMfree()`.
 /// \internal
@@ -140,18 +140,18 @@ pub unsafe extern "C" fn AMmapPutBool(
 /// doc must be a pointer to a valid AMdoc
 /// obj_id must be a pointer to a valid AMobjId or NULL
 /// key must be a c string of the map key to be used
-/// value must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMmapPutBytes(
     doc: *mut AMdoc,
     obj_id: *const AMobjId,
     key: *const c_char,
-    value: *const u8,
+    src: *const u8,
     count: usize,
 ) -> *mut AMresult {
     let doc = to_doc!(doc);
     let mut vec = Vec::new();
-    vec.extend_from_slice(std::slice::from_raw_parts(value, count));
+    vec.extend_from_slice(std::slice::from_raw_parts(src, count));
     to_result(doc.put(to_obj_id!(obj_id), to_str(key), vec))
 }
 
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn AMmapPutBytes(
 /// \brief Puts a CRDT counter as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn AMmapPutCounter(
 /// \brief Puts null as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \return A pointer to an `AMresult` struct containing a void.
 /// \pre \p doc must be a valid address.
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn AMmapPutNull(
 /// \brief Puts an empty object as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] obj_type An `AMobjIdType` enum tag.
 /// \return A pointer to an `AMresult` struct containing a pointer to an `AMobjId` struct.
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn AMmapPutObject(
 /// \brief Puts a float as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit float.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn AMmapPutF64(
 /// \brief Puts a signed integer as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn AMmapPutInt(
 /// \brief Puts a UTF-8 string as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A UTF-8 string.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn AMmapPutStr(
 /// \brief Puts a Lamport timestamp as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit signed integer.
 /// \return A pointer to an `AMresult` struct containing a void.
@@ -370,7 +370,7 @@ pub unsafe extern "C" fn AMmapPutTimestamp(
 /// \brief Puts an unsigned integer as the value of a key in a map object.
 ///
 /// \param[in] doc A pointer to an `AMdoc` struct.
-/// \param[in] obj_id A pointer to an `AMobjId` struct or `NULL`.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] key A UTF-8 string key for the map object identified by \p obj_id.
 /// \param[in] value A 64-bit unsigned integer.
 /// \return A pointer to an `AMresult` struct containing a void.

--- a/automerge-c/src/doc/utils.rs
+++ b/automerge-c/src/doc/utils.rs
@@ -25,6 +25,18 @@ macro_rules! to_doc {
 
 pub(crate) use to_doc;
 
+macro_rules! to_doc_const {
+    ($handle:expr) => {{
+        let handle = $handle.as_ref();
+        match handle {
+            Some(b) => b,
+            None => return AMresult::err("Invalid AMdoc pointer").into(),
+        }
+    }};
+}
+
+pub(crate) use to_doc_const;
+
 macro_rules! to_obj_id {
     ($handle:expr) => {{
         match $handle.as_ref() {

--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -6,4 +6,5 @@ mod changes;
 mod doc;
 mod obj;
 mod result;
+mod strings;
 mod sync;

--- a/automerge-c/src/strings.rs
+++ b/automerge-c/src/strings.rs
@@ -31,11 +31,16 @@ impl Detail {
     }
 
     pub fn advance(&mut self, n: isize) {
-        if n != 0 && !self.is_stopped() {
-            let n = if self.offset < 0 { -n } else { n };
-            let len = self.len as isize;
-            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
-        };
+        if n == 0 {
+            return;
+        }
+        let len = self.len as isize;
+        self.offset = if self.offset < 0 {
+            /* It's reversed. */
+            std::cmp::max(-(len + 1), std::cmp::min(self.offset - n, -1))
+        } else {
+            std::cmp::max(0, std::cmp::min(self.offset + n, len))
+        }
     }
 
     pub fn get_index(&self) -> usize {
@@ -48,7 +53,7 @@ impl Detail {
     }
 
     pub fn next(&mut self, n: isize) -> Option<*const c_char> {
-        if n == 0 || self.is_stopped() {
+        if self.is_stopped() {
             return None;
         }
         let slice: &[String] =
@@ -72,8 +77,10 @@ impl Detail {
     }
 
     pub fn prev(&mut self, n: isize) -> Option<*const c_char> {
-        self.advance(n);
-        if n == 0 || self.is_stopped() {
+        /* Check for rewinding. */
+        let prior_offset = self.offset;
+        self.advance(-n);
+        if (self.offset == prior_offset) || self.is_stopped() {
             return None;
         }
         let slice: &[String] =

--- a/automerge-c/src/strings.rs
+++ b/automerge-c/src/strings.rs
@@ -161,7 +161,7 @@ impl Default for AMstrings {
 ///        \p |n| positions where the sign of \p n is relative to the
 ///        iterator's direction.
 ///
-/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \param[in,out] strings A pointer to an `AMstrings` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \pre \p strings must be a valid address.
@@ -214,7 +214,7 @@ pub unsafe extern "C" fn AMstringsCmp(
 ///        sequence of UTF-8 strings and then advances it by at most \p |n|
 ///        positions where the sign of \p n is relative to the iterator's direction.
 ///
-/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \param[in,out] strings A pointer to an `AMstrings` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return A UTF-8 string that's `NULL` when \p strings was previously
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn AMstringsNext(strings: *mut AMstrings, n: isize) -> *co
 ///        \p |n| positions where the sign of \p n is relative to the
 ///        iterator's direction and then gets the key at its new position.
 ///
-/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \param[in,out] strings A pointer to an `AMstrings` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return A UTF-8 string that's `NULL` when \p strings is presently advanced

--- a/automerge-c/src/strings.rs
+++ b/automerge-c/src/strings.rs
@@ -1,0 +1,320 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::ffi::{c_void, CString};
+use std::mem::size_of;
+use std::os::raw::c_char;
+
+#[repr(C)]
+struct Detail {
+    len: usize,
+    offset: isize,
+    ptr: *const c_void,
+    storage: *mut c_void,
+}
+
+/// \note cbindgen won't propagate the value of a `std::mem::size_of<T>()` call
+///       (https://github.com/eqrion/cbindgen/issues/252) but it will
+///       propagate the name of a constant initialized from it so if the
+///       constant's name is a symbolic representation of the value it can be
+///       converted into a number by post-processing the header it generated.
+pub const USIZE_USIZE_USIZE_USIZE_: usize = size_of::<Detail>();
+
+impl Detail {
+    fn new(strings: &[String], offset: isize, storage: &mut BTreeMap<usize, CString>) -> Self {
+        let storage: *mut BTreeMap<usize, CString> = storage;
+        Self {
+            len: strings.len(),
+            offset,
+            ptr: strings.as_ptr() as *const c_void,
+            storage: storage as *mut c_void,
+        }
+    }
+
+    pub fn advance(&mut self, n: isize) {
+        if n != 0 && !self.is_stopped() {
+            let n = if self.offset < 0 { -n } else { n };
+            let len = self.len as isize;
+            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
+        };
+    }
+
+    pub fn get_index(&self) -> usize {
+        (self.offset
+            + if self.offset < 0 {
+                self.len as isize
+            } else {
+                0
+            }) as usize
+    }
+
+    pub fn next(&mut self, n: isize) -> Option<*const c_char> {
+        if n == 0 || self.is_stopped() {
+            return None;
+        }
+        let slice: &[String] =
+            unsafe { std::slice::from_raw_parts(self.ptr as *const String, self.len) };
+        let storage = unsafe { &mut *(self.storage as *mut BTreeMap<usize, CString>) };
+        let index = self.get_index();
+        let value = match storage.get_mut(&index) {
+            Some(value) => value,
+            None => {
+                storage.insert(index, CString::new(slice[index].as_str()).unwrap());
+                storage.get_mut(&index).unwrap()
+            }
+        };
+        self.advance(n);
+        Some(value.as_ptr())
+    }
+
+    pub fn is_stopped(&self) -> bool {
+        let len = self.len as isize;
+        self.offset < -len || self.offset == len
+    }
+
+    pub fn prev(&mut self, n: isize) -> Option<*const c_char> {
+        self.advance(n);
+        if n == 0 || self.is_stopped() {
+            return None;
+        }
+        let slice: &[String] =
+            unsafe { std::slice::from_raw_parts(self.ptr as *const String, self.len) };
+        let storage = unsafe { &mut *(self.storage as *mut BTreeMap<usize, CString>) };
+        let index = self.get_index();
+        Some(
+            match storage.get_mut(&index) {
+                Some(value) => value,
+                None => {
+                    storage.insert(index, CString::new(slice[index].as_str()).unwrap());
+                    storage.get_mut(&index).unwrap()
+                }
+            }
+            .as_ptr(),
+        )
+    }
+
+    pub fn reversed(&self) -> Self {
+        Self {
+            len: self.len,
+            offset: -(self.offset + 1),
+            ptr: self.ptr,
+            storage: self.storage,
+        }
+    }
+}
+
+impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
+    fn from(detail: Detail) -> Self {
+        unsafe {
+            std::slice::from_raw_parts(
+                (&detail as *const Detail) as *const u8,
+                USIZE_USIZE_USIZE_USIZE_,
+            )
+            .try_into()
+            .unwrap()
+        }
+    }
+}
+
+/// \struct AMstrings
+/// \brief A random-access iterator over a sequence of UTF-8 strings.
+#[repr(C)]
+pub struct AMstrings {
+    /// An implementation detail that is intentionally opaque.
+    /// \warning Modifying \p detail will cause undefined behavior.
+    /// \note The actual size of \p detail will vary by platform, this is just
+    ///       the one for the platform this documentation was built on.
+    detail: [u8; USIZE_USIZE_USIZE_USIZE_],
+}
+
+impl AMstrings {
+    pub fn new(strings: &[String], storage: &mut BTreeMap<usize, CString>) -> Self {
+        Self {
+            detail: Detail::new(strings, 0, storage).into(),
+        }
+    }
+
+    pub fn advance(&mut self, n: isize) {
+        let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
+        detail.advance(n);
+    }
+
+    pub fn len(&self) -> usize {
+        let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
+        detail.len
+    }
+
+    pub fn next(&mut self, n: isize) -> Option<*const c_char> {
+        let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
+        detail.next(n)
+    }
+
+    pub fn prev(&mut self, n: isize) -> Option<*const c_char> {
+        let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
+        detail.prev(n)
+    }
+
+    pub fn reversed(&self) -> Self {
+        let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
+        Self {
+            detail: detail.reversed().into(),
+        }
+    }
+}
+
+impl AsRef<[String]> for AMstrings {
+    fn as_ref(&self) -> &[String] {
+        let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
+        unsafe { std::slice::from_raw_parts(detail.ptr as *const String, detail.len) }
+    }
+}
+
+impl Default for AMstrings {
+    fn default() -> Self {
+        Self {
+            detail: [0; USIZE_USIZE_USIZE_USIZE_],
+        }
+    }
+}
+
+/// \memberof AMstrings
+/// \brief Advances an iterator over a sequence of UTF-8 strings by at most
+///        \p |n| positions where the sign of \p n is relative to the
+///        iterator's direction.
+///
+/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
+///              number of positions to advance.
+/// \pre \p strings must be a valid address.
+/// \internal
+///
+/// #Safety
+/// strings must be a pointer to a valid AMstrings
+#[no_mangle]
+pub unsafe extern "C" fn AMstringsAdvance(strings: *mut AMstrings, n: isize) {
+    if let Some(strings) = strings.as_mut() {
+        strings.advance(n);
+    };
+}
+
+/// \memberof AMstrings
+/// \brief Compares the sequences of UTF-8 strings underlying a pair of
+///        iterators.
+///
+/// \param[in] strings1 A pointer to an `AMstrings` struct.
+/// \param[in] strings2 A pointer to an `AMstrings` struct.
+/// \return `-1` if \p strings1 `<` \p strings2, `0` if
+///         \p strings1 `==` \p strings2 and `1` if
+///         \p strings1 `>` \p strings2.
+/// \pre \p strings1 must be a valid address.
+/// \pre \p strings2 must be a valid address.
+/// \internal
+///
+/// #Safety
+/// strings1 must be a pointer to a valid AMstrings
+/// strings2 must be a pointer to a valid AMstrings
+#[no_mangle]
+pub unsafe extern "C" fn AMstringsCmp(
+    strings1: *const AMstrings,
+    strings2: *const AMstrings,
+) -> isize {
+    match (strings1.as_ref(), strings2.as_ref()) {
+        (Some(strings1), Some(strings2)) => match strings1.as_ref().cmp(strings2.as_ref()) {
+            Ordering::Less => -1,
+            Ordering::Equal => 0,
+            Ordering::Greater => 1,
+        },
+        (None, Some(_)) => -1,
+        (Some(_), None) => 1,
+        (None, None) => 0,
+    }
+}
+
+/// \memberof AMstrings
+/// \brief Gets the key at the current position of an iterator over a
+///        sequence of UTF-8 strings and then advances it by at most \p |n|
+///        positions where the sign of \p n is relative to the iterator's direction.
+///
+/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
+///              number of positions to advance.
+/// \return A UTF-8 string that's `NULL` when \p strings was previously
+///         advanced past its forward/reverse limit.
+/// \pre \p strings must be a valid address.
+/// \internal
+///
+/// #Safety
+/// strings must be a pointer to a valid AMstrings
+#[no_mangle]
+pub unsafe extern "C" fn AMstringsNext(strings: *mut AMstrings, n: isize) -> *const c_char {
+    if let Some(strings) = strings.as_mut() {
+        if let Some(key) = strings.next(n) {
+            return key;
+        }
+    }
+    std::ptr::null()
+}
+
+/// \memberof AMstrings
+/// \brief Advances an iterator over a sequence of UTF-8 strings by at most
+///        \p |n| positions where the sign of \p n is relative to the
+///        iterator's direction and then gets the key at its new position.
+///
+/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
+///              number of positions to advance.
+/// \return A UTF-8 string that's `NULL` when \p strings is presently advanced
+///         past its forward/reverse limit.
+/// \pre \p strings must be a valid address.
+/// \internal
+///
+/// #Safety
+/// strings must be a pointer to a valid AMstrings
+#[no_mangle]
+pub unsafe extern "C" fn AMstringsPrev(strings: *mut AMstrings, n: isize) -> *const c_char {
+    if let Some(strings) = strings.as_mut() {
+        if let Some(key) = strings.prev(n) {
+            return key;
+        }
+    }
+    std::ptr::null()
+}
+
+/// \memberof AMstrings
+/// \brief Gets the size of the sequence of UTF-8 strings underlying an
+///        iterator.
+///
+/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \return The count of values in \p strings.
+/// \pre \p strings must be a valid address.
+/// \internal
+///
+/// #Safety
+/// strings must be a pointer to a valid AMstrings
+#[no_mangle]
+pub unsafe extern "C" fn AMstringsSize(strings: *const AMstrings) -> usize {
+    if let Some(strings) = strings.as_ref() {
+        strings.len()
+    } else {
+        0
+    }
+}
+
+/// \memberof AMstrings
+/// \brief Creates an iterator over the same sequence of UTF-8 strings as the
+///        given one but with the opposite position and direction.
+///
+/// \param[in] strings A pointer to an `AMstrings` struct.
+/// \return An `AMstrings` struct.
+/// \pre \p strings must be a valid address.
+/// \internal
+///
+/// #Safety
+/// strings must be a pointer to a valid AMstrings
+#[no_mangle]
+pub unsafe extern "C" fn AMstringsReversed(strings: *const AMstrings) -> AMstrings {
+    if let Some(strings) = strings.as_ref() {
+        strings.reversed()
+    } else {
+        AMstrings::default()
+    }
+}

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -53,7 +53,7 @@ impl Detail {
     }
 
     pub fn next(&mut self, n: isize) -> Option<*const AMsyncHave> {
-        if self.is_stopped() {
+        if n == 0 || self.is_stopped() {
             return None;
         }
         let slice: &[am::sync::Have] =
@@ -78,7 +78,7 @@ impl Detail {
 
     pub fn prev(&mut self, n: isize) -> Option<*const AMsyncHave> {
         self.advance(n);
-        if self.is_stopped() {
+        if n == 0 || self.is_stopped() {
             return None;
         }
         let slice: &[am::sync::Have] =
@@ -121,7 +121,10 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
 /// \brief A random-access iterator over a sequence of synchronization haves.
 #[repr(C)]
 pub struct AMsyncHaves {
-    /// Reserved.
+    /// An implementation detail that is intentionally opaque.
+    /// \warning Modifying \p detail will cause undefined behavior.
+    /// \note The actual size of \p detail will vary by platform, this is just
+    ///       the one for the platform this documentation was built on.
     detail: [u8; USIZE_USIZE_USIZE_USIZE_],
 }
 

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -36,11 +36,16 @@ impl Detail {
     }
 
     pub fn advance(&mut self, n: isize) {
-        if n != 0 && !self.is_stopped() {
-            let n = if self.offset < 0 { -n } else { n };
-            let len = self.len as isize;
-            self.offset = std::cmp::max(-(len + 1), std::cmp::min(self.offset + n, len));
-        };
+        if n == 0 {
+            return;
+        }
+        let len = self.len as isize;
+        self.offset = if self.offset < 0 {
+            /* It's reversed. */
+            std::cmp::max(-(len + 1), std::cmp::min(self.offset - n, -1))
+        } else {
+            std::cmp::max(0, std::cmp::min(self.offset + n, len))
+        }
     }
 
     pub fn get_index(&self) -> usize {
@@ -53,7 +58,7 @@ impl Detail {
     }
 
     pub fn next(&mut self, n: isize) -> Option<*const AMsyncHave> {
-        if n == 0 || self.is_stopped() {
+        if self.is_stopped() {
             return None;
         }
         let slice: &[am::sync::Have] =
@@ -77,8 +82,10 @@ impl Detail {
     }
 
     pub fn prev(&mut self, n: isize) -> Option<*const AMsyncHave> {
-        self.advance(n);
-        if n == 0 || self.is_stopped() {
+        /* Check for rewinding. */
+        let prior_offset = self.offset;
+        self.advance(-n);
+        if (self.offset == prior_offset) || self.is_stopped() {
             return None;
         }
         let slice: &[am::sync::Have] =

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -190,7 +190,7 @@ impl Default for AMsyncHaves {
 ///        most \p |n| positions where the sign of \p n is relative to the
 ///        iterator's direction.
 ///
-/// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
+/// \param[in,out] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \pre \p sync_haves must be a valid address.
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn AMsyncHavesEqual(
 ///        most \p |n| positions where the sign of \p n is relative to the
 ///        iterator's direction.
 ///
-/// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
+/// \param[in,out] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return A pointer to an `AMsyncHave` struct that's `NULL` when
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn AMsyncHavesNext(
 ///        iterator's direction and then gets the synchronization have at its
 ///        new position.
 ///
-/// \param[in] sync_haves A pointer to an `AMsyncHaves` struct.
+/// \param[in,out] sync_haves A pointer to an `AMsyncHaves` struct.
 /// \param[in] n The direction (\p -n -> opposite, \p n -> same) and maximum
 ///              number of positions to advance.
 /// \return A pointer to an `AMsyncHave` struct that's `NULL` when

--- a/automerge-c/src/sync/message.rs
+++ b/automerge-c/src/sync/message.rs
@@ -75,13 +75,13 @@ pub unsafe extern "C" fn AMsyncMessageChanges(sync_message: *const AMsyncMessage
 /// \return A pointer to an `AMresult` struct containing an `AMsyncMessage`
 ///         struct.
 /// \pre \p src must be a valid address.
-/// \pre `0 <=` \p count `<=` length of \p src.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
 ///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
-/// src must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMsyncMessageDecode(src: *const u8, count: usize) -> *mut AMresult {
     let mut data = Vec::new();

--- a/automerge-c/src/sync/state.rs
+++ b/automerge-c/src/sync/state.rs
@@ -61,13 +61,13 @@ impl From<AMsyncState> for *mut AMsyncState {
 /// \return A pointer to an `AMresult` struct containing an `AMsyncState`
 ///         struct.
 /// \pre \p src must be a valid address.
-/// \pre `0 <=` \p count `<=` length of \p src.
+/// \pre `0 <=` \p count `<=` size of \p src.
 /// \warning To avoid a memory leak, the returned `AMresult` struct must be
 ///          deallocated with `AMfree()`.
 /// \internal
 ///
 /// # Safety
-/// src must be a byte array of length `>= count`
+/// src must be a byte array of size `>= count`
 #[no_mangle]
 pub unsafe extern "C" fn AMsyncStateDecode(src: *const u8, count: usize) -> *mut AMresult {
     let mut data = Vec::new();

--- a/automerge-c/test/actor_id_tests.c
+++ b/automerge-c/test/actor_id_tests.c
@@ -36,7 +36,7 @@ static int group_teardown(void** state) {
     return 0;
 }
 
-static void test_AMactorIdInit(void **state) {
+static void test_AMactorIdInit() {
     AMresult* prior_result = NULL;
     AMbyteSpan prior_bytes;
     char const* prior_str = NULL;

--- a/automerge-c/test/doc_tests.c
+++ b/automerge-c/test/doc_tests.c
@@ -50,8 +50,10 @@ static void test_AMkeys_empty() {
     assert_int_equal(AMstringsSize(&value.strings), 0);
     AMstrings forward = value.strings;
     assert_null(AMstringsNext(&forward, 1));
+    assert_null(AMstringsPrev(&forward, 1));
     AMstrings reverse = AMstringsReversed(&value.strings);
     assert_null(AMstringsNext(&reverse, 1));
+    assert_null(AMstringsPrev(&reverse, 1));
     AMfree(strings_result);
     AMfree(doc_result);
 }
@@ -71,6 +73,7 @@ static void test_AMkeys_list() {
     assert_int_equal(value.tag, AM_VALUE_STRINGS);
     AMstrings forward = value.strings;
     assert_int_equal(AMstringsSize(&forward), 3);
+    /* Forward iterator forward. */
     char const* str = AMstringsNext(&forward, 1);
     assert_ptr_equal(strstr(str, "1@"), str);
     str = AMstringsNext(&forward, 1);
@@ -78,15 +81,32 @@ static void test_AMkeys_list() {
     str = AMstringsNext(&forward, 1);
     assert_ptr_equal(strstr(str, "3@"), str);
     assert_null(AMstringsNext(&forward, 1));
+    /* Forward iterator reverse. */
+    str = AMstringsPrev(&forward, 1);
+    assert_ptr_equal(strstr(str, "3@"), str);
+    str = AMstringsPrev(&forward, 1);
+    assert_ptr_equal(strstr(str, "2@"), str);
+    str = AMstringsPrev(&forward, 1);
+    assert_ptr_equal(strstr(str, "1@"), str);
+    assert_null(AMstringsPrev(&forward, 1));
     AMstrings reverse = AMstringsReversed(&value.strings);
     assert_int_equal(AMstringsSize(&reverse), 3);
+    /* Reverse iterator forward. */
     str = AMstringsNext(&reverse, 1);
     assert_ptr_equal(strstr(str, "3@"), str);
     str = AMstringsNext(&reverse, 1);
     assert_ptr_equal(strstr(str, "2@"), str);
     str = AMstringsNext(&reverse, 1);
     assert_ptr_equal(strstr(str, "1@"), str);
+    /* Reverse iterator reverse. */
     assert_null(AMstringsNext(&reverse, 1));
+    str = AMstringsPrev(&reverse, 1);
+    assert_ptr_equal(strstr(str, "1@"), str);
+    str = AMstringsPrev(&reverse, 1);
+    assert_ptr_equal(strstr(str, "2@"), str);
+    str = AMstringsPrev(&reverse, 1);
+    assert_ptr_equal(strstr(str, "3@"), str);
+    assert_null(AMstringsPrev(&reverse, 1));
     AMfree(strings_result);
     AMfree(doc_result);
 }
@@ -106,16 +126,28 @@ static void test_AMkeys_map() {
     assert_int_equal(value.tag, AM_VALUE_STRINGS);
     AMstrings forward = value.strings;
     assert_int_equal(AMstringsSize(&forward), 3);
+    /* Forward iterator forward. */
     assert_string_equal(AMstringsNext(&forward, 1), "one");
     assert_string_equal(AMstringsNext(&forward, 1), "three");
     assert_string_equal(AMstringsNext(&forward, 1), "two");
     assert_null(AMstringsNext(&forward, 1));
+    /* Forward iterator reverse. */
+    assert_string_equal(AMstringsPrev(&forward, 1), "two");
+    assert_string_equal(AMstringsPrev(&forward, 1), "three");
+    assert_string_equal(AMstringsPrev(&forward, 1), "one");
+    assert_null(AMstringsPrev(&forward, 1));
     AMstrings reverse = AMstringsReversed(&value.strings);
     assert_int_equal(AMstringsSize(&reverse), 3);
+    /* Reverse iterator forward. */
     assert_string_equal(AMstringsNext(&reverse, 1), "two");
     assert_string_equal(AMstringsNext(&reverse, 1), "three");
     assert_string_equal(AMstringsNext(&reverse, 1), "one");
     assert_null(AMstringsNext(&reverse, 1));
+    /* Reverse iterator reverse. */
+    assert_string_equal(AMstringsPrev(&reverse, 1), "one");
+    assert_string_equal(AMstringsPrev(&reverse, 1), "three");
+    assert_string_equal(AMstringsPrev(&reverse, 1), "two");
+    assert_null(AMstringsPrev(&reverse, 1));
     AMfree(strings_result);
     AMfree(doc_result);
 }

--- a/automerge-c/test/doc_tests.c
+++ b/automerge-c/test/doc_tests.c
@@ -207,6 +207,24 @@ static void test_AMputActor_hex(void **state) {
     AMfree(result);
 }
 
+static void test_AMspliceText() {
+    AMresult* const doc_result = AMcreate();
+    AMdoc* const doc = AMresultValue(doc_result).doc;
+    AMfree(AMspliceText(doc, AM_ROOT, 0, 0, "one + "));
+    AMfree(AMspliceText(doc, AM_ROOT, 4, 2, "two = "));
+    AMfree(AMspliceText(doc, AM_ROOT, 8, 2, "three"));
+    AMresult* const text_result = AMtext(doc, AM_ROOT, NULL);
+    if (AMresultStatus(text_result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(text_result));
+    }
+    assert_int_equal(AMresultSize(text_result), 1);
+    AMvalue value = AMresultValue(text_result);
+    assert_int_equal(value.tag, AM_VALUE_STR);
+    assert_string_equal(value.str, "one two three");
+    AMfree(text_result);
+    AMfree(doc_result);
+}
+
 int run_doc_tests(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_AMkeys_empty),
@@ -214,6 +232,7 @@ int run_doc_tests(void) {
         cmocka_unit_test(test_AMkeys_map),
         cmocka_unit_test_setup_teardown(test_AMputActor_bytes, setup, teardown),
         cmocka_unit_test_setup_teardown(test_AMputActor_hex, setup, teardown),
+        cmocka_unit_test(test_AMspliceText),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/automerge-c/test/doc_tests.c
+++ b/automerge-c/test/doc_tests.c
@@ -8,6 +8,7 @@
 #include <cmocka.h>
 
 /* local */
+#include "automerge.h"
 #include "group_state.h"
 #include "str_utils.h"
 
@@ -35,6 +36,88 @@ static int teardown(void** state) {
     free(test_state->actor_id_bytes);
     free(test_state);
     return 0;
+}
+
+static void test_AMkeys_empty() {
+    AMresult* const doc_result = AMcreate();
+    AMresult* const strings_result = AMkeys(AMresultValue(doc_result).doc, AM_ROOT, NULL);
+    if (AMresultStatus(strings_result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(strings_result));
+    }
+    assert_int_equal(AMresultSize(strings_result), 0);
+    AMvalue value = AMresultValue(strings_result);
+    assert_int_equal(value.tag, AM_VALUE_STRINGS);
+    assert_int_equal(AMstringsSize(&value.strings), 0);
+    AMstrings forward = value.strings;
+    assert_null(AMstringsNext(&forward, 1));
+    AMstrings reverse = AMstringsReversed(&value.strings);
+    assert_null(AMstringsNext(&reverse, 1));
+    AMfree(strings_result);
+    AMfree(doc_result);
+}
+
+static void test_AMkeys_list() {
+    AMresult* const doc_result = AMcreate();
+    AMdoc* const doc = AMresultValue(doc_result).doc;
+    AMfree(AMlistPutInt(doc, AM_ROOT, 0, true, 1));
+    AMfree(AMlistPutInt(doc, AM_ROOT, 1, true, 2));
+    AMfree(AMlistPutInt(doc, AM_ROOT, 2, true, 3));
+    AMresult* const strings_result = AMkeys(doc, AM_ROOT, NULL);
+    if (AMresultStatus(strings_result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(strings_result));
+    }
+    assert_int_equal(AMresultSize(strings_result), 3);
+    AMvalue value = AMresultValue(strings_result);
+    assert_int_equal(value.tag, AM_VALUE_STRINGS);
+    AMstrings forward = value.strings;
+    assert_int_equal(AMstringsSize(&forward), 3);
+    char const* str = AMstringsNext(&forward, 1);
+    assert_ptr_equal(strstr(str, "1@"), str);
+    str = AMstringsNext(&forward, 1);
+    assert_ptr_equal(strstr(str, "2@"), str);
+    str = AMstringsNext(&forward, 1);
+    assert_ptr_equal(strstr(str, "3@"), str);
+    assert_null(AMstringsNext(&forward, 1));
+    AMstrings reverse = AMstringsReversed(&value.strings);
+    assert_int_equal(AMstringsSize(&reverse), 3);
+    str = AMstringsNext(&reverse, 1);
+    assert_ptr_equal(strstr(str, "3@"), str);
+    str = AMstringsNext(&reverse, 1);
+    assert_ptr_equal(strstr(str, "2@"), str);
+    str = AMstringsNext(&reverse, 1);
+    assert_ptr_equal(strstr(str, "1@"), str);
+    assert_null(AMstringsNext(&reverse, 1));
+    AMfree(strings_result);
+    AMfree(doc_result);
+}
+
+static void test_AMkeys_map() {
+    AMresult* const doc_result = AMcreate();
+    AMdoc* const doc = AMresultValue(doc_result).doc;
+    AMfree(AMmapPutInt(doc, AM_ROOT, "one", 1));
+    AMfree(AMmapPutInt(doc, AM_ROOT, "two", 2));
+    AMfree(AMmapPutInt(doc, AM_ROOT, "three", 3));
+    AMresult* const strings_result = AMkeys(doc, AM_ROOT, NULL);
+    if (AMresultStatus(strings_result) != AM_STATUS_OK) {
+        fail_msg("%s", AMerrorMessage(strings_result));
+    }
+    assert_int_equal(AMresultSize(strings_result), 3);
+    AMvalue value = AMresultValue(strings_result);
+    assert_int_equal(value.tag, AM_VALUE_STRINGS);
+    AMstrings forward = value.strings;
+    assert_int_equal(AMstringsSize(&forward), 3);
+    assert_string_equal(AMstringsNext(&forward, 1), "one");
+    assert_string_equal(AMstringsNext(&forward, 1), "three");
+    assert_string_equal(AMstringsNext(&forward, 1), "two");
+    assert_null(AMstringsNext(&forward, 1));
+    AMstrings reverse = AMstringsReversed(&value.strings);
+    assert_int_equal(AMstringsSize(&reverse), 3);
+    assert_string_equal(AMstringsNext(&reverse, 1), "two");
+    assert_string_equal(AMstringsNext(&reverse, 1), "three");
+    assert_string_equal(AMstringsNext(&reverse, 1), "one");
+    assert_null(AMstringsNext(&reverse, 1));
+    AMfree(strings_result);
+    AMfree(doc_result);
 }
 
 static void test_AMputActor_bytes(void **state) {
@@ -94,6 +177,9 @@ static void test_AMputActor_hex(void **state) {
 
 int run_doc_tests(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_AMkeys_empty),
+        cmocka_unit_test(test_AMkeys_list),
+        cmocka_unit_test(test_AMkeys_map),
         cmocka_unit_test_setup_teardown(test_AMputActor_bytes, setup, teardown),
         cmocka_unit_test_setup_teardown(test_AMputActor_hex, setup, teardown),
     };

--- a/automerge-c/test/list_tests.c
+++ b/automerge-c/test/list_tests.c
@@ -10,6 +10,7 @@
 #include <cmocka.h>
 
 /* local */
+#include "automerge.h"
 #include "group_state.h"
 #include "macro_utils.h"
 
@@ -152,7 +153,7 @@ static void test_AMlistPutObject_ ## label ## _ ## mode(void **state) {       \
     AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
     assert_non_null(value.obj_id);                                            \
-    assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
+    assert_int_equal(AMobjSize(group_state->doc, value.obj_id, NULL), 0);     \
     AMfree(res);                                                              \
 }
 

--- a/automerge-c/test/map_tests.c
+++ b/automerge-c/test/map_tests.c
@@ -10,6 +10,7 @@
 #include <cmocka.h>
 
 /* local */
+#include "automerge.h"
 #include "group_state.h"
 #include "macro_utils.h"
 
@@ -96,7 +97,7 @@ static void test_AMmapPutObject_ ## label(void **state) {                     \
     AMvalue value = AMresultValue(res);                                       \
     assert_int_equal(value.tag, AM_VALUE_OBJ_ID);                             \
     assert_non_null(value.obj_id);                                            \
-    assert_int_equal(AMobjSize(group_state->doc, value.obj_id), 0);           \
+    assert_int_equal(AMobjSize(group_state->doc, value.obj_id, NULL), 0);     \
     AMfree(res);                                                              \
 }
 

--- a/automerge/src/lib.rs
+++ b/automerge/src/lib.rs
@@ -93,6 +93,7 @@ pub use decoding::InvalidChangeError;
 pub use encoding::Error as EncodingError;
 pub use error::AutomergeError;
 pub use error::InvalidActorId;
+pub use error::InvalidChangeHashSlice;
 pub use exid::ExId as ObjId;
 pub use keys::Keys;
 pub use keys_at::KeysAt;


### PR DESCRIPTION
@orionz, I've added the `AMchangeHashesInit()`, `AMkeys()`, `AMspliceText()`, and `AMtext()` functions as well as the `AMstrings` struct to the C API.

@lightsprint09, I've removed `AMobjSizeAt()` from the C API because it wasn't symmetric with `automerge::AutoCommit::length_at()` and because I've added a `heads` argument to `AMobjSize()` which makes it symmetric with `automerge::AutoCommit::length_at()` when `heads != NULL`. I've also replaced some pointer arguments with `const` pointer arguments where possible.

BTW, it should be easier to compare the C quickstart example to the Rust one now that I've sublimated its memory management and, IMHO, its current form is also a more realistic example of a C program that uses Automerge.



