### PR TITLE
publish: Add description to automerge crate

### DIFF
--- a/automerge/Cargo.toml
+++ b/automerge/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 repository = "https://github.com/automerge/automerge-rs"
 documentation = "https://automerge.org/automerge-rs/automerge/"
 rust-version = "1.57.0"
+description = "A JSON-like data structure (a CRDT) that can be modified concurrently by different users, and merged again automatically"
 
 [features]
 optree-visualisation = ["dot", "rand"]


### PR DESCRIPTION
Came up as a warning in a dry-run publish.

I've taken the current 'About' text from https://github.com/automerge/automerge.