### PR TITLE
javascript: Make getObjectId tolerate non object arguments

### DIFF
--- a/crates/automerge-wasm/src/interop.rs
+++ b/crates/automerge-wasm/src/interop.rs
@@ -533,8 +533,10 @@ impl Automerge {
         } else {
             value
         };
+        if matches!(datatype, Datatype::Map | Datatype::List | Datatype::Text) {
+            set_hidden_value(&value, &Symbol::for_(RAW_OBJECT_SYMBOL), id)?;
+        }
         set_hidden_value(&value, &Symbol::for_(DATATYPE_SYMBOL), datatype)?;
-        set_hidden_value(&value, &Symbol::for_(RAW_OBJECT_SYMBOL), id)?;
         set_hidden_value(&value, &Symbol::for_(META_SYMBOL), meta)?;
         Ok(value)
     }

--- a/crates/automerge-wasm/test/apply.ts
+++ b/crates/automerge-wasm/test/apply.ts
@@ -165,6 +165,46 @@ describe('Automerge', () => {
       assert.deepEqual( mat, { notes: new String("hello everyone") } )
     })
 
+    it('should set the OBJECT_ID property on lists, maps, and text objects and not on scalars', () => {
+        const doc1 = create('aaaa')
+        let mat: any = doc1.materialize("/")
+        doc1.enablePatches(true)
+        doc1.registerDatatype("counter", (n: number) => new Counter(n))
+        doc1.put("/", "string", "string", "str")
+        doc1.put("/", "uint", 2, "uint")
+        doc1.put("/", "int", 2, "int")
+        doc1.put("/", "float", 2.3, "f64")
+        doc1.put("/", "bytes", new Uint8Array(), "bytes")
+        doc1.put("/", "counter", 1, "counter")
+        doc1.put("/", "date", new Date(), "timestamp")
+        doc1.putObject("/", "text", "text")
+        doc1.putObject("/", "list", [])
+        doc1.putObject("/", "map", {})
+        const applied = doc1.applyPatches(mat)
+
+        assert.equal(_obj(applied.string), null)
+        assert.equal(_obj(applied.uint), null)
+        assert.equal(_obj(applied.int), null)
+        assert.equal(_obj(applied.float), null)
+        assert.equal(_obj(applied.bytes), null)
+        assert.equal(_obj(applied.counter), null)
+        assert.equal(_obj(applied.date), null)
+
+        assert.notEqual(_obj(applied.text), null)
+        assert.notEqual(_obj(applied.list), null)
+        assert.notEqual(_obj(applied.map), null)
+    })
+
+    it('should set the root OBJECT_ID to "_root"', () => {
+        const doc1 = create('aaaa')
+        let mat: any = doc1.materialize("/")
+        assert.equal(_obj(mat), "_root")
+        doc1.enablePatches(true)
+        doc1.put("/", "key", "value")
+        let applied = doc1.applyPatches(mat)
+        assert.equal(_obj(applied), "_root")
+    })
+
     it.skip('it can patch quickly', () => {
 /*
       console.time("init")

--- a/wrappers/javascript/src/index.ts
+++ b/wrappers/javascript/src/index.ts
@@ -77,15 +77,11 @@ function _clear_heads<T>(doc: Doc<T>) {
   Reflect.set(doc,TRACE,undefined)
 }
 
-function _obj<T>(doc: Doc<T>) : ObjID {
-  let proxy_objid = Reflect.get(doc,OBJECT_ID)
-  if (proxy_objid) {
-    return proxy_objid
+function _obj<T>(doc: Doc<T>) : ObjID | null{
+  if (!(typeof doc === 'object') || doc === null) {
+    return null
   }
-  if (Reflect.get(doc,STATE)) {
-    return "_root"
-  }
-  throw new RangeError("invalid document passed to _obj()")
+  return Reflect.get(doc,OBJECT_ID)
 }
 
 function _readonly<T>(doc: Doc<T>) : boolean {
@@ -299,7 +295,11 @@ function conflictAt(context : Automerge, objectId: ObjID, prop: Prop) : Conflict
 export function getConflicts<T>(doc: Doc<T>, prop: Prop) : Conflicts | undefined {
   const state = _state(doc, false)
   const objectId = _obj(doc)
-  return conflictAt(state.handle, objectId, prop)
+  if (objectId != null) {
+    return conflictAt(state.handle, objectId, prop)
+  } else {
+    return undefined
+  }
 }
 
 export function getLastLocalChange<T>(doc: Doc<T>) : Change | undefined {
@@ -307,7 +307,7 @@ export function getLastLocalChange<T>(doc: Doc<T>) : Change | undefined {
   return state.handle.getLastLocalChange() || undefined
 }
 
-export function getObjectId<T>(doc: Doc<T>) : ObjID {
+export function getObjectId(doc: any) : ObjID | null{
   return _obj(doc)
 }
 

--- a/wrappers/javascript/test/basic_test.ts
+++ b/wrappers/javascript/test/basic_test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+import {Counter} from 'automerge'
 import * as Automerge from '../src'
 
 describe('Automerge', () => {
@@ -228,6 +229,39 @@ describe('Automerge', () => {
       const m1 = Automerge.merge(Automerge.clone(s1), Automerge.clone(s2))
       const m2 = Automerge.merge(Automerge.clone(s2), Automerge.clone(s1))
       assert.deepStrictEqual(Automerge.getConflicts(m1, 'x'), Automerge.getConflicts(m2, 'x'))
+    })
+
+    describe("getObjectId", () => {
+        let s1 = Automerge.from({
+            "string": "string",
+            "number": 1,
+            "null": null,
+            "date": new Date(),
+            "counter": new Automerge.Counter(),
+            "bytes": new Uint8Array(10),
+            "text": new Automerge.Text(),
+            "list": [],
+            "map": {}
+        })
+
+        it("should return null for scalar values", () => {
+            assert.equal(Automerge.getObjectId(s1.string), null)
+            assert.equal(Automerge.getObjectId(s1.number), null)
+            assert.equal(Automerge.getObjectId(s1.null), null)
+            assert.equal(Automerge.getObjectId(s1.date), null)
+            assert.equal(Automerge.getObjectId(s1.counter), null)
+            assert.equal(Automerge.getObjectId(s1.bytes), null)
+        })
+
+        it("should return _root for the root object", () => {
+            assert.equal(Automerge.getObjectId(s1), "_root")
+        })
+
+        it("should return non-null for map, list, text, and objects", () => {
+            assert.notEqual(Automerge.getObjectId(s1.text), null)
+            assert.notEqual(Automerge.getObjectId(s1.list), null)
+            assert.notEqual(Automerge.getObjectId(s1.map), null)
+        })
     })
 })
 


### PR DESCRIPTION
Fixes #433. `getObjectId` was previously throwing an error if passed something which was not an object. In the process of fixing this I simplified the logic of `getObjectId` by modifying automerge-wasm to not set the OBJECT_ID hidden property on objects which are not maps, lists, or text - it was previously setting this property on anything which was a JS object, including `Date` and `Uint8Array`.