### PR TITLE
Change parents to return result if objid is not an object

### DIFF
--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -499,11 +499,7 @@ impl Transactable for AutoCommit {
         self.doc.get_all_at(obj, prop, heads)
     }
 
-    fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
-        self.doc.parent_object(obj)
-    }
-
-    fn parents(&self, obj: ExId) -> Parents<'_> {
+    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
         self.doc.parents(obj)
     }
 }

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -224,34 +224,45 @@ impl Automerge {
 
     /// Get the object id of the object that contains this object and the prop that this object is
     /// at in that object.
-    pub fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
-        if let Ok(obj) = self.exid_to_obj(obj.as_ref()) {
-            if obj == ObjId::root() {
-                // root has no parent
-                None
-            } else {
-                self.ops
-                    .parent_object(&obj)
-                    .map(|(id, key)| (self.id_to_exid(id.0), self.export_key(id, key)))
-            }
-        } else {
+    pub(crate) fn parent_object(&self, obj: ObjId) -> Option<(ObjId, Key)> {
+        if obj == ObjId::root() {
+            // root has no parent
             None
+        } else {
+            self.ops.parent_object(&obj)
         }
     }
 
-    /// Get an iterator over the parents of an object.
-    pub fn parents(&self, obj: ExId) -> Parents<'_> {
-        Parents { obj, doc: self }
+    /// Get the parents of an object in the document tree.
+    ///
+    /// ### Errors
+    ///
+    /// Returns an error when the id given is not the id of an object in this document.
+    /// This function does not get the parents of scalar values contained within objects.
+    ///
+    /// ### Experimental
+    ///
+    /// This function may in future be changed to allow getting the parents from the id of a scalar
+    /// value.
+    pub fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
+        let obj_id = self.exid_to_obj(obj.as_ref())?;
+        Ok(Parents {
+            obj: obj_id,
+            doc: self,
+        })
     }
 
-    pub fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Vec<(ExId, Prop)> {
-        let mut path = self.parents(obj.as_ref().clone()).collect::<Vec<_>>();
+    pub fn path_to_object<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+    ) -> Result<Vec<(ExId, Prop)>, AutomergeError> {
+        let mut path = self.parents(obj.as_ref().clone())?.collect::<Vec<_>>();
         path.reverse();
-        path
+        Ok(path)
     }
 
     /// Export a key to a prop.
-    fn export_key(&self, obj: ObjId, key: Key) -> Prop {
+    pub(crate) fn export_key(&self, obj: ObjId, key: Key) -> Prop {
         match key {
             Key::Map(m) => Prop::Map(self.ops.m.props.get(m).into()),
             Key::Seq(opid) => {
@@ -420,8 +431,8 @@ impl Automerge {
             ExId::Id(ctr, actor, idx) => {
                 // do a direct get here b/c this could be foriegn and not be within the array
                 // bounds
-                if self.ops.m.actors.cache.get(*idx) == Some(actor) {
-                    Ok(ObjId(OpId(*ctr, *idx)))
+                let obj = if self.ops.m.actors.cache.get(*idx) == Some(actor) {
+                    ObjId(OpId(*ctr, *idx))
                 } else {
                     // FIXME - make a real error
                     let idx = self
@@ -430,7 +441,12 @@ impl Automerge {
                         .actors
                         .lookup(actor)
                         .ok_or(AutomergeError::Fail)?;
-                    Ok(ObjId(OpId(*ctr, idx)))
+                    ObjId(OpId(*ctr, idx))
+                };
+                if self.ops.object_type(&obj).is_some() {
+                    Ok(obj)
+                } else {
+                    Err(AutomergeError::NotAnObject)
                 }
             }
         }

--- a/automerge/src/automerge/tests.rs
+++ b/automerge/src/automerge/tests.rs
@@ -1322,9 +1322,18 @@ fn get_parent_objects() {
     doc.insert(&list, 0, 2).unwrap();
     let text = doc.put_object(&list, 0, ObjType::Text).unwrap();
 
-    assert_eq!(doc.parent_object(&map), Some((ROOT, Prop::Map("a".into()))));
-    assert_eq!(doc.parent_object(&list), Some((map, Prop::Seq(0))));
-    assert_eq!(doc.parent_object(&text), Some((list, Prop::Seq(0))));
+    assert_eq!(
+        doc.parents(&map).unwrap().next(),
+        Some((ROOT, Prop::Map("a".into())))
+    );
+    assert_eq!(
+        doc.parents(&list).unwrap().next(),
+        Some((map, Prop::Seq(0)))
+    );
+    assert_eq!(
+        doc.parents(&text).unwrap().next(),
+        Some((list, Prop::Seq(0)))
+    );
 }
 
 #[test]
@@ -1336,15 +1345,15 @@ fn get_path_to_object() {
     let text = doc.put_object(&list, 0, ObjType::Text).unwrap();
 
     assert_eq!(
-        doc.path_to_object(&map),
+        doc.path_to_object(&map).unwrap(),
         vec![(ROOT, Prop::Map("a".into()))]
     );
     assert_eq!(
-        doc.path_to_object(&list),
+        doc.path_to_object(&list).unwrap(),
         vec![(ROOT, Prop::Map("a".into())), (map.clone(), Prop::Seq(0)),]
     );
     assert_eq!(
-        doc.path_to_object(&text),
+        doc.path_to_object(&text).unwrap(),
         vec![
             (ROOT, Prop::Map("a".into())),
             (map, Prop::Seq(0)),
@@ -1361,7 +1370,7 @@ fn parents_iterator() {
     doc.insert(&list, 0, 2).unwrap();
     let text = doc.put_object(&list, 0, ObjType::Text).unwrap();
 
-    let mut parents = doc.parents(text);
+    let mut parents = doc.parents(text).unwrap();
     assert_eq!(parents.next(), Some((list, Prop::Seq(0))));
     assert_eq!(parents.next(), Some((map, Prop::Seq(0))));
     assert_eq!(parents.next(), Some((ROOT, Prop::Map("a".into()))));

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum AutomergeError {
+    #[error("id was not an object id")]
+    NotAnObject,
     #[error("invalid obj id format `{0}`")]
     InvalidObjIdFormat(String),
     #[error("invalid obj id `{0}`")]

--- a/automerge/src/parents.rs
+++ b/automerge/src/parents.rs
@@ -1,8 +1,8 @@
-use crate::{exid::ExId, Automerge, Prop};
+use crate::{exid::ExId, types::ObjId, Automerge, Prop};
 
 #[derive(Debug)]
 pub struct Parents<'a> {
-    pub(crate) obj: ExId,
+    pub(crate) obj: ObjId,
     pub(crate) doc: &'a Automerge,
 }
 
@@ -10,9 +10,9 @@ impl<'a> Iterator for Parents<'a> {
     type Item = (ExId, Prop);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some((obj, prop)) = self.doc.parent_object(&self.obj) {
-            self.obj = obj.clone();
-            Some((obj, prop))
+        if let Some((obj, key)) = self.doc.parent_object(self.obj) {
+            self.obj = obj;
+            Some((self.doc.id_to_exid(obj.0), self.doc.export_key(obj, key)))
         } else {
             None
         }

--- a/automerge/src/transaction/manual_transaction.rs
+++ b/automerge/src/transaction/manual_transaction.rs
@@ -287,11 +287,7 @@ impl<'a> Transactable for Transaction<'a> {
         self.doc.get_all_at(obj, prop, heads)
     }
 
-    fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)> {
-        self.doc.parent_object(obj)
-    }
-
-    fn parents(&self, obj: ExId) -> crate::Parents<'_> {
+    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<crate::Parents<'_>, AutomergeError> {
         self.doc.parents(obj)
     }
 }

--- a/automerge/src/transaction/transactable.rs
+++ b/automerge/src/transaction/transactable.rs
@@ -179,15 +179,22 @@ pub trait Transactable {
         heads: &[ChangeHash],
     ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError>;
 
-    /// Get the object id of the object that contains this object and the prop that this object is
-    /// at in that object.
-    fn parent_object<O: AsRef<ExId>>(&self, obj: O) -> Option<(ExId, Prop)>;
+    /// Get the parents of an object in the document tree.
+    ///
+    /// ### Errors
+    ///
+    /// Returns an error when the id given is not the id of an object in this document.
+    /// This function does not get the parents of scalar values contained within objects.
+    ///
+    /// ### Experimental
+    ///
+    /// This function may in future be changed to allow getting the parents from the id of a scalar
+    /// value.
+    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError>;
 
-    fn parents(&self, obj: ExId) -> Parents<'_>;
-
-    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Vec<(ExId, Prop)> {
-        let mut path = self.parents(obj.as_ref().clone()).collect::<Vec<_>>();
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<(ExId, Prop)>, AutomergeError> {
+        let mut path = self.parents(obj.as_ref().clone())?.collect::<Vec<_>>();
         path.reverse();
-        path
+        Ok(path)
     }
 }


### PR DESCRIPTION
There is easy confusion when calling parents with the id of a scalar,
wanting it to get the parent object first but that is not implemented.
To get the parent object of a scalar id would mean searching every
object for the OpId which may get too expensive when lots of objects are
around, this may be reconsidered later but the result would still be
useful to indicate when the id doesn't exist in the document vs has no
parents.

Fixes #388 