### PR TITLE
Fixed bug with length not being set in C frontend of automerge-1.0

### DIFF
--- a/automerge-c/src/lib.rs
+++ b/automerge-c/src/lib.rs
@@ -40,6 +40,7 @@ impl Deref for Backend {
 
 unsafe fn from_buf_raw<T>(ptr: *const T, elts: usize) -> Vec<T> {
     let mut dst = Vec::with_capacity(elts);
+    dst.set_len(elts);
     ptr::copy(ptr, dst.as_mut_ptr(), elts);
     dst
 }


### PR DESCRIPTION
I know this branch may not be actively maintained, but hoping to merge in a fix for a bug I found which prevented any documents from being loaded and the tests to fail. I'm using the [automerge-swift](https://github.com/automerge/automerge-swift) frontend which is currently built against an even older commit (cf2a5125a198653b83490b2c996e4f6982f98e57) from this repository. I'm working on at least updating it to this branch, which seems to be (at least close to) the latest point before the C frontend was completely rewritten.

Anyways, I bisected the issue to 1c61986d3 and this PR reverts the change that commit made to this function. The vector was being created with the correct capacity, but its length was not explicitly set, resulting in the caller getting a seemingly-empty vector.

Without this change, running the automerge-c tests results in the following failure:
```
Assertion failed: (strlen(buff) == strlen(buff2)), function main, file automerge.c, line 167.
````
With this change, the tests pass.