### PR TITLE
Add OpIds to enforce ordering of Op::succ and Op::pred

### DIFF
--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -710,11 +710,7 @@ impl Automerge {
                     legacy::ObjectId::Root => ObjId::root(),
                     legacy::ObjectId::Id(id) => ObjId(OpId(id.0, self.ops.m.actors.cache(id.1))),
                 };
-                let pred = c
-                    .pred
-                    .iter()
-                    .map(|i| OpId(i.0, self.ops.m.actors.cache(i.1.clone())))
-                    .collect();
+                let pred = self.ops.m.import_opids(c.pred);
                 let key = match &c.key {
                     legacy::Key::Map(n) => Key::Map(self.ops.m.props.cache(n.to_string())),
                     legacy::Key::Seq(legacy::ElementId::Head) => Key::Seq(types::HEAD),
@@ -1048,7 +1044,7 @@ impl Automerge {
                 OpType::Delete => format!("del{}", 0),
             };
             let pred: Vec<_> = op.pred.iter().map(|id| self.to_string(*id)).collect();
-            let succ: Vec<_> = op.succ.iter().map(|id| self.to_string(*id)).collect();
+            let succ: Vec<_> = op.succ.into_iter().map(|id| self.to_string(*id)).collect();
             log!(
                 "  {:12} {:12} {:12} {:12} {:12?} {:12?}",
                 id,

--- a/automerge/src/columnar.rs
+++ b/automerge/src/columnar.rs
@@ -773,11 +773,18 @@ impl SuccEncoder {
         }
     }
 
-    fn append(&mut self, succ: &[OpId], actors: &[usize]) {
-        self.num.append_value(succ.len());
-        let mut sorted_succ = succ.to_vec();
-        sorted_succ.sort_by(|left, right| succ_ord(left, right, actors));
-        for s in sorted_succ.iter() {
+    fn append<
+        'a,
+        I: IntoIterator<Item = &'a OpId, IntoIter = II>,
+        II: ExactSizeIterator + Iterator<Item = &'a OpId>,
+    >(
+        &mut self,
+        succ: I,
+        actors: &[usize],
+    ) {
+        let iter = succ.into_iter();
+        self.num.append_value(iter.len());
+        for s in iter {
             self.ctr.append_value(s.0);
             self.actor.append_value(actors[s.1]);
         }

--- a/automerge/src/op_tree.rs
+++ b/automerge/src/op_tree.rs
@@ -762,8 +762,8 @@ mod tests {
             id: zero,
             action: amp::OpType::Put(0.into()),
             key: zero.into(),
-            succ: vec![],
-            pred: vec![],
+            succ: Default::default(),
+            pred: Default::default(),
             insert: false,
         }
     }

--- a/automerge/src/op_tree/iter.rs
+++ b/automerge/src/op_tree/iter.rs
@@ -260,8 +260,8 @@ mod tests {
             action: OpType::Put(ScalarValue::Uint(counter)),
             id: OpId(counter, 0),
             key: Key::Map(0),
-            succ: Vec::new(),
-            pred: Vec::new(),
+            succ: Default::default(),
+            pred: Default::default(),
             insert: false,
         }
     }

--- a/automerge/src/query.rs
+++ b/automerge/src/query.rs
@@ -209,11 +209,11 @@ impl VisWindow {
                     CounterData {
                         pos,
                         val: start,
-                        succ: op.succ.iter().cloned().collect(),
+                        succ: op.succ.into_iter().cloned().collect(),
                         op: op.clone(),
                     },
                 );
-                if !op.succ.iter().any(|i| clock.covers(i)) {
+                if !op.succ.into_iter().any(|i| clock.covers(i)) {
                     visible = true;
                 }
             }
@@ -231,7 +231,7 @@ impl VisWindow {
                 }
             }
             _ => {
-                if !op.succ.iter().any(|i| clock.covers(i)) {
+                if !op.succ.into_iter().any(|i| clock.covers(i)) {
                     visible = true;
                 }
             }

--- a/automerge/src/types.rs
+++ b/automerge/src/types.rs
@@ -8,6 +8,9 @@ use std::fmt::Display;
 use std::str::FromStr;
 use tinyvec::{ArrayVec, TinyVec};
 
+mod opids;
+pub(crate) use opids::OpIds;
+
 pub(crate) use crate::clock::Clock;
 pub(crate) use crate::value::{Counter, ScalarValue, Value};
 
@@ -379,14 +382,14 @@ pub(crate) struct Op {
     pub(crate) id: OpId,
     pub(crate) action: OpType,
     pub(crate) key: Key,
-    pub(crate) succ: Vec<OpId>,
-    pub(crate) pred: Vec<OpId>,
+    pub(crate) succ: OpIds,
+    pub(crate) pred: OpIds,
     pub(crate) insert: bool,
 }
 
 impl Op {
-    pub(crate) fn add_succ(&mut self, op: &Op) {
-        self.succ.push(op.id);
+    pub(crate) fn add_succ<F: Fn(&OpId, &OpId) -> std::cmp::Ordering>(&mut self, op: &Op, cmp: F) {
+        self.succ.add(op.id, cmp);
         if let OpType::Put(ScalarValue::Counter(Counter {
             current,
             increments,

--- a/automerge/src/types/opids.rs
+++ b/automerge/src/types/opids.rs
@@ -1,0 +1,126 @@
+use itertools::Itertools;
+
+use super::OpId;
+
+/// A wrapper around `Vec<Opid>` which preserves the invariant that the ops are
+/// in ascending order with respect to their counters and actor IDs. In order to
+/// maintain this invariant you must provide a comparator function when adding
+/// ops as the actor indices in an  OpId are not sufficient to order the OpIds
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct OpIds(Vec<OpId>);
+
+impl<'a> IntoIterator for &'a OpIds {
+    type Item = &'a OpId;
+    type IntoIter = std::slice::Iter<'a, OpId>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl OpIds {
+    pub(crate) fn new<I: Iterator<Item = OpId>, F: Fn(&OpId, &OpId) -> std::cmp::Ordering>(
+        opids: I,
+        cmp: F,
+    ) -> Self {
+        let mut inner = opids.collect::<Vec<_>>();
+        inner.sort_by(cmp);
+        Self(inner)
+    }
+
+    /// Add an op to this set of OpIds. The `comparator` must provide a
+    /// consistent ordering between successive calls to `add`.
+    pub(crate) fn add<F: Fn(&OpId, &OpId) -> std::cmp::Ordering>(
+        &mut self,
+        opid: OpId,
+        comparator: F,
+    ) {
+        use std::cmp::Ordering::*;
+        if self.is_empty() {
+            self.0.push(opid);
+            return;
+        }
+        let idx_and_elem = self
+            .0
+            .iter()
+            .find_position(|an_opid| matches!(comparator(an_opid, &opid), Greater | Equal));
+        if let Some((idx, an_opid)) = idx_and_elem {
+            if comparator(an_opid, &opid) == Equal {
+                // nothing to do
+            } else {
+                self.0.insert(idx, opid);
+            }
+        } else {
+            self.0.push(opid);
+        }
+    }
+
+    pub(crate) fn retain<F: Fn(&OpId) -> bool>(&mut self, f: F) {
+        self.0.retain(f)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, OpId> {
+        self.0.iter()
+    }
+
+    pub(crate) fn contains(&self, op: &OpId) -> bool {
+        self.0.contains(op)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OpId, OpIds};
+    use crate::ActorId;
+    use proptest::prelude::*;
+
+    fn gen_opid(actors: Vec<ActorId>) -> impl Strategy<Value = OpId> {
+        (0..actors.len()).prop_flat_map(|actor_idx| {
+            (Just(actor_idx), 0..u64::MAX).prop_map(|(actor_idx, counter)| OpId(counter, actor_idx))
+        })
+    }
+
+    fn scenario() -> impl Strategy<Value = (Vec<ActorId>, Vec<OpId>)> {
+        let actors = vec![
+            "aaaa".try_into().unwrap(),
+            "cccc".try_into().unwrap(),
+            "bbbb".try_into().unwrap(),
+        ];
+        proptest::collection::vec(gen_opid(actors.clone()), 0..100)
+            .prop_map(move |opids| (actors.clone(), opids))
+    }
+
+    proptest! {
+        #[test]
+        fn test_sorted_opids((actors, opids) in scenario()) {
+            let mut sorted_opids = OpIds::default();
+            for opid in &opids {
+                sorted_opids.add(*opid, |left, right| cmp(&actors, left, right));
+            }
+            let result = sorted_opids.into_iter().cloned().collect::<Vec<_>>();
+            let mut expected = opids;
+            expected.sort_by(|left, right| cmp(&actors, left, right));
+            expected.dedup();
+            assert_eq!(result, expected);
+        }
+    }
+
+    fn cmp(actors: &[ActorId], left: &OpId, right: &OpId) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (left, right) {
+            (OpId(0, _), OpId(0, _)) => Ordering::Equal,
+            (OpId(0, _), OpId(_, _)) => Ordering::Less,
+            (OpId(_, _), OpId(0, _)) => Ordering::Greater,
+            (OpId(a, x), OpId(b, y)) if a == b => actors[*x].cmp(&actors[*y]),
+            (OpId(a, _), OpId(b, _)) => a.cmp(b),
+        }
+    }
+}


### PR DESCRIPTION
I was thinking a bit more about #401 and I've decided that actually we probably should maintain the op ID ordering invariant in the OpSet. My reasoning is that sorting op IDs when encoding forces us to allocate for every op in every change which has a succ when we commit a transaction and I worry about this affecting performance. This PR introduces an `OpIds` type which enforces the sorting invariant.