### PR TITLE
Make Op::add_succ sort succ vector after adding

### DIFF
--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -754,6 +754,16 @@ struct SuccEncoder {
     ctr: DeltaEncoder,
 }
 
+fn succ_ord(left: &OpId, right: &OpId, actors: &[usize]) -> Ordering {
+    match (left, right) {
+        (OpId(0, _), OpId(0, _)) => Ordering::Equal,
+        (OpId(0, _), OpId(_, _)) => Ordering::Less,
+        (OpId(_, _), OpId(0, _)) => Ordering::Greater,
+        (OpId(a, x), OpId(b, y)) if a == b => actors[*x].cmp(&actors[*y]),
+        (OpId(a, _), OpId(b, _)) => a.cmp(b),
+    }
+}
+
 impl SuccEncoder {
     fn new() -> SuccEncoder {
         SuccEncoder {
@@ -765,7 +775,9 @@ impl SuccEncoder {
 
     fn append(&mut self, succ: &[OpId], actors: &[usize]) {
         self.num.append_value(succ.len());
-        for s in succ.iter() {
+        let mut sorted_succ = succ.to_vec();
+        sorted_succ.sort_by(|left, right| succ_ord(left, right, actors));
+        for s in sorted_succ.iter() {
             self.ctr.append_value(s.0);
             self.actor.append_value(actors[s.1]);
         }


### PR DESCRIPTION
Fixes https://github.com/automerge/automerge-rs/issues/394

Let me know if there is a more elegant approach than sorting after push, maybe using something like a BinaryHeap instead of Vec for the succ list.

Optree before fix (note the ordering of successors on line 5):
![image](https://user-images.githubusercontent.com/761605/178326339-da44648c-93e8-49a6-8c43-7e7893427b54.png)

Optree after fix:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/761605/178326428-40599a74-e1c4-4a29-94d6-a33254a1ed1c.png">
