### PR TITLE
Correctly load documents with deleted objects

### DIFF
--- a/automerge/src/storage/load/reconstruct_document.rs
+++ b/automerge/src/storage/load/reconstruct_document.rs
@@ -236,9 +236,9 @@ impl LoadingObject {
     }
 
     fn append_op(&mut self, op: Op) -> Result<(), Error> {
-        // Collect set operations so we can find the keys which delete operations refer to in
-        // `finish`
-        if matches!(op.action, OpType::Put(_)) {
+        // Collect set and make operations so we can find the keys which delete operations refer to
+        // in `finish`
+        if matches!(op.action, OpType::Put(_) | OpType::Make(_)) {
             match op.key {
                 Key::Map(_) => {
                     self.set_ops.insert(op.id, op.key);

--- a/automerge/tests/test.rs
+++ b/automerge/tests/test.rs
@@ -1332,3 +1332,19 @@ fn load_incremental_with_corrupted_tail() {
         }
     );
 }
+
+#[test]
+fn load_doc_with_deleted_objects() {
+    // Reproduces an issue where a document with deleted objects failed to load
+    let mut doc = AutoCommit::new();
+    doc.put_object(ROOT, "list", ObjType::List).unwrap();
+    doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.put_object(ROOT, "map", ObjType::Map).unwrap();
+    doc.put_object(ROOT, "table", ObjType::Table).unwrap();
+    doc.delete(&ROOT, "list").unwrap();
+    doc.delete(&ROOT, "text").unwrap();
+    doc.delete(&ROOT, "map").unwrap();
+    doc.delete(&ROOT, "table").unwrap();
+    let saved = doc.save();
+    Automerge::load(&saved).unwrap();
+}


### PR DESCRIPTION
The logic for reconstructing changes from the compressed document format records operations which set a key in an object so that it can later reconstruct delete operations from the successor list of the document format operations. The logic to do this was only recording set operations and not `make*` operations. This meant that delete operations targeting `make*` operations could not be loaded correctly.

Correctly record `make*` operations for later use in constructing delete operations.