### PR TITLE
OpSet::visualise: add argument to filter by obj ID

### DIFF
--- a/automerge/src/autocommit.rs
+++ b/automerge/src/autocommit.rs
@@ -231,9 +231,15 @@ impl AutoCommit {
             .receive_sync_message_with(sync_state, message, options)
     }
 
+    /// Return a graphviz representation of the opset.
+    ///
+    /// # Arguments
+    ///
+    /// * objects: An optional list of object IDs to display, if not specified all objects are
+    ///            visualised
     #[cfg(feature = "optree-visualisation")]
-    pub fn visualise_optree(&self) -> String {
-        self.doc.visualise_optree()
+    pub fn visualise_optree(&self, objects: Option<Vec<ExId>>) -> String {
+        self.doc.visualise_optree(objects)
     }
 
     /// Get the current heads of the document.

--- a/automerge/src/automerge.rs
+++ b/automerge/src/automerge.rs
@@ -1178,9 +1178,17 @@ impl Automerge {
         }
     }
 
+    /// Return a graphviz representation of the opset.
+    ///
+    /// # Arguments
+    ///
+    /// * objects: An optional list of object IDs to display, if not specified all objects are
+    ///            visualised
     #[cfg(feature = "optree-visualisation")]
-    pub fn visualise_optree(&self) -> String {
-        self.ops.visualise()
+    pub fn visualise_optree(&self, objects: Option<Vec<ExId>>) -> String {
+        let objects =
+            objects.map(|os| os.iter().filter_map(|o| self.exid_to_obj(o).ok()).collect());
+        self.ops.visualise(objects)
     }
 }
 

--- a/automerge/src/op_set.rs
+++ b/automerge/src/op_set.rs
@@ -300,10 +300,24 @@ impl OpSetInternal {
         self.trees.get(id).map(|tree| tree.objtype)
     }
 
+    /// Return a graphviz representation of the opset.
+    ///
+    /// # Arguments
+    ///
+    /// * objects: An optional list of object IDs to display, if not specified all objects are
+    ///            visualised
     #[cfg(feature = "optree-visualisation")]
-    pub(crate) fn visualise(&self) -> String {
+    pub(crate) fn visualise(&self, objects: Option<Vec<ObjId>>) -> String {
+        use std::borrow::Cow;
         let mut out = Vec::new();
-        let graph = super::visualisation::GraphVisualisation::construct(&self.trees, &self.m);
+        let trees = if let Some(objects) = objects {
+            let mut filtered = self.trees.clone();
+            filtered.retain(|k, _| objects.contains(k));
+            Cow::Owned(filtered)
+        } else {
+            Cow::Borrowed(&self.trees)
+        };
+        let graph = super::visualisation::GraphVisualisation::construct(&trees, &self.m);
         dot::render(&graph, &mut out).unwrap();
         String::from_utf8_lossy(&out[..]).to_string()
     }


### PR DESCRIPTION
Occasionally one needs to debug problems in a document with a large number of objects. In this case it is unhelpful to print a graphviz of the whole opset because there are too many objects. Add a `Option<Vec<ObjId>>` argument to `OpSet::visualise` to filter the objects which are visualised.