### PR TITLE
Add license for unicode-idents

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,13 @@ exceptions = [
     # since this is an application not a library people would link to it should be fine
     { allow = ["EPL-2.0"], name = "colored_json" },
 
+    # The Unicode-DFS--2016 license is necessary for unicode-ident because they
+    # use data from the unicode tables to generate the tables which are
+    # included in the application. We do not distribute those data files so
+    # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
+    # for more details.
+    { allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"], name = "unicode-ident" },
+
     # these are needed by cbindgen and its dependancies
     # should be revied more fully before release
     { allow = ["MPL-2.0"], name = "cbindgen" },


### PR DESCRIPTION
`unicode-idents` distributes some data tables from unicode.org which
require an additional license. This doesn't affect our licensing because
we don't distribute the data files - just the generated code. Explicitly
allow the Unicode-DFS-2016 license for unicode-idents.