### PR TITLE
query::Prop: don't scan past end of OpTree

### DIFF
--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -1350,6 +1350,16 @@ fn load_doc_with_deleted_objects() {
 }
 
 #[test]
+fn insert_after_many_deletes() {
+    let mut doc = AutoCommit::new();
+    let obj = doc.put_object(&ROOT, "object", ObjType::Map).unwrap();
+    for i in 0..100 {
+        doc.put(&obj, i.to_string(), i).unwrap();
+        doc.delete(&obj, i.to_string()).unwrap();
+    }
+}
+
+#[test]
 fn simple_bad_saveload() {
     let mut doc = Automerge::new();
     doc.transact::<_, _, AutomergeError>(|d| {


### PR DESCRIPTION
The logic in `query::Prop` works by first doing a binary search in the OpTree for the node where the key we are looking for starts, and then proceeding from this point forwards skipping over nodes which contain only invisible ops. This logic was incorrect if the start index returned by the binary search was in the last child of the optree and the last child only contains invisible ops. In this case the index returned by the query would be greater than the length of the optree.

Clamp the index returned by the query to the total length of the opset.

Fixes #400 