### PR TITLE
Don't build tests for docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+    - main
 
 name: Documentation
 
@@ -58,6 +61,7 @@ jobs:
         run: echo '<meta http-equiv="refresh" content="0; url=automerge">' > docs/index.html
 
       - name: Deploy docs
+        if: github.event_name == 'push' && github.head_ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci/cmake-docs
+++ b/scripts/ci/cmake-docs
@@ -4,7 +4,7 @@ set -eoux pipefail
 
 mkdir -p automerge-c/build
 cd automerge-c/build
-cmake -B . -S ..
+cmake -B . -S .. -DBUILD_TESTING=OFF
 cmake --build . --target automerge_docs
 
 echo "Try opening automerge-c/build/src/html/index.html"


### PR DESCRIPTION
The test `CMakeLists.txt` brings in cmocka but we don't actually need to
build the tests to get the docs. This just makes the cmake docs script
tell cmake not to build docs.

Fixes #398 