### PR TITLE
Add #[derive(Eq)] to satisfy clippy

### DIFF
--- a/automerge-c/src/actor_id.rs
+++ b/automerge-c/src/actor_id.rs
@@ -11,7 +11,7 @@ use crate::result::{to_result, AMresult};
 /// \struct AMactorId
 /// \installed_headerfile
 /// \brief An actor's unique identifier.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMactorId {
     body: *const am::ActorId,
     c_str: RefCell<Option<CString>>,

--- a/automerge-c/src/byte_span.rs
+++ b/automerge-c/src/byte_span.rs
@@ -4,7 +4,7 @@ use automerge as am;
 /// \installed_headerfile
 /// \brief A view onto a contiguous sequence of bytes.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMbyteSpan {
     /// A pointer to an array of bytes.
     /// \attention <b>NEVER CALL `free()` ON \p src!</b>

--- a/automerge-c/src/change.rs
+++ b/automerge-c/src/change.rs
@@ -20,7 +20,7 @@ macro_rules! to_change {
 /// \struct AMchange
 /// \installed_headerfile
 /// \brief A group of operations performed by an actor.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMchange {
     body: *mut am::Change,
     c_msg: RefCell<Option<CString>>,

--- a/automerge-c/src/change_hashes.rs
+++ b/automerge-c/src/change_hashes.rs
@@ -120,7 +120,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of change hashes.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMchangeHashes {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/changes.rs
+++ b/automerge-c/src/changes.rs
@@ -145,7 +145,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of changes.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMchanges {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/doc/list/items.rs
+++ b/automerge-c/src/doc/list/items.rs
@@ -117,7 +117,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of list object items.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMlistItems {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/doc/map/items.rs
+++ b/automerge-c/src/doc/map/items.rs
@@ -117,7 +117,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of map object items.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMmapItems {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/obj.rs
+++ b/automerge-c/src/obj.rs
@@ -10,7 +10,7 @@ pub mod items;
 /// \struct AMobjId
 /// \installed_headerfile
 /// \brief An object's unique identifier.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMobjId {
     body: am::ObjId,
     c_actor_id: RefCell<Option<AMactorId>>,

--- a/automerge-c/src/obj/items.rs
+++ b/automerge-c/src/obj/items.rs
@@ -117,7 +117,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of object items.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMobjItems {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/result.rs
+++ b/automerge-c/src/result.rs
@@ -903,7 +903,8 @@ pub unsafe extern "C" fn AMresultValue<'a>(result: *mut AMresult) -> AMvalue<'a>
 /// \struct AMunknownValue
 /// \installed_headerfile
 /// \brief A value (typically for a `set` operation) whose type is unknown.
-#[derive(PartialEq)]
+///
+#[derive(Eq, PartialEq)]
 #[repr(C)]
 pub struct AMunknownValue {
     /// The value's raw bytes.

--- a/automerge-c/src/strs.rs
+++ b/automerge-c/src/strs.rs
@@ -117,7 +117,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of UTF-8 strings.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMstrs {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/sync/have.rs
+++ b/automerge-c/src/sync/have.rs
@@ -6,7 +6,7 @@ use crate::change_hashes::AMchangeHashes;
 /// \installed_headerfile
 /// \brief A summary of the changes that the sender of a synchronization
 ///        message already has.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct AMsyncHave(*const am::sync::Have);
 
 impl AMsyncHave {

--- a/automerge-c/src/sync/haves.rs
+++ b/automerge-c/src/sync/haves.rs
@@ -147,7 +147,7 @@ impl From<Detail> for [u8; USIZE_USIZE_USIZE_USIZE_] {
 /// \installed_headerfile
 /// \brief A random-access iterator over a sequence of synchronization haves.
 #[repr(C)]
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMsyncHaves {
     /// An implementation detail that is intentionally opaque.
     /// \warning Modifying \p detail will cause undefined behavior.

--- a/automerge-c/src/sync/state.rs
+++ b/automerge-c/src/sync/state.rs
@@ -22,7 +22,7 @@ pub(crate) use to_sync_state;
 /// \struct AMsyncState
 /// \installed_headerfile
 /// \brief The state of synchronization with a peer.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub struct AMsyncState {
     body: am::sync::State,
     their_haves_storage: RefCell<BTreeMap<usize, AMsyncHave>>,

--- a/automerge/src/columnar/column_range/value.rs
+++ b/automerge/src/columnar/column_range/value.rs
@@ -298,7 +298,7 @@ impl<'a> ValueIter<'a> {
             }
             Ok(bytes) => bytes,
         };
-        let val = match f(&*raw) {
+        let val = match f(raw) {
             Ok(v) => v,
             Err(e) => return Some(Err(e)),
         };

--- a/automerge/src/error.rs
+++ b/automerge/src/error.rs
@@ -63,11 +63,11 @@ pub(crate) struct InvalidScalarValue {
     pub(crate) expected: String,
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, Eq, PartialEq)]
 #[error("Invalid change hash slice: {0:?}")]
 pub struct InvalidChangeHashSlice(pub Vec<u8>);
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, Eq, PartialEq)]
 #[error("Invalid object ID: {0}")]
 pub struct InvalidObjectId(pub String);
 

--- a/automerge/src/legacy/mod.rs
+++ b/automerge/src/legacy/mod.rs
@@ -132,7 +132,7 @@ impl Key {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct SortedVec<T>(Vec<T>);
 


### PR DESCRIPTION
The latest clippy (90.1.65 for me) added a lint which checks for types
that implement `PartialEq` and could implement `Eq`
(`derive_partial_eq_without_eq`). Add a `derive(Eq)` in a bunch of
places to satisfy this lint.