### PR TITLE
Allow for empty head indices when decoding doc

### DIFF
--- a/automerge/src/storage/chunk.rs
+++ b/automerge/src/storage/chunk.rs
@@ -56,6 +56,7 @@ impl<'a> Chunk<'a> {
             first: chunk_input,
             remaining,
         } = i.split(header.data_bytes().len());
+        tracing::trace!(?header, "parsed chunk header");
         let chunk = match header.chunk_type {
             ChunkType::Change => {
                 let (remaining, change) =

--- a/automerge/src/storage/load.rs
+++ b/automerge/src/storage/load.rs
@@ -80,6 +80,7 @@ fn load_next_change<'a>(
     }
     match chunk {
         storage::Chunk::Document(d) => {
+            tracing::trace!("loading document chunk");
             let Reconstructed {
                 changes: new_changes,
                 ..


### PR DESCRIPTION
The compressed document format includes at the end of the document chunk
the indicies of the heads of the document. Older versions of the
javascript implementation do not include these indicies so we allow them
to be omitted when decoding.

Whilst we're here add some tracing::trace logs to make it easier to
understand where parsing is failing.