### PR TITLE
Patch C API changes for "storage-v2"

### DIFF
--- a/automerge-c/CMakeLists.txt
+++ b/automerge-c/CMakeLists.txt
@@ -57,6 +57,8 @@ include(CTest)
 
 option(BUILD_SHARED_LIBS "Enable the choice of a shared or static library.")
 
+option(FEATURE_FLAG_STORAGE_V2 "Toggle the \"storage-v2\" feature flag.")
+
 include(CMakePackageConfigHelpers)
 
 include(GNUInstallDirs)

--- a/automerge-c/src/CMakeLists.txt
+++ b/automerge-c/src/CMakeLists.txt
@@ -23,6 +23,12 @@ else()
     set(CARGO_FLAG "--release")
 endif()
 
+if(FEATURE_FLAG_STORAGE_V2)
+    set(CARGO_FEATURES --features storage-v2)
+else()
+    set(CARGO_FEATURES "")
+endif()
+
 set(CARGO_CURRENT_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_BUILD_TYPE}")
 
 set(
@@ -47,7 +53,7 @@ add_custom_command(
         #       updated.
         ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${CMAKE_SOURCE_DIR}/cmake/file_touch.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h ${CMAKE_SOURCE_DIR}/cbindgen.toml
     COMMAND
-        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} ${CARGO_CMD} build ${CARGO_FLAG}
+        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
     MAIN_DEPENDENCY
         lib.rs
     DEPENDS


### PR DESCRIPTION
> I've made a few changes to `automerge-c` to accomodate a new `ScalarValue::Unknown` variant. ... I've also not made any attempt to run the tests for automerge-c with a storage-v2 feature flag enabled.

@alexjg, this patch enables you to do that by appending `-DFEATURE_FLAG_STORAGE_V2=ON` to the CMake invocation.

The C API's unit test suite still passes when the "storage-v2" feature is enabled.