### PR TITLE
Expose `Vec<automerge::Change>` initialization and `automerge::AutoCommit::with_actor()` to the C API

### DIFF
--- a/automerge-c/CMakeLists.txt
+++ b/automerge-c/CMakeLists.txt
@@ -67,6 +67,10 @@ string(TOUPPER ${SYMBOL_PREFIX} SYMBOL_PREFIX)
 
 set(CARGO_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/Cargo/target")
 
+set(CBINDGEN_INCLUDEDIR "${CARGO_TARGET_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
+
+set(CBINDGEN_TARGET_DIR "${CBINDGEN_INCLUDEDIR}/${PROJECT_NAME}")
+
 add_subdirectory(src)
 
 # Generate and install the configuration header.

--- a/automerge-c/build.rs
+++ b/automerge-c/build.rs
@@ -14,7 +14,7 @@ fn main() {
         // \note CMake sets this environment variable before invoking Cargo so
         //       that it can direct the generated header file into its
         //       out-of-source build directory for post-processing.
-        if let Ok(target_dir) = env::var("CARGO_TARGET_DIR") {
+        if let Ok(target_dir) = env::var("CBINDGEN_TARGET_DIR") {
             writer.write_to_file(PathBuf::from(target_dir).join("automerge.h"));
         }
     }

--- a/automerge-c/examples/CMakeLists.txt
+++ b/automerge-c/examples/CMakeLists.txt
@@ -12,7 +12,7 @@ set_target_properties(example_quickstart PROPERTIES LINKER_LANGUAGE C)
 #       must be specified for all of its dependent targets instead.
 target_include_directories(
     example_quickstart
-    PRIVATE "$<BUILD_INTERFACE:${CARGO_TARGET_DIR}>"
+    PRIVATE "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR}>"
 )
 
 target_link_libraries(example_quickstart PRIVATE ${LIBRARY_NAME})

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -11,7 +11,7 @@ static void abort_cb(AMresultStack**, uint8_t);
  */
 int main(int argc, char** argv) {
     AMresultStack* stack = NULL;
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, abort_cb).doc;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, abort_cb).doc;
     AMobjId const* const cards = AMpush(&stack,
                                         AMmapPutObject(doc1, AM_ROOT, "cards", AM_OBJ_TYPE_LIST),
                                         AM_VALUE_OBJ_ID,
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
     AMfree(AMmapPutBool(doc1, card2, "done", false));
     AMfree(AMcommit(doc1, "Add card", NULL));
 
-    AMdoc* doc2 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, abort_cb).doc;
+    AMdoc* doc2 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, abort_cb).doc;
     AMfree(AMmerge(doc2, doc1));
 
     AMbyteSpan const binary = AMpush(&stack, AMsave(doc1), AM_VALUE_BYTES, abort_cb).bytes;

--- a/automerge-c/examples/quickstart.c
+++ b/automerge-c/examples/quickstart.c
@@ -2,51 +2,59 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <automerge.h>
+#include <automerge-c/automerge.h>
 
 static void abort_cb(AMresultStack**, uint8_t);
 
-/*
- *  Based on https://automerge.github.io/docs/quickstart
+/**
+ * \brief Based on https://automerge.github.io/docs/quickstart
  */
 int main(int argc, char** argv) {
-    AMresultStack* results = NULL;
-    AMdoc* const doc1 = AMpush(&results, AMcreate(), AM_VALUE_DOC, abort_cb).doc;
-    AMobjId const* const
-        cards = AMpush(&results, AMmapPutObject(doc1, AM_ROOT, "cards", AM_OBJ_TYPE_LIST), AM_VALUE_OBJ_ID, abort_cb).obj_id;
-    AMobjId const* const
-        card1 = AMpush(&results, AMlistPutObject(doc1, cards, 0, true, AM_OBJ_TYPE_MAP), AM_VALUE_OBJ_ID, abort_cb).obj_id;
-    AMpush(&results, AMmapPutStr(doc1, card1, "title", "Rewrite everything in Clojure"), AM_VALUE_VOID, abort_cb);
-    AMpush(&results, AMmapPutBool(doc1, card1, "done", false), AM_VALUE_VOID, abort_cb);
-    AMobjId const* const
-        card2 = AMpush(&results, AMlistPutObject(doc1, cards, 0, true, AM_OBJ_TYPE_MAP), AM_VALUE_OBJ_ID, abort_cb).obj_id;
-    AMpush(&results, AMmapPutStr(doc1, card2, "title", "Rewrite everything in Haskell"), AM_VALUE_VOID, abort_cb);
-    AMpush(&results, AMmapPutBool(doc1, card2, "done", false), AM_VALUE_VOID, abort_cb);
-    AMpush(&results, AMcommit(doc1, "Add card", NULL), AM_VALUE_CHANGE_HASHES, abort_cb);
+    AMresultStack* stack = NULL;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, abort_cb).doc;
+    AMobjId const* const cards = AMpush(&stack,
+                                        AMmapPutObject(doc1, AM_ROOT, "cards", AM_OBJ_TYPE_LIST),
+                                        AM_VALUE_OBJ_ID,
+                                        abort_cb).obj_id;
+    AMobjId const* const card1 = AMpush(&stack,
+                                        AMlistPutObject(doc1, cards, SIZE_MAX, true, AM_OBJ_TYPE_MAP),
+                                        AM_VALUE_OBJ_ID,
+                                        abort_cb).obj_id;
+    AMfree(AMmapPutStr(doc1, card1, "title", "Rewrite everything in Clojure"));
+    AMfree(AMmapPutBool(doc1, card1, "done", false));
+    AMobjId const* const card2 = AMpush(&stack,
+                                        AMlistPutObject(doc1, cards, SIZE_MAX, true, AM_OBJ_TYPE_MAP),
+                                        AM_VALUE_OBJ_ID,
+                                        abort_cb).obj_id;
+    AMfree(AMmapPutStr(doc1, card2, "title", "Rewrite everything in Haskell"));
+    AMfree(AMmapPutBool(doc1, card2, "done", false));
+    AMfree(AMcommit(doc1, "Add card", NULL));
 
-    AMdoc* doc2 = AMpush(&results, AMcreate(), AM_VALUE_DOC, abort_cb).doc;
-    AMpush(&results, AMmerge(doc2, doc1), AM_VALUE_CHANGE_HASHES, abort_cb);
+    AMdoc* doc2 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, abort_cb).doc;
+    AMfree(AMmerge(doc2, doc1));
 
-    AMbyteSpan const binary = AMpush(&results, AMsave(doc1), AM_VALUE_BYTES, abort_cb).bytes;
-    doc2 = AMpush(&results, AMload(binary.src, binary.count), AM_VALUE_DOC, abort_cb).doc;
+    AMbyteSpan const binary = AMpush(&stack, AMsave(doc1), AM_VALUE_BYTES, abort_cb).bytes;
+    doc2 = AMpush(&stack, AMload(binary.src, binary.count), AM_VALUE_DOC, abort_cb).doc;
 
-    AMpush(&results, AMmapPutBool(doc1, card1, "done", true), AM_VALUE_VOID, abort_cb);
-    AMpush(&results, AMcommit(doc1, "Mark card as done", NULL), AM_VALUE_CHANGE_HASHES, abort_cb);
+    AMfree(AMmapPutBool(doc1, card1, "done", true));
+    AMfree(AMcommit(doc1, "Mark card as done", NULL));
 
-    AMpush(&results, AMlistDelete(doc2, cards, 0), AM_VALUE_VOID, abort_cb);
-    AMpush(&results, AMcommit(doc2, "Delete card", NULL), AM_VALUE_CHANGE_HASHES, abort_cb);
+    AMfree(AMlistDelete(doc2, cards, 0));
+    AMfree(AMcommit(doc2, "Delete card", NULL));
 
-    AMpush(&results, AMmerge(doc1, doc2), AM_VALUE_CHANGE_HASHES, abort_cb);
+    AMfree(AMmerge(doc1, doc2));
 
-    AMchanges changes = AMpush(&results, AMgetChanges(doc1, NULL), AM_VALUE_CHANGES, abort_cb).changes;
+    AMchanges changes = AMpush(&stack, AMgetChanges(doc1, NULL), AM_VALUE_CHANGES, abort_cb).changes;
     AMchange const* change = NULL;
     while ((change = AMchangesNext(&changes, 1)) != NULL) {
         AMbyteSpan const change_hash = AMchangeHash(change);
-        AMchangeHashes const
-            heads = AMpush(&results, AMchangeHashesInit(&change_hash, 1), AM_VALUE_CHANGE_HASHES, abort_cb).change_hashes;
+        AMchangeHashes const heads = AMpush(&stack,
+                                            AMchangeHashesInit(&change_hash, 1),
+                                            AM_VALUE_CHANGE_HASHES,
+                                            abort_cb).change_hashes;
         printf("%s %ld\n", AMchangeMessage(change), AMobjSize(doc1, cards, &heads));
     }
-    AMfreeStack(&results);
+    AMfreeStack(&stack);
 }
 
 static char const* discriminant_suffix(AMvalueVariant const);

--- a/automerge-c/src/CMakeLists.txt
+++ b/automerge-c/src/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CARGO_CURRENT_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_BUILD_TYPE}")
 
 set(
     CARGO_OUTPUT
-        ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
         ${CARGO_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
         ${CARGO_CURRENT_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
@@ -47,9 +47,9 @@ add_custom_command(
         # \note cbindgen won't regenerate its output header file after it's
         #       been removed but it will after its configuration file has been
         #       updated.
-        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${CMAKE_SOURCE_DIR}/cmake/file_touch.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h ${CMAKE_SOURCE_DIR}/cbindgen.toml
+        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${CMAKE_SOURCE_DIR}/cmake/file_touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CMAKE_SOURCE_DIR}/cbindgen.toml
     COMMAND
-        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
+        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
     MAIN_DEPENDENCY
         lib.rs
     DEPENDS
@@ -99,16 +99,16 @@ add_custom_command(
     POST_BUILD
     COMMAND
         # Compensate for cbindgen's variant struct naming.
-        ${CMAKE_COMMAND} -DMATCH_REGEX=AM\([^_]+_[^_]+\)_Body -DREPLACE_EXPR=AM\\1 -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=AM\([^_]+_[^_]+\)_Body -DREPLACE_EXPR=AM\\1 -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     COMMAND
         # Compensate for cbindgen's union tag enum type naming.
-        ${CMAKE_COMMAND} -DMATCH_REGEX=AM\([^_]+\)_Tag -DREPLACE_EXPR=AM\\1Variant -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=AM\([^_]+\)_Tag -DREPLACE_EXPR=AM\\1Variant -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     COMMAND
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
-        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     COMMAND
         # Compensate for cbindgen ignoring `std:mem::size_of<usize>()` calls.
-        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${CMAKE_SOURCE_DIR}/cmake/file_regex_replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     WORKING_DIRECTORY
         ${CMAKE_SOURCE_DIR}
     COMMENT
@@ -166,7 +166,7 @@ set_target_properties(
         IMPORTED_NO_SONAME "${LIBRARY_NO_SONAME}"
         IMPORTED_SONAME "${LIBRARY_SONAME}"
         LINKER_LANGUAGE C
-        PUBLIC_HEADER "${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h"
+        PUBLIC_HEADER "${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h"
         SOVERSION "${PROJECT_VERSION_MAJOR}"
         VERSION "${PROJECT_VERSION}"
         # \note Cargo exports all of the symbols automatically.
@@ -222,6 +222,8 @@ install(
 find_package(Doxygen OPTIONAL_COMPONENTS dot)
 
 if(DOXYGEN_FOUND)
+    set(DOXYGEN_ALIASES "installed_headerfile=\\headerfile ${LIBRARY_NAME}.h <${PROJECT_NAME}/${LIBRARY_NAME}.h>")
+
     set(DOXYGEN_GENERATE_LATEX YES)
 
     set(DOXYGEN_PDF_HYPERLINKS YES)
@@ -234,7 +236,7 @@ if(DOXYGEN_FOUND)
 
     doxygen_add_docs(
         ${LIBRARY_NAME}_docs
-        "${CARGO_TARGET_DIR}/${LIBRARY_NAME}.h"
+        "${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h"
         "${CMAKE_SOURCE_DIR}/README.md"
         USE_STAMP_FILE
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/automerge-c/src/actor_id.rs
+++ b/automerge-c/src/actor_id.rs
@@ -18,10 +18,10 @@ pub struct AMactorId {
 }
 
 impl AMactorId {
-    pub fn new(body: &am::ActorId) -> Self {
+    pub fn new(actor_id: &am::ActorId) -> Self {
         Self {
-            body,
-            c_str: RefCell::<Option<CString>>::default(),
+            body: actor_id,
+            c_str: Default::default(),
         }
     }
 

--- a/automerge-c/src/actor_id.rs
+++ b/automerge-c/src/actor_id.rs
@@ -9,6 +9,7 @@ use crate::byte_span::AMbyteSpan;
 use crate::result::{to_result, AMresult};
 
 /// \struct AMactorId
+/// \installed_headerfile
 /// \brief An actor's unique identifier.
 #[derive(PartialEq)]
 pub struct AMactorId {

--- a/automerge-c/src/byte_span.rs
+++ b/automerge-c/src/byte_span.rs
@@ -1,6 +1,7 @@
 use automerge as am;
 
 /// \struct AMbyteSpan
+/// \installed_headerfile
 /// \brief A contiguous sequence of bytes.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/byte_span.rs
+++ b/automerge-c/src/byte_span.rs
@@ -2,13 +2,14 @@ use automerge as am;
 
 /// \struct AMbyteSpan
 /// \installed_headerfile
-/// \brief A contiguous sequence of bytes.
+/// \brief A view onto a contiguous sequence of bytes.
 #[repr(C)]
 #[derive(PartialEq)]
 pub struct AMbyteSpan {
     /// A pointer to an array of bytes.
-    /// \warning \p src is only valid until the `AMfree()` function is
-    ///          called on the `AMresult` struct hosting the array of bytes to
+    /// \attention <b>NEVER CALL `free()` ON \p src!</b>
+    /// \warning \p src is only valid until the `AMfree()` function is called
+    ///          on the `AMresult` struct that stores the array of bytes to
     ///          which it points.
     pub src: *const u8,
     /// The number of bytes in the array.

--- a/automerge-c/src/change.rs
+++ b/automerge-c/src/change.rs
@@ -18,6 +18,7 @@ macro_rules! to_change {
 }
 
 /// \struct AMchange
+/// \installed_headerfile
 /// \brief A group of operations performed by an actor.
 #[derive(PartialEq)]
 pub struct AMchange {

--- a/automerge-c/src/change_hashes.rs
+++ b/automerge-c/src/change_hashes.rs
@@ -117,6 +117,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMchangeHashes
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of change hashes.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/change_hashes.rs
+++ b/automerge-c/src/change_hashes.rs
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn AMchangeHashesInit(src: *const AMbyteSpan, count: usize
     for n in 0..count {
         let byte_span = &*src.add(n);
         let slice = std::slice::from_raw_parts(byte_span.src, byte_span.count);
-        match am::ChangeHash::try_from(slice) {
+        match slice.try_into() {
             Ok(change_hash) => {
                 change_hashes.push(change_hash);
             }

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -140,6 +140,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMchanges
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of changes.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/doc.rs
+++ b/automerge-c/src/doc.rs
@@ -47,6 +47,7 @@ macro_rules! to_sync_state_mut {
 }
 
 /// \struct AMdoc
+/// \installed_headerfile
 /// \brief A JSON-like CRDT.
 #[derive(Clone)]
 pub struct AMdoc(am::AutoCommit);

--- a/automerge-c/src/doc.rs
+++ b/automerge-c/src/doc.rs
@@ -124,13 +124,21 @@ pub unsafe extern "C" fn AMclone(doc: *const AMdoc) -> *mut AMresult {
 /// \memberof AMdoc
 /// \brief Allocates a new document and initializes it with defaults.
 ///
+/// \param[in] actor_id A pointer to an `AMactorId` struct or `NULL` for a
+///                     random one.
 /// \return A pointer to an `AMresult` struct containing a pointer to an
 ///         `AMdoc` struct.
 /// \warning The returned `AMresult` struct must be deallocated with `AMfree()`
 ///          in order to prevent a memory leak.
+///
+/// # Safety
+/// actor_id must be a valid pointer to an AMactorId or std::ptr::null()
 #[no_mangle]
-pub extern "C" fn AMcreate() -> *mut AMresult {
-    to_result(am::AutoCommit::new())
+pub unsafe extern "C" fn AMcreate(actor_id: *const AMactorId) -> *mut AMresult {
+    to_result(match actor_id.as_ref() {
+        Some(actor_id) => am::AutoCommit::new().with_actor(actor_id.as_ref().clone()),
+        None => am::AutoCommit::new(),
+    })
 }
 
 /// \memberof AMdoc
@@ -282,7 +290,7 @@ pub unsafe extern "C" fn AMgetChangeByHash(
 ) -> *mut AMresult {
     let doc = to_doc_mut!(doc);
     let slice = std::slice::from_raw_parts(src, count);
-    match am::ChangeHash::try_from(slice) {
+    match slice.try_into() {
         Ok(change_hash) => to_result(doc.get_change_by_hash(&change_hash)),
         Err(e) => AMresult::err(&e.to_string()).into(),
     }

--- a/automerge-c/src/doc.rs
+++ b/automerge-c/src/doc.rs
@@ -53,8 +53,8 @@ macro_rules! to_sync_state_mut {
 pub struct AMdoc(am::AutoCommit);
 
 impl AMdoc {
-    pub fn new(body: am::AutoCommit) -> Self {
-        Self(body)
+    pub fn new(auto_commit: am::AutoCommit) -> Self {
+        Self(auto_commit)
     }
 }
 

--- a/automerge-c/src/doc/list/item.rs
+++ b/automerge-c/src/doc/list/item.rs
@@ -23,7 +23,7 @@ impl AMlistItem {
         Self {
             index,
             obj_id: AMobjId::new(obj_id),
-            value: (value, RefCell::<Option<CString>>::default()),
+            value: (value, Default::default()),
         }
     }
 }

--- a/automerge-c/src/doc/list/item.rs
+++ b/automerge-c/src/doc/list/item.rs
@@ -6,6 +6,7 @@ use crate::obj::AMobjId;
 use crate::result::AMvalue;
 
 /// \struct AMlistItem
+/// \installed_headerfile
 /// \brief An item in a list object.
 #[repr(C)]
 pub struct AMlistItem {

--- a/automerge-c/src/doc/list/items.rs
+++ b/automerge-c/src/doc/list/items.rs
@@ -114,6 +114,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMlistItems
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of list object items.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/doc/map/item.rs
+++ b/automerge-c/src/doc/map/item.rs
@@ -24,7 +24,7 @@ impl AMmapItem {
         Self {
             key: CString::new(key).unwrap(),
             obj_id: AMobjId::new(obj_id),
-            value: (value, RefCell::<Option<CString>>::default()),
+            value: (value, Default::default()),
         }
     }
 }

--- a/automerge-c/src/doc/map/item.rs
+++ b/automerge-c/src/doc/map/item.rs
@@ -7,6 +7,7 @@ use crate::obj::AMobjId;
 use crate::result::AMvalue;
 
 /// \struct AMmapItem
+/// \installed_headerfile
 /// \brief An item in a map object.
 #[repr(C)]
 pub struct AMmapItem {

--- a/automerge-c/src/doc/map/items.rs
+++ b/automerge-c/src/doc/map/items.rs
@@ -114,6 +114,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMmapItems
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of map object items.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/obj.rs
+++ b/automerge-c/src/obj.rs
@@ -17,10 +17,10 @@ pub struct AMobjId {
 }
 
 impl AMobjId {
-    pub fn new(body: am::ObjId) -> Self {
+    pub fn new(obj_id: am::ObjId) -> Self {
         Self {
-            body,
-            c_actor_id: RefCell::<Option<AMactorId>>::default(),
+            body: obj_id,
+            c_actor_id: Default::default(),
         }
     }
 

--- a/automerge-c/src/obj.rs
+++ b/automerge-c/src/obj.rs
@@ -8,6 +8,7 @@ pub mod item;
 pub mod items;
 
 /// \struct AMobjId
+/// \installed_headerfile
 /// \brief An object's unique identifier.
 #[derive(PartialEq)]
 pub struct AMobjId {

--- a/automerge-c/src/obj/item.rs
+++ b/automerge-c/src/obj/item.rs
@@ -20,7 +20,7 @@ impl AMobjItem {
     pub fn new(value: am::Value<'static>, obj_id: am::ObjId) -> Self {
         Self {
             obj_id: AMobjId::new(obj_id),
-            value: (value, RefCell::<Option<CString>>::default()),
+            value: (value, Default::default()),
         }
     }
 }

--- a/automerge-c/src/obj/item.rs
+++ b/automerge-c/src/obj/item.rs
@@ -6,6 +6,7 @@ use crate::obj::AMobjId;
 use crate::result::AMvalue;
 
 /// \struct AMobjItem
+/// \installed_headerfile
 /// \brief An item in an object.
 #[repr(C)]
 pub struct AMobjItem {

--- a/automerge-c/src/obj/items.rs
+++ b/automerge-c/src/obj/items.rs
@@ -114,6 +114,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMobjItems
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of object items.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/result.rs
+++ b/automerge-c/src/result.rs
@@ -24,6 +24,7 @@ use crate::strs::AMstrs;
 use crate::sync::{AMsyncMessage, AMsyncState};
 
 /// \struct AMvalue
+/// \installed_headerfile
 /// \brief A discriminated union of value type variants for a result.
 ///
 /// \enum AMvalueVariant
@@ -73,15 +74,6 @@ use crate::sync::{AMsyncMessage, AMsyncState};
 ///
 /// \var AMvalue::strs
 /// A sequence of UTF-8 strings as an `AMstrs` struct.
-///
-/// \var AMvalue::sync_message
-/// A synchronization message as a pointer to an `AMsyncMessage` struct.
-///
-/// \var AMvalue::sync_state
-/// A synchronization state as a pointer to an `AMsyncState` struct.
-///
-/// \var AMvalue::tag
-/// The variant discriminator.
 ///
 /// \var AMvalue::sync_message
 /// A synchronization message as a pointer to an `AMsyncMessage` struct.
@@ -215,8 +207,8 @@ impl From<&AMvalue<'_>> for u8 {
     fn from(value: &AMvalue) -> Self {
         use AMvalue::*;
 
-        // Note that these numbers are the order of appearance of the respective variants in the
-        // source of AMValue.
+        // \warning These numbers must correspond to the order in which the
+        //          variants of an AMvalue are declared within it.
         match value {
             ActorId(_) => 1,
             Boolean(_) => 2,
@@ -349,6 +341,7 @@ pub unsafe extern "C" fn AMvalueEqual(value1: *const AMvalue, value2: *const AMv
 }
 
 /// \struct AMresult
+/// \installed_headerfile
 /// \brief A discriminated union of result variants.
 pub enum AMresult {
     ActorId(am::ActorId, Option<AMactorId>),
@@ -905,8 +898,8 @@ pub unsafe extern "C" fn AMresultValue<'a>(result: *mut AMresult) -> AMvalue<'a>
 }
 
 /// \struct AMunknownValue
+/// \installed_headerfile
 /// \brief A value (typically for a `set` operation) whose type is unknown.
-///
 #[derive(PartialEq)]
 #[repr(C)]
 pub struct AMunknownValue {

--- a/automerge-c/src/result.rs
+++ b/automerge-c/src/result.rs
@@ -658,6 +658,15 @@ impl From<Result<Vec<am::Change>, am::AutomergeError>> for AMresult {
     }
 }
 
+impl From<Result<Vec<am::Change>, am::LoadChangeError>> for AMresult {
+    fn from(maybe: Result<Vec<am::Change>, am::LoadChangeError>) -> Self {
+        match maybe {
+            Ok(changes) => AMresult::Changes(changes, None),
+            Err(e) => AMresult::err(&e.to_string()),
+        }
+    }
+}
+
 impl From<Result<Vec<&am::Change>, am::AutomergeError>> for AMresult {
     fn from(maybe: Result<Vec<&am::Change>, am::AutomergeError>) -> Self {
         match maybe {

--- a/automerge-c/src/result.rs
+++ b/automerge-c/src/result.rs
@@ -89,6 +89,9 @@ use crate::sync::{AMsyncMessage, AMsyncState};
 ///
 /// \var AMvalue::uint
 /// A 64-bit unsigned integer.
+///
+/// \var AMvalue::unknown
+/// A value of unknown type as an `AMunknownValue` struct.
 #[repr(u8)]
 pub enum AMvalue<'a> {
     /// A void variant.
@@ -609,7 +612,7 @@ impl From<Result<am::sync::State, am::sync::DecodeStateError>> for AMresult {
 impl From<Result<am::Value<'static>, am::AutomergeError>> for AMresult {
     fn from(maybe: Result<am::Value<'static>, am::AutomergeError>) -> Self {
         match maybe {
-            Ok(value) => AMresult::Value(value, RefCell::<Option<CString>>::default()),
+            Ok(value) => AMresult::Value(value, Default::default()),
             Err(e) => AMresult::err(&e.to_string()),
         }
     }
@@ -620,7 +623,7 @@ impl From<Result<Option<(am::Value<'static>, am::ObjId)>, am::AutomergeError>> f
         match maybe {
             Ok(Some((value, obj_id))) => match value {
                 am::Value::Object(_) => AMresult::ObjId(AMobjId::new(obj_id)),
-                _ => AMresult::Value(value, RefCell::<Option<CString>>::default()),
+                _ => AMresult::Value(value, Default::default()),
             },
             Ok(None) => AMresult::Void,
             Err(e) => AMresult::err(&e.to_string()),
@@ -640,10 +643,7 @@ impl From<Result<String, am::AutomergeError>> for AMresult {
 impl From<Result<usize, am::AutomergeError>> for AMresult {
     fn from(maybe: Result<usize, am::AutomergeError>) -> Self {
         match maybe {
-            Ok(size) => AMresult::Value(
-                am::Value::uint(size as u64),
-                RefCell::<Option<CString>>::default(),
-            ),
+            Ok(size) => AMresult::Value(am::Value::uint(size as u64), Default::default()),
             Err(e) => AMresult::err(&e.to_string()),
         }
     }
@@ -692,10 +692,7 @@ impl From<Result<Vec<am::ChangeHash>, am::InvalidChangeHashSlice>> for AMresult 
 impl From<Result<Vec<u8>, am::AutomergeError>> for AMresult {
     fn from(maybe: Result<Vec<u8>, am::AutomergeError>) -> Self {
         match maybe {
-            Ok(bytes) => AMresult::Value(
-                am::Value::bytes(bytes),
-                RefCell::<Option<CString>>::default(),
-            ),
+            Ok(bytes) => AMresult::Value(am::Value::bytes(bytes), Default::default()),
             Err(e) => AMresult::err(&e.to_string()),
         }
     }
@@ -716,10 +713,7 @@ impl From<Vec<am::ChangeHash>> for AMresult {
 
 impl From<Vec<u8>> for AMresult {
     fn from(bytes: Vec<u8>) -> Self {
-        AMresult::Value(
-            am::Value::bytes(bytes),
-            RefCell::<Option<CString>>::default(),
-        )
+        AMresult::Value(am::Value::bytes(bytes), Default::default())
     }
 }
 
@@ -903,6 +897,8 @@ pub unsafe extern "C" fn AMresultValue<'a>(result: *mut AMresult) -> AMvalue<'a>
 #[derive(PartialEq)]
 #[repr(C)]
 pub struct AMunknownValue {
+    /// The value's raw bytes.
     bytes: AMbyteSpan,
+    /// The value's encoded type identifier.
     type_code: u8,
 }

--- a/automerge-c/src/result_stack.rs
+++ b/automerge-c/src/result_stack.rs
@@ -103,7 +103,7 @@ pub type AMpushCallback =
 /// \note Calling this function is purely optional because its only purpose is
 ///       to make memory management tolerable for direct usage of this API in
 ///       C, C++ and Objective-C.
-// \internal
+/// \internal
 ///
 /// # Safety
 /// stack must be a valid AMresultStack pointer pointer

--- a/automerge-c/src/result_stack.rs
+++ b/automerge-c/src/result_stack.rs
@@ -1,6 +1,7 @@
 use crate::result::{AMfree, AMresult, AMresultStatus, AMresultValue, AMstatus, AMvalue};
 
 /// \struct AMresultStack
+/// \installed_headerfile
 /// \brief A node in a singly-linked list of result pointers.
 #[repr(C)]
 pub struct AMresultStack {

--- a/automerge-c/src/result_stack.rs
+++ b/automerge-c/src/result_stack.rs
@@ -3,6 +3,10 @@ use crate::result::{AMfree, AMresult, AMresultStatus, AMresultValue, AMstatus, A
 /// \struct AMresultStack
 /// \installed_headerfile
 /// \brief A node in a singly-linked list of result pointers.
+///
+/// \note Using this data structure is purely optional because its only purpose
+///       is to make memory management tolerable for direct usage of this API
+///       in C, C++ and Objective-C.
 #[repr(C)]
 pub struct AMresultStack {
     /// A result to be deallocated.
@@ -24,6 +28,9 @@ impl AMresultStack {
 /// \return The number of `AMresult` structs freed.
 /// \pre \p stack `!= NULL`.
 /// \post `*stack == NULL`.
+/// \note Calling this function is purely optional because its only purpose is
+///       to make memory management tolerable for direct usage of this API in
+///       C, C++ and Objective-C.
 /// \internal
 ///
 /// # Safety
@@ -48,6 +55,9 @@ pub unsafe extern "C" fn AMfreeStack(stack: *mut *mut AMresultStack) -> usize {
 /// \return A pointer to an `AMresult` struct or `NULL`.
 /// \pre \p stack `!= NULL`.
 /// \post `*stack == NULL`.
+/// \note Calling this function is purely optional because its only purpose is
+///       to make memory management tolerable for direct usage of this API in
+///       C, C++ and Objective-C.
 /// \internal
 ///
 /// # Safety
@@ -68,6 +78,10 @@ pub unsafe extern "C" fn AMpop(stack: *mut *mut AMresultStack) -> *mut AMresult 
 /// \brief The prototype of a function to be called when a value matching the
 ///        given discriminant cannot be extracted from the result at the top of
 ///        the given stack.
+///
+/// \note Implementing this function is purely optional because its only purpose
+///       is to make memory management tolerable for direct usage of this API
+///       in C, C++ and Objective-C.
 pub type AMpushCallback =
     Option<extern "C" fn(stack: *mut *mut AMresultStack, discriminant: u8) -> ()>;
 
@@ -86,7 +100,10 @@ pub type AMpushCallback =
 /// \pre \p result `!= NULL`.
 /// \warning If \p stack `== NULL` then \p result is deallocated in order to
 ///          prevent a memory leak.
-/// \internal
+/// \note Calling this function is purely optional because its only purpose is
+///       to make memory management tolerable for direct usage of this API in
+///       C, C++ and Objective-C.
+// \internal
 ///
 /// # Safety
 /// stack must be a valid AMresultStack pointer pointer

--- a/automerge-c/src/strs.rs
+++ b/automerge-c/src/strs.rs
@@ -114,6 +114,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMstrs
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of UTF-8 strings.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/sync/have.rs
+++ b/automerge-c/src/sync/have.rs
@@ -3,6 +3,7 @@ use automerge as am;
 use crate::change_hashes::AMchangeHashes;
 
 /// \struct AMsyncHave
+/// \installed_headerfile
 /// \brief A summary of the changes that the sender of a synchronization
 ///        message already has.
 #[derive(Clone, PartialEq)]

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -144,6 +144,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
 }
 
 /// \struct AMsyncHaves
+/// \installed_headerfile
 /// \brief A random-access iterator over a sequence of synchronization haves.
 #[repr(C)]
 #[derive(PartialEq)]

--- a/automerge-c/src/sync/message.rs
+++ b/automerge-c/src/sync/message.rs
@@ -22,6 +22,7 @@ macro_rules! to_sync_message {
 pub(crate) use to_sync_message;
 
 /// \struct AMsyncMessage
+/// \installed_headerfile
 /// \brief A synchronization message for a peer.
 #[derive(PartialEq)]
 pub struct AMsyncMessage {

--- a/automerge-c/src/sync/state.rs
+++ b/automerge-c/src/sync/state.rs
@@ -20,6 +20,7 @@ macro_rules! to_sync_state {
 pub(crate) use to_sync_state;
 
 /// \struct AMsyncState
+/// \installed_headerfile
 /// \brief The state of synchronization with a peer.
 #[derive(PartialEq)]
 pub struct AMsyncState {

--- a/automerge-c/test/CMakeLists.txt
+++ b/automerge-c/test/CMakeLists.txt
@@ -25,7 +25,7 @@ set_target_properties(test_${LIBRARY_NAME} PROPERTIES LINKER_LANGUAGE C)
 #       must be specified for all of its dependent targets instead.
 target_include_directories(
     test_${LIBRARY_NAME}
-    PRIVATE "$<BUILD_INTERFACE:${CARGO_TARGET_DIR}>"
+    PRIVATE "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR}>"
 )
 
 target_link_libraries(test_${LIBRARY_NAME} PRIVATE cmocka ${LIBRARY_NAME})

--- a/automerge-c/test/actor_id_tests.c
+++ b/automerge-c/test/actor_id_tests.c
@@ -10,7 +10,7 @@
 #include <cmocka.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 #include "str_utils.h"
 
 typedef struct {

--- a/automerge-c/test/doc_tests.c
+++ b/automerge-c/test/doc_tests.c
@@ -8,7 +8,7 @@
 #include <cmocka.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 #include "group_state.h"
 #include "stack_utils.h"
 #include "str_utils.h"

--- a/automerge-c/test/doc_tests.c
+++ b/automerge-c/test/doc_tests.c
@@ -41,7 +41,7 @@ static int teardown(void** state) {
 
 static void test_AMkeys_empty() {
     AMresultStack* stack = NULL;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMstrs forward = AMpush(&stack,
                             AMkeys(doc, AM_ROOT, NULL),
                             AM_VALUE_STRS,
@@ -58,7 +58,7 @@ static void test_AMkeys_empty() {
 
 static void test_AMkeys_list() {
     AMresultStack* stack = NULL;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMfree(AMlistPutInt(doc, AM_ROOT, 0, true, 1));
     AMfree(AMlistPutInt(doc, AM_ROOT, 1, true, 2));
     AMfree(AMlistPutInt(doc, AM_ROOT, 2, true, 3));
@@ -106,7 +106,7 @@ static void test_AMkeys_list() {
 
 static void test_AMkeys_map() {
     AMresultStack* stack = NULL;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMfree(AMmapPutInt(doc, AM_ROOT, "one", 1));
     AMfree(AMmapPutInt(doc, AM_ROOT, "two", 2));
     AMfree(AMmapPutInt(doc, AM_ROOT, "three", 3));
@@ -158,7 +158,7 @@ static void test_AMputActor_bytes(void **state) {
     assert_memory_equal(bytes.src, test_state->actor_id_bytes, bytes.count);
 }
 
-static void test_AMputActor_hex(void **state) {
+static void test_AMputActor_str(void **state) {
     TestState* test_state = *state;
     AMactorId const* actor_id = AMpush(&test_state->group_state->stack,
                                        AMactorIdInitStr(test_state->actor_id_str),
@@ -176,7 +176,7 @@ static void test_AMputActor_hex(void **state) {
 
 static void test_AMspliceText() {
     AMresultStack* stack = NULL;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMfree(AMspliceText(doc, AM_ROOT, 0, 0, "one + "));
     AMfree(AMspliceText(doc, AM_ROOT, 4, 2, "two = "));
     AMfree(AMspliceText(doc, AM_ROOT, 8, 2, "three"));
@@ -194,7 +194,7 @@ int run_doc_tests(void) {
         cmocka_unit_test(test_AMkeys_list),
         cmocka_unit_test(test_AMkeys_map),
         cmocka_unit_test_setup_teardown(test_AMputActor_bytes, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_AMputActor_hex, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_AMputActor_str, setup, teardown),
         cmocka_unit_test(test_AMspliceText),
     };
 

--- a/automerge-c/test/group_state.c
+++ b/automerge-c/test/group_state.c
@@ -12,7 +12,7 @@
 int group_setup(void** state) {
     GroupState* group_state = test_calloc(1, sizeof(GroupState));
     group_state->doc = AMpush(&group_state->stack,
-                              AMcreate(),
+                              AMcreate(NULL),
                               AM_VALUE_DOC,
                               cmocka_cb).doc;
     *state = group_state;

--- a/automerge-c/test/group_state.h
+++ b/automerge-c/test/group_state.h
@@ -2,7 +2,7 @@
 #define GROUP_STATE_H
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 
 typedef struct {
     AMresultStack* stack;

--- a/automerge-c/test/list_tests.c
+++ b/automerge-c/test/list_tests.c
@@ -179,7 +179,7 @@ static_void_test_AMlistPut(Uint, update, uint, UINT64_MAX)
 
 static void test_insert_at_index(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
 
     AMobjId const* const list = AMpush(
         &stack,
@@ -205,7 +205,7 @@ static void test_insert_at_index(void** state) {
 
 static void test_get_list_values(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMobjId const* const list = AMpush(
         &stack,
         AMmapPutObject(doc1, AM_ROOT, "list", AM_OBJ_TYPE_LIST),

--- a/automerge-c/test/list_tests.c
+++ b/automerge-c/test/list_tests.c
@@ -10,7 +10,7 @@
 #include <cmocka.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 #include "group_state.h"
 #include "macro_utils.h"
 #include "stack_utils.h"

--- a/automerge-c/test/macro_utils.h
+++ b/automerge-c/test/macro_utils.h
@@ -2,7 +2,7 @@
 #define MACRO_UTILS_H
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 
 /**
  * \brief Gets the result value discriminant corresponding to a function name

--- a/automerge-c/test/map_tests.c
+++ b/automerge-c/test/map_tests.c
@@ -132,7 +132,7 @@ static_void_test_AMmapPut(Uint, uint, UINT64_MAX)
 
 static void test_range_iter_map(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMfree(AMmapPutUint(doc, AM_ROOT, "a", 3));
     AMfree(AMmapPutUint(doc, AM_ROOT, "b", 4));
     AMfree(AMmapPutUint(doc, AM_ROOT, "c", 5));
@@ -320,7 +320,7 @@ static void test_range_iter_map(void** state) {
 
 static void test_map_range_back_and_forth_single(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMactorId const* const actor_id = AMpush(&stack,
                                              AMgetActorId(doc),
                                              AM_VALUE_ACTOR_ID,
@@ -487,7 +487,7 @@ static void test_map_range_back_and_forth_single(void** state) {
 
 static void test_map_range_back_and_forth_double(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMactorId const* const actor_id1= AMpush(&stack,
                                              AMactorIdInitBytes("\0", 1),
                                              AM_VALUE_ACTOR_ID,
@@ -499,7 +499,7 @@ static void test_map_range_back_and_forth_double(void** state) {
     AMfree(AMmapPutStr(doc1, AM_ROOT, "3", "c"));
 
     /* The second actor should win all conflicts here. */
-    AMdoc* const doc2 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc2 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMactorId const* const actor_id2 = AMpush(&stack,
                                               AMactorIdInitBytes("\1", 1),
                                               AM_VALUE_ACTOR_ID,
@@ -668,7 +668,7 @@ static void test_map_range_back_and_forth_double(void** state) {
 
 static void test_map_range_at_back_and_forth_single(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMactorId const* const actor_id = AMpush(&stack,
                                              AMgetActorId(doc),
                                              AM_VALUE_ACTOR_ID,
@@ -840,7 +840,7 @@ static void test_map_range_at_back_and_forth_single(void** state) {
 
 static void test_map_range_at_back_and_forth_double(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMactorId const* const actor_id1= AMpush(&stack,
                                              AMactorIdInitBytes("\0", 1),
                                              AM_VALUE_ACTOR_ID,
@@ -852,7 +852,7 @@ static void test_map_range_at_back_and_forth_double(void** state) {
     AMfree(AMmapPutStr(doc1, AM_ROOT, "3", "c"));
 
     /* The second actor should win all conflicts here. */
-    AMdoc* const doc2 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc2 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMactorId const* const actor_id2= AMpush(&stack,
                                              AMactorIdInitBytes("\1", 1),
                                              AM_VALUE_ACTOR_ID,
@@ -1025,7 +1025,7 @@ static void test_map_range_at_back_and_forth_double(void** state) {
 
 static void test_get_range_values(void** state) {
     AMresultStack* stack = *state;
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     AMfree(AMmapPutStr(doc1, AM_ROOT, "aa", "aaa"));
     AMfree(AMmapPutStr(doc1, AM_ROOT, "bb", "bbb"));
     AMfree(AMmapPutStr(doc1, AM_ROOT, "cc", "ccc"));

--- a/automerge-c/test/map_tests.c
+++ b/automerge-c/test/map_tests.c
@@ -9,7 +9,7 @@
 #include <cmocka.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 #include "group_state.h"
 #include "macro_utils.h"
 #include "stack_utils.h"

--- a/automerge-c/test/ported_wasm/basic_tests.c
+++ b/automerge-c/test/ported_wasm/basic_tests.c
@@ -24,7 +24,7 @@ static void test_default_import_init_should_return_a_promise(void** state);
 static void test_create_clone_and_free(void** state) {
     AMresultStack* stack = *state;
     /* const doc1 = create()                                                 */
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc1 = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const doc2 = doc1.clone()                                             */
     AMdoc* const doc2 = AMpush(&stack, AMclone(doc1), AM_VALUE_DOC, cmocka_cb).doc;
 }
@@ -35,7 +35,7 @@ static void test_create_clone_and_free(void** state) {
 static void test_start_and_commit(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* doc.commit()                                                          */
     AMpush(&stack, AMcommit(doc, NULL, NULL), AM_VALUE_CHANGE_HASHES, cmocka_cb);
 }
@@ -46,7 +46,7 @@ static void test_start_and_commit(void** state) {
 static void test_getting_a_nonexistent_prop_does_not_throw_an_error(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /* const result = doc.getWithType(root, "hello")                         */
     /* assert.deepEqual(result, undefined)                                   */
@@ -62,11 +62,13 @@ static void test_getting_a_nonexistent_prop_does_not_throw_an_error(void** state
 static void test_should_be_able_to_set_and_get_a_simple_value(void** state) {
     AMresultStack* stack = *state;
     /* const doc: Automerge = create("aabbcc")                               */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc, AMpush(&stack,
-                                    AMactorIdInitStr("aabbcc"),
-                                    AM_VALUE_ACTOR_ID,
-                                    cmocka_cb).actor_id));
+    AMdoc* const doc = AMpush(&stack,
+                              AMcreate(AMpush(&stack,
+                                              AMactorIdInitStr("aabbcc"),
+                                              AM_VALUE_ACTOR_ID,
+                                              cmocka_cb).actor_id),
+                              AM_VALUE_DOC,
+                              cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /* let result                                                            */
     /*                                                                       */
@@ -192,7 +194,7 @@ static void test_should_be_able_to_set_and_get_a_simple_value(void** state) {
 static void test_should_be_able_to_use_bytes(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* doc.put("_root", "data1", new Uint8Array([10, 11, 12]));              */
     static uint8_t const DATA1[] = {10, 11, 12};
     AMfree(AMmapPutBytes(doc, AM_ROOT, "data1", DATA1, sizeof(DATA1)));
@@ -223,7 +225,7 @@ static void test_should_be_able_to_use_bytes(void** state) {
 static void test_should_be_able_to_make_subobjects(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /* let result                                                            */
     /*                                                                       */
@@ -261,7 +263,7 @@ static void test_should_be_able_to_make_subobjects(void** state) {
 static void test_should_be_able_to_make_lists(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /*                                                                       */
     /* const sublist = doc.putObject(root, "numbers", [])                    */
@@ -320,7 +322,7 @@ static void test_should_be_able_to_make_lists(void** state) {
 static void test_lists_have_insert_set_splice_and_push_ops(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /*                                                                       */
     /* const sublist = doc.putObject(root, "letters", [])                    */
@@ -516,7 +518,7 @@ static void test_lists_have_insert_set_splice_and_push_ops(void** state) {
 static void test_should_be_able_to_delete_non_existent_props(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /*                                                                       */
     /* doc.put("_root", "foo", "bar")                                        */
     AMfree(AMmapPutStr(doc, AM_ROOT, "foo", "bar"));
@@ -573,7 +575,7 @@ static void test_should_be_able_to_delete_non_existent_props(void** state) {
 static void test_should_be_able_to_del(void **state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /*                                                                       */
     /* doc.put(root, "xxx", "xxx");                                          */
@@ -598,7 +600,7 @@ static void test_should_be_able_to_del(void **state) {
 static void test_should_be_able_to_use_counters(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root"                                                  */
     /*                                                                       */
     /* doc.put(root, "counter", 10, "counter");                              */
@@ -630,7 +632,7 @@ static void test_should_be_able_to_use_counters(void** state) {
 static void test_should_be_able_to_splice_text(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const root = "_root";                                                 */
     /*                                                                       */
     /* const text = doc.putObject(root, "text", "");                         */
@@ -690,7 +692,7 @@ static void test_should_be_able_to_splice_text(void** state) {
 static void test_should_be_able_to_insert_objects_into_text(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const text = doc.putObject("/", "text", "Hello world");               */
     AMobjId const* const text = AMpush(
         &stack,
@@ -728,7 +730,7 @@ static void test_should_be_able_to_insert_objects_into_text(void** state) {
 static void test_should_be_able_to_save_all_or_incrementally(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /*                                                                       */
     /* doc.put("_root", "foo", 1)                                            */
     AMfree(AMmapPutInt(doc, AM_ROOT, "foo", 1));
@@ -837,7 +839,7 @@ static void test_should_be_able_to_save_all_or_incrementally(void** state) {
 static void test_should_be_able_to_splice_text_2(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create()                                                  */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
+    AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* const text = doc.putObject("_root", "text", "");                      */
     AMobjId const* const text = AMpush(
         &stack,
@@ -887,11 +889,13 @@ static void test_should_be_able_to_splice_text_2(void** state) {
 static void test_local_inc_increments_all_visible_counters_in_a_map(void** state) {
     AMresultStack* stack = *state;
     /* const doc1 = create("aaaa")                                           */
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc1, AMpush(&stack,
-                                     AMactorIdInitStr("aaaa"),
-                                     AM_VALUE_ACTOR_ID,
-                                     cmocka_cb).actor_id));
+    AMdoc* const doc1 = AMpush(&stack,
+                               AMcreate(AMpush(&stack,
+                                               AMactorIdInitStr("aaaa"),
+                                               AM_VALUE_ACTOR_ID,
+                                               cmocka_cb).actor_id),
+                               AM_VALUE_DOC,
+                               cmocka_cb).doc;
     /* doc1.put("_root", "hello", "world")                                   */
     AMfree(AMmapPutStr(doc1, AM_ROOT, "hello", "world"));
     /* const doc2 = load(doc1.save(), "bbbb");                               */
@@ -1011,11 +1015,13 @@ static void test_local_inc_increments_all_visible_counters_in_a_map(void** state
 static void test_local_inc_increments_all_visible_counters_in_a_sequence(void** state) {
     AMresultStack* stack = *state;
     /* const doc1 = create("aaaa")                                           */
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc1, AMpush(&stack,
-                                     AMactorIdInitStr("aaaa"),
-                                     AM_VALUE_ACTOR_ID,
-                                     cmocka_cb).actor_id));
+    AMdoc* const doc1 = AMpush(&stack,
+                               AMcreate(AMpush(&stack,
+                                               AMactorIdInitStr("aaaa"),
+                                               AM_VALUE_ACTOR_ID,
+                                               cmocka_cb).actor_id),
+                               AM_VALUE_DOC,
+                               cmocka_cb).doc;
     /* const seq = doc1.putObject("_root", "seq", [])                        */
     AMobjId const* const seq = AMpush(
         &stack,
@@ -1146,17 +1152,21 @@ static void test_paths_can_be_used_instead_of_objids(void** state);
 static void test_should_be_able_to_fetch_changes_by_hash(void** state) {
     AMresultStack* stack = *state;
     /* const doc1 = create("aaaa")                                           */
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc1, AMpush(&stack,
-                                     AMactorIdInitStr("aaaa"),
-                                     AM_VALUE_ACTOR_ID,
-                                     cmocka_cb).actor_id));
+    AMdoc* const doc1 = AMpush(&stack,
+                               AMcreate(AMpush(&stack,
+                                               AMactorIdInitStr("aaaa"),
+                                               AM_VALUE_ACTOR_ID,
+                                               cmocka_cb).actor_id),
+                               AM_VALUE_DOC,
+                               cmocka_cb).doc;
     /* const doc2 = create("bbbb")                                           */
-    AMdoc* const doc2 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc2, AMpush(&stack,
-                                     AMactorIdInitStr("bbbb"),
-                                     AM_VALUE_ACTOR_ID,
-                                     cmocka_cb).actor_id));
+    AMdoc* const doc2 = AMpush(&stack,
+                               AMcreate(AMpush(&stack,
+                                               AMactorIdInitStr("bbbb"),
+                                               AM_VALUE_ACTOR_ID,
+                                               cmocka_cb).actor_id),
+                               AM_VALUE_DOC,
+                               cmocka_cb).doc;
     /* doc1.put("/", "a", "b")                                               */
     AMfree(AMmapPutStr(doc1, AM_ROOT, "a", "b"));
     /* doc2.put("/", "b", "c")                                               */
@@ -1198,11 +1208,13 @@ static void test_should_be_able_to_fetch_changes_by_hash(void** state) {
 static void test_recursive_sets_are_possible(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create("aaaa")                                            */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc, AMpush(&stack,
-                                    AMactorIdInitStr("aaaa"),
-                                    AM_VALUE_ACTOR_ID,
-                                    cmocka_cb).actor_id));
+    AMdoc* const doc = AMpush(&stack,
+                              AMcreate(AMpush(&stack,
+                                              AMactorIdInitStr("aaaa"),
+                                              AM_VALUE_ACTOR_ID,
+                                              cmocka_cb).actor_id),
+                              AM_VALUE_DOC,
+                              cmocka_cb).doc;
     /* const l1 = doc.putObject("_root", "list", [{ foo: "bar" }, [1, 2, 3]])*/
     AMobjId const* const l1 = AMpush(
         &stack,
@@ -1427,11 +1439,13 @@ static void test_recursive_sets_are_possible(void** state) {
 static void test_only_returns_an_object_id_when_objects_are_created(void** state) {
     AMresultStack* stack = *state;
     /* const doc = create("aaaa")                                            */
-    AMdoc* const doc = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc, AMpush(&stack,
-                                    AMactorIdInitStr("aaaa"),
-                                    AM_VALUE_ACTOR_ID,
-                                    cmocka_cb).actor_id));
+    AMdoc* const doc = AMpush(&stack,
+                              AMcreate(AMpush(&stack,
+                                              AMactorIdInitStr("aaaa"),
+                                              AM_VALUE_ACTOR_ID,
+                                              cmocka_cb).actor_id),
+                              AM_VALUE_DOC,
+                              cmocka_cb).doc;
     /* const r1 = doc.put("_root", "foo", "bar")
        assert.deepEqual(r1, null);                                           */
     AMpush(&stack,
@@ -1496,11 +1510,13 @@ static void test_only_returns_an_object_id_when_objects_are_created(void** state
 static void test_objects_without_properties_are_preserved(void** state) {
     AMresultStack* stack = *state;
     /* const doc1 = create("aaaa")                                           */
-    AMdoc* const doc1 = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(doc1, AMpush(&stack,
-                                    AMactorIdInitStr("aaaa"),
-                                    AM_VALUE_ACTOR_ID,
-                                    cmocka_cb).actor_id));
+    AMdoc* const doc1 = AMpush(&stack,
+                               AMcreate(AMpush(&stack,
+                                               AMactorIdInitStr("aaaa"),
+                                               AM_VALUE_ACTOR_ID,
+                                               cmocka_cb).actor_id),
+                               AM_VALUE_DOC,
+                               cmocka_cb).doc;
     /* const a = doc1.putObject("_root", "a", {});                           */
     AMobjId const* const a = AMpush(
         &stack,
@@ -1567,11 +1583,13 @@ static void test_objects_without_properties_are_preserved(void** state) {
 static void test_should_allow_you_to_forkAt_a_heads(void** state) {
     AMresultStack* stack = *state;
     /* const A = create("aaaaaa")                                            */
-    AMdoc* const A = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(A, AMpush(&stack,
-                                  AMactorIdInitStr("aaaaaa"),
-                                  AM_VALUE_ACTOR_ID,
-                                  cmocka_cb).actor_id));
+    AMdoc* const A = AMpush(&stack,
+                            AMcreate(AMpush(&stack,
+                                            AMactorIdInitStr("aaaaaa"),
+                                            AM_VALUE_ACTOR_ID,
+                                            cmocka_cb).actor_id),
+                            AM_VALUE_DOC,
+                            cmocka_cb).doc;
     /* A.put("/", "key1", "val1");                                           */
     AMfree(AMmapPutStr(A, AM_ROOT, "key1", "val1"));
     /* A.put("/", "key2", "val2");                                           */
@@ -1634,11 +1652,13 @@ static void test_should_allow_you_to_forkAt_a_heads(void** state) {
 static void test_should_handle_merging_text_conflicts_then_saving_and_loading(void** state) {
     AMresultStack* stack = *state;
     /* const A = create("aabbcc")                                            */
-    AMdoc* const A = AMpush(&stack, AMcreate(), AM_VALUE_DOC, cmocka_cb).doc;
-    AMfree(AMsetActorId(A, AMpush(&stack,
-                                  AMactorIdInitStr("aabbcc"),
-                                  AM_VALUE_ACTOR_ID,
-                                  cmocka_cb).actor_id));
+    AMdoc* const A = AMpush(&stack,
+                            AMcreate(AMpush(&stack,
+                                            AMactorIdInitStr("aabbcc"),
+                                            AM_VALUE_ACTOR_ID,
+                                            cmocka_cb).actor_id),
+                            AM_VALUE_DOC,
+                            cmocka_cb).doc;
     /* const At = A.putObject('_root', 'text', "")                           */
     AMobjId const* const At = AMpush(
         &stack,

--- a/automerge-c/test/ported_wasm/basic_tests.c
+++ b/automerge-c/test/ported_wasm/basic_tests.c
@@ -10,7 +10,7 @@
 #include <cmocka.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 #include "../stack_utils.h"
 
 /**

--- a/automerge-c/test/ported_wasm/sync_tests.c
+++ b/automerge-c/test/ported_wasm/sync_tests.c
@@ -22,11 +22,17 @@ typedef struct {
 static int setup(void** state) {
     TestState* test_state = test_calloc(1, sizeof(TestState));
     test_state->n1 = AMpush(&test_state->stack,
-                            AMcreate(),
+                            AMcreate(AMpush(&test_state->stack,
+                                            AMactorIdInitStr("01234567"),
+                                            AM_VALUE_ACTOR_ID,
+                                            cmocka_cb).actor_id),
                             AM_VALUE_DOC,
                             cmocka_cb).doc;
     test_state->n2 = AMpush(&test_state->stack,
-                            AMcreate(),
+                            AMcreate(AMpush(&test_state->stack,
+                                            AMactorIdInitStr("89abcdef"),
+                                            AM_VALUE_ACTOR_ID,
+                                            cmocka_cb).actor_id),
                             AM_VALUE_DOC,
                             cmocka_cb).doc;
     test_state->s1 = AMpush(&test_state->stack,
@@ -650,14 +656,6 @@ static void test_should_assume_sent_changes_were_received_until_we_hear_otherwis
     /* const n1 = create('01234567'), n2 = create('89abcdef')
        const s1 = initSyncState(), s2 = initSyncState()                      */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     /* let message = null                                                    */
     /*                                                                       */
     /* const items = n1.putObject("_root", "items", [])                      */
@@ -771,14 +769,6 @@ static void test_should_work_without_prior_sync_state(void **state) {
     /* const n1 = create('01234567'), n2 = create('89abcdef')
        const s1 = initSyncState(), s2 = initSyncState()                      */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     /*                                                                       */
     /* for (let i = 0; i < 10; i++) {                                        */
     for (size_t i = 0; i != 10; ++i) {
@@ -842,14 +832,6 @@ static void test_should_work_with_prior_sync_state_2(void **state) {
     /* const n1 = create('01234567'), n2 = create('89abcdef')
        let s1 = initSyncState(), s2 = initSyncState()                        */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     /*                                                                       */
     /* for (let i = 0; i < 10; i++) {                                        */
     for (size_t i = 0; i != 10; ++i) {
@@ -925,14 +907,6 @@ static void test_should_ensure_non_empty_state_after_sync(void **state) {
     /* const n1 = create('01234567'), n2 = create('89abcdef')
        const s1 = initSyncState(), s2 = initSyncState()                      */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     /*                                                                       */
     /* for (let i = 0; i < 3; i++) {                                         */
     for (size_t i = 0; i != 3; ++i) {
@@ -972,14 +946,6 @@ static void test_should_resync_after_one_node_crashed_with_data_loss(void **stat
        let s1 = initSyncState()
        const s2 = initSyncState()                                            */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     /*                                                                       */
     /* n1 makes three changes, which we sync to n2 */
     /* for (let i = 0; i < 3; i++) {                                         */
@@ -1114,14 +1080,6 @@ static void test_should_resync_after_one_node_experiences_data_loss_without_disc
     /* const n1 = create('01234567'), n2 = create('89abcdef')
        const s1 = initSyncState(), s2 = initSyncState()                      */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     /*                                                                       */
     /* n1 makes three changes which we sync to n2 */
     /* for (let i = 0; i < 3; i++) {                                         */
@@ -1151,13 +1109,12 @@ static void test_should_resync_after_one_node_experiences_data_loss_without_disc
     /*                                                                       */
     /* const n2AfterDataLoss = create('89abcdef')                            */
     AMdoc* n2_after_data_loss = AMpush(&test_state->stack,
-                                       AMcreate(),
+                                       AMcreate(AMpush(&test_state->stack,
+                                                       AMactorIdInitStr("89abcdef"),
+                                                       AM_VALUE_ACTOR_ID,
+                                                       cmocka_cb).actor_id),
                                        AM_VALUE_DOC,
                                        cmocka_cb).doc;
-    AMfree(AMsetActorId(n2_after_data_loss, AMpush(&test_state->stack,
-                                                   AMactorIdInitStr("89abcdef"),
-                                                   AM_VALUE_ACTOR_ID,
-                                                   cmocka_cb).actor_id));
     /*                                                                       */
     /* "n2" now has no data, but n1 still thinks it does. Note we don't do
      * decodeSyncState(encodeSyncState(s1)) in order to simulate data loss
@@ -1188,22 +1145,13 @@ static void test_should_resync_after_one_node_experiences_data_loss_without_disc
 static void test_should_handle_changes_concurrrent_to_the_last_sync_heads(void **state) {
     /* const n1 = create('01234567'), n2 = create('89abcdef'), n3 = create('fedcba98')*/
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     AMdoc* n3 = AMpush(&test_state->stack,
-                       AMcreate(),
+                       AMcreate(AMpush(&test_state->stack,
+                                       AMactorIdInitStr("fedcba98"),
+                                       AM_VALUE_ACTOR_ID,
+                                       cmocka_cb).actor_id),
                        AM_VALUE_DOC,
                        cmocka_cb).doc;
-    AMfree(AMsetActorId(n3, AMpush(&test_state->stack,
-                                   AMactorIdInitStr("fedcba98"),
-                                   AM_VALUE_ACTOR_ID,
-                                   cmocka_cb).actor_id));
     /* const s12 = initSyncState(), s21 = initSyncState(), s23 = initSyncState(), s32 = initSyncState()*/
     AMsyncState* s12 = test_state->s1;
     AMsyncState* s21 = test_state->s2;
@@ -1281,22 +1229,13 @@ static void test_should_handle_histories_with_lots_of_branching_and_merging(void
     /* const n1 = create('01234567'), n2 = create('89abcdef'), n3 = create('fedcba98')
        const s1 = initSyncState(), s2 = initSyncState()                      */
     TestState* test_state = *state;
-    AMfree(AMsetActorId(test_state->n1, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("01234567"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
-    AMfree(AMsetActorId(test_state->n2, AMpush(&test_state->stack,
-                                               AMactorIdInitStr("89abcdef"),
-                                               AM_VALUE_ACTOR_ID,
-                                               cmocka_cb).actor_id));
     AMdoc* n3 = AMpush(&test_state->stack,
-                       AMcreate(),
+                       AMcreate(AMpush(&test_state->stack,
+                                       AMactorIdInitStr("fedcba98"),
+                                       AM_VALUE_ACTOR_ID,
+                                       cmocka_cb).actor_id),
                        AM_VALUE_DOC,
                        cmocka_cb).doc;
-    AMfree(AMsetActorId(n3, AMpush(&test_state->stack,
-                                   AMactorIdInitStr("fedcba98"),
-                                   AM_VALUE_ACTOR_ID,
-                                   cmocka_cb).actor_id));
     /* n1.put("_root", "x", 0); n1.commit("", 0)                             */
     AMfree(AMmapPutUint(test_state->n1, AM_ROOT, "x", 0));
     AMfree(AMcommit(test_state->n1, "", &TIME_0));

--- a/automerge-c/test/ported_wasm/sync_tests.c
+++ b/automerge-c/test/ported_wasm/sync_tests.c
@@ -8,7 +8,7 @@
 #include <cmocka.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 #include "../stack_utils.h"
 
 typedef struct {

--- a/automerge-c/test/stack_utils.h
+++ b/automerge-c/test/stack_utils.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 /* local */
-#include "automerge.h"
+#include <automerge-c/automerge.h>
 
 /**
  * \brief Reports an error through a cmocka assertion.


### PR DESCRIPTION
@orionz, in this PR I've done the following:
* Exposed `Vec<automerge::Change>` initialization through `AMchangesInit()` for @rkuhn in #411.
* Exposed `automerge::AutoCommit::with_actor()` through `AMcreate()`.
* Clarified the purpose of `AMfreeStack()`, `AMpop()`, `AMpush()`, `AMpushCallback()`, and `AMresultStack`.
* Added missing documentation for the `AMvalue.unknown` variant, the `AMunknownValue.bytes` member and the `AMunknownValue.type_code` member introduced by #355.
* Made all of the include statements for the C API's header within the C source files and the generated documentation consistent with its installation location i.e. `#include "automerge.h"` has been replaced with `#include <automerge-c/automerge.h>` everywhere.

@lightsprint09 and @heckj, all `AMcreate()` calls must be replaced with `AMcreate(NULL)` calls now and I've moved the C header generated by cbindgen from `automerge-rs/automerge-c/build/Cargo/target/automerge.h` to `automerge-rs/automerge-c/build/Cargo/target/include/automerge-c/automerge.h`.