### PR TITLE
Implement weak refs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,8 +73,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli wasm-opt
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/wasm_tests
 
@@ -82,8 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli wasm-opt
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/js_tests
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ implementation via FFI in other languages in `./wrappers`. Because this is
 To build this codebase you will need:
 
 - `rust`
-- `wasm-pack`
+- `wasm-bindgen-cli`
+- `wasm-opt`
 - `node`
 - `yarn`
 - `cmake`

--- a/crates/automerge-wasm/.gitignore
+++ b/crates/automerge-wasm/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
-/dev
-/target
+/bundler
+/nodejs
 Cargo.lock
 yarn.lock

--- a/crates/automerge-wasm/README.md
+++ b/crates/automerge-wasm/README.md
@@ -18,34 +18,6 @@ An Object id uniquely identifies a Map, List or Text object within a document.  
 
 Heads refers to a set of hashes that uniquely identifies a point in time in a document's history.  Heads are useful for comparing documents state or retrieving past states from the document.
 
-### Using the Library and Creating a Document
-
-This is a rust/wasm package and will work in a node or web environment.  Node is able to load wasm synchronously but a web environment is not.  The 'init' export of the package is a function that returns a promise that resolves once the wasm is loaded.
-
-This creates a document in node.  The memory allocated is handled by wasm and isn't managed by the javascript garbage collector and thus needs to be manually freed.
-
-```javascript
-  import { create } from "automerge-wasm"
-
-  let doc = create()
-
-  doc.free()
-```
-
-While this will work in both node and in a web context
-
-```javascript
-  import { init, create } from "automerge-wasm"
-
-  init().then(_ => {
-    let doc = create()
-    doc.free()
-  })
-
-```
-
-The examples below will assume a node context for brevity.
-
 ### Automerge Scalar Types
 
 Automerge has many scalar types.  Methods like `put()` and `insert()` take an optional data type parameter.  Normally the type can be inferred but in some cases, such as telling the difference between int, uint and a counter, it cannot.
@@ -53,7 +25,7 @@ Automerge has many scalar types.  Methods like `put()` and `insert()` take an op
 These are puts without a data type
 
 ```javascript
-  import { create } from "automerge-wasm"
+  import { create } from "@automerge/automerge-wasm"
 
   let doc = create()
   doc.put("/", "prop1", 100)  // int
@@ -63,7 +35,6 @@ These are puts without a data type
   doc.put("/", "prop5", new Uint8Array([1,2,3]))
   doc.put("/", "prop6", true)
   doc.put("/", "prop7", null)
-  doc.free()
 ```
 
 Put's with a data type and examples of all the supported data types.
@@ -71,7 +42,7 @@ Put's with a data type and examples of all the supported data types.
 While int vs uint vs f64 matters little in javascript, Automerge is a cross platform library where these distinctions matter.
 
 ```javascript
-  import { create } from "automerge-wasm"
+  import { create } from "@automerge/automerge-wasm"
 
   let doc = create()
   doc.put("/", "prop1", 100, "int")
@@ -84,7 +55,6 @@ While int vs uint vs f64 matters little in javascript, Automerge is a cross plat
   doc.put("/", "prop8", new Uint8Array([1,2,3]), "bytes")
   doc.put("/", "prop9", true, "boolean")
   doc.put("/", "prop10", null, "null")
-  doc.free()
 ```
 
 ### Automerge Object Types
@@ -92,7 +62,7 @@ While int vs uint vs f64 matters little in javascript, Automerge is a cross plat
 Automerge WASM supports 3 object types.  Maps, lists, and text.  Maps are key value stores where the values can be any scalar type or any object type.  Lists are numerically indexed sets of data that can hold any scalar or any object type.
 
 ```javascript
-  import { create } from "automerge-wasm"
+  import { create } from "@automerge/automerge-wasm"
 
   let doc = create()
 
@@ -111,14 +81,12 @@ Automerge WASM supports 3 object types.  Maps, lists, and text.  Maps are key va
   // text is initialized with a string
 
   let notes = doc.putObject("/", "notes", "Hello world!")
-
-  doc.free()
 ```
 
 You can access objects by passing the object id as the first parameter for a call.
 
 ```javascript
-  import { create } from "automerge-wasm"
+  import { create } from "@automerge/automerge-wasm"
 
   let doc = create()
 
@@ -142,8 +110,6 @@ You can access objects by passing the object id as the first parameter for a cal
   // use a path instead
 
   doc.put("/config", "align", "right")
-
-  doc.free()
 ```
 
 Using the id directly is always faster (as it prevents the path to id conversion internally) so it is preferred for performance critical code.
@@ -165,7 +131,6 @@ Maps are key/value stores.  The root object is always a map.  The keys are alway
 
     doc.keys(mymap)           // returns ["bytes","foo","sub"]
     doc.materialize("_root")  // returns { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {}}}
-    doc.free()
 ```
 
 ### Lists
@@ -185,7 +150,6 @@ Lists are index addressable sets of values.  These values can be any scalar or o
 
     doc.materialize(items)                        // returns [ "bat", [1,2], { hello : "world" }, true, "bag", "brick"]
     doc.length(items)                             // returns 6
-    doc.free()
 ```
 
 ### Text
@@ -204,7 +168,6 @@ Text is a specialized list type intended for modifying a text document.  The pri
     doc.text(notes)       // returns "Hello \ufffceveryone"
     doc.getWithType(notes, 6)   // returns ["map", obj]
     doc.get(obj, "hi") // returns "there"
-    doc.free()
 ```
 
 ### Tables
@@ -234,7 +197,6 @@ When querying maps use the `get()` method with the object in question and the pr
 
     doc1.get("_root","key3")   // returns "doc2val"
     doc1.getAll("_root","key3")  // returns [[ "str", "doc1val"], ["str", "doc2val"]]
-    doc1.free(); doc2.free()
 ```
 
 ### Counters
@@ -256,8 +218,6 @@ Counters are 64 bit ints that support the increment operation.  Frequently diffe
     doc1.merge(doc2)
 
     doc1.materialize("_root")  // returns { number: 10, total: 33 }
-
-    doc1.free(); doc2.free()
 ```
 
 ### Transactions
@@ -285,8 +245,6 @@ Generally speaking you don't need to think about transactions when using Automer
 
     doc.get("_root", "key")        // returns "val2"
     doc.pendingOps()                 // returns 0
-
-    doc.free()
 ```
 
 ### Viewing Old Versions of the Document
@@ -308,8 +266,6 @@ All query functions can take an optional argument of `heads` which allow you to 
     doc.get("_root","key",heads2)   // returns "val2"
     doc.get("_root","key",heads1)   // returns "val1"
     doc.get("_root","key",[])       // returns undefined
-
-    doc.free()
 ```
 
 This works for `get()`, `getAll()`, `keys()`, `length()`, `text()`, and `materialize()`
@@ -335,8 +291,6 @@ The `merge()` command applies all changes in the argument doc into the calling d
 
     doc1.materialize("_root")       // returns { key1: "val1", key2: "val2", key3: "val3" }
     doc2.materialize("_root")       // returns { key1: "val1", key3: "val3" }
-
-    doc1.free(); doc2.free()
 ```
 
 Note that calling `a.merge(a)` will produce an unrecoverable error from the wasm-bindgen layer which (as of this writing) there is no workaround for.
@@ -350,7 +304,7 @@ If you wish to incrementally update a saved Automerge doc you can call `saveIncr
 The `load()` function takes a `Uint8Array()` of bytes produced in this way and constitutes a new document.  The `loadIncremental()` method is available if you wish to consume the result of a `saveIncremental()` with an already instanciated document.
 
 ```javascript
-  import { create, load } from "automerge-wasm"
+  import { create, load } from "@automerge/automerge-wasm"
 
   let doc1 = create()
 
@@ -382,14 +336,12 @@ The `load()` function takes a `Uint8Array()` of bytes produced in this way and c
   doc2.materialize("_root")  // returns { key1: "value1", key2: "value2" }
   doc3.materialize("_root")  // returns { key1: "value1", key2: "value2" }
   doc4.materialize("_root")  // returns { key1: "value1", key2: "value2" }
-
-  doc1.free(); doc2.free(); doc3.free(); doc4.free()
 ```
 
 One interesting feature of automerge binary saves is that they can be concatenated together in any order and can still be loaded into a coherent merged document.
 
 ```javascript
-import { load } from "automerge-wasm"
+import { load } from "@automerge/automerge-wasm"
 import * as fs from "fs"
 
 let file1 = fs.readFileSync("automerge_save_1");
@@ -409,7 +361,7 @@ When syncing a document the `generateSyncMessage()` and `receiveSyncMessage()` m
 A very simple sync implementation might look like this.
 
 ```javascript
-  import { encodeSyncState, decodeSyncState, initSyncState } from "automerge-wasm"
+  import { encodeSyncState, decodeSyncState, initSyncState } from "@automerge/automerge-wasm"
 
   let states = {}
 
@@ -457,7 +409,7 @@ Actors are ids that need to be unique to each process writing to a document.  Th
 Methods that create new documents will generate random actors automatically - if you wish to supply your own it is always taken as an optional argument.  This is true for the following functions.
 
 ```javascript
-  import { create, load } from "automerge-wasm"
+  import { create, load } from "@automerge/automerge-wasm"
 
   let doc1 = create()  // random actorid
   let doc2 = create("aabbccdd")
@@ -467,8 +419,6 @@ Methods that create new documents will generate random actors automatically - if
   let doc6 = load(doc4.save(), "00aabb11")
 
   let actor = doc1.getActor()
-
-  doc1.free(); doc2.free(); doc3.free(); doc4.free(); doc5.free(); doc6.free()
 ```
 
 ### Glossary: Object Id's
@@ -491,7 +441,35 @@ Object Ids uniquely identify an object within a document.  They are represented 
   doc.put(o1v2, "x", "y")  // modifying the new "o1" object
 
   assert.deepEqual(doc.materialize("_root"), { "o1": { x: "y" }, "o2": {} })
-
-  doc.free()
 ```
 
+### Appendix: Building
+
+  The following steps should allow you to build the package
+
+  ```
+   $ rustup target add wasm32-unknown-unknown
+   $ cargo install wasm-bindgen-cli
+   $ cargo install wasm-opt
+   $ yarn
+   $ yarn release
+   $ yarn pack
+  ```
+
+### Appendix: WASM and Memory Allocation
+
+Allocated memory in rust will be freed automatically on platforms that support `FinalizationRegistry`.
+
+This is currently supported in [all major browsers and nodejs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry).
+
+On unsupported platforms you can free memory explicitly.
+
+```javascript
+  import { create, initSyncState } from "@automerge/automerge-wasm"
+
+  let doc = create()
+  let sync = initSyncState()
+
+  doc.free()
+  sync.free()
+```

--- a/crates/automerge-wasm/package.json
+++ b/crates/automerge-wasm/package.json
@@ -15,23 +15,26 @@
     "LICENSE",
     "package.json",
     "index.d.ts",
-    "nodejs/bindgen.js",
-    "nodejs/bindgen_bg.wasm",
-    "bundler/bindgen.js",
-    "bundler/bindgen_bg.js",
-    "bundler/bindgen_bg.wasm"
+    "nodejs/automerge_wasm.js",
+    "nodejs/automerge_wasm_bg.wasm",
+    "bundler/automerge_wasm.js",
+    "bundler/automerge_wasm_bg.js",
+    "bundler/automerge_wasm_bg.wasm"
   ],
   "private": false,
   "types": "index.d.ts",
-  "module": "./bundler/bindgen.js",
-  "main": "./nodejs/bindgen.js",
+  "module": "./bundler/automerge_wasm.js",
+  "main": "./nodejs/automerge_wasm.js",
   "scripts": {
     "lint": "eslint test/*.ts index.d.ts",
-    "debug": "cross-env PROFILE=dev yarn buildall",
-    "build": "cross-env PROFILE=dev FEATURES='' yarn buildall",
-    "release": "cross-env PROFILE=release yarn buildall",
+    "debug": "cross-env PROFILE=dev TARGET_DIR=debug yarn buildall",
+    "build": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' yarn buildall",
+    "release": "cross-env PROFILE=release TARGET_DIR=release yarn buildall",
     "buildall": "cross-env TARGET=nodejs yarn target && cross-env TARGET=bundler yarn target",
-    "target": "rimraf ./$TARGET && wasm-pack build --target $TARGET --$PROFILE --out-name bindgen -d $TARGET -- $FEATURES",
+    "target": "rimraf ./$TARGET && yarn compile && yarn bindgen && yarn opt",
+    "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
+    "bindgen": "wasm-bindgen --no-typescript --weak-refs --target $TARGET --out-dir $TARGET ../../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
+    "opt": "wasm-opt -Oz $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
     "test": "ts-mocha -p tsconfig.json --type-check --bail --full-trace test/*.ts"
   },
   "devDependencies": {
@@ -52,7 +55,7 @@
     "typescript": "^4.6.4"
   },
   "exports": {
-    "browser": "./bundler/bindgen.js",
-    "require": "./nodejs/bindgen.js"
+    "browser": "./bundler/automerge_wasm.js",
+    "require": "./nodejs/automerge_wasm.js"
   }
 }

--- a/crates/automerge-wasm/src/lib.rs
+++ b/crates/automerge-wasm/src/lib.rs
@@ -121,8 +121,6 @@ impl Automerge {
         Ok(automerge)
     }
 
-    pub fn free(self) {}
-
     #[wasm_bindgen(js_name = pendingOps)]
     pub fn pending_ops(&self) -> JsValue {
         (self.doc.pending_ops() as u32).into()
@@ -826,8 +824,8 @@ pub fn import_sync_state(state: JsValue) -> Result<SyncState, JsValue> {
 
 // this is needed to be compatible with the automerge-js api
 #[wasm_bindgen(js_name = exportSyncState)]
-pub fn export_sync_state(state: SyncState) -> JsValue {
-    JS::from(state.0).into()
+pub fn export_sync_state(state: &SyncState) -> JsValue {
+    JS::from(state.0.clone()).into()
 }
 
 #[wasm_bindgen(js_name = encodeSyncMessage)]
@@ -865,9 +863,9 @@ pub fn decode_sync_message(msg: Uint8Array) -> Result<JsValue, JsValue> {
 }
 
 #[wasm_bindgen(js_name = encodeSyncState)]
-pub fn encode_sync_state(state: SyncState) -> Result<Uint8Array, JsValue> {
-    let state = state.0;
-    Ok(Uint8Array::from(state.encode().as_slice()))
+pub fn encode_sync_state(state: &SyncState) -> Result<Uint8Array, JsValue> {
+    //let state = state.0.clone();
+    Ok(Uint8Array::from(state.0.encode().as_slice()))
 }
 
 #[wasm_bindgen(js_name = decodeSyncState)]

--- a/crates/automerge-wasm/test/readme.ts
+++ b/crates/automerge-wasm/test/readme.ts
@@ -1,18 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, it } from 'mocha';
 import * as assert from 'assert'
-import { create, load } from '..'
+import { create, load, initSyncState } from '..'
 
 describe('Automerge', () => {
   describe('Readme Examples', () => {
-    it('Using the Library and Creating a Document (1)', () => {
+    it('Using the Library and Creating a Document', () => {
       const doc = create()
+      const sync = initSyncState()
       doc.free()
-    })
-    it('Using the Library and Creating a Document (2)', (done) => {
-      const doc = create()
-      doc.free()
-      done()
+      sync.free()
     })
     it('Automerge Scalar Types (1)', () => {
       const doc = create()
@@ -33,8 +30,6 @@ describe('Automerge', () => {
         prop6: true,
         prop7: null
       })
-
-      doc.free()
     })
     it('Automerge Scalar Types (2)', () => {
       const doc = create()
@@ -48,7 +43,6 @@ describe('Automerge', () => {
       doc.put("/", "prop8", new Uint8Array([1,2,3]), "bytes")
       doc.put("/", "prop9", true, "boolean")
       doc.put("/", "prop10", null, "null")
-      doc.free()
     })
     it('Automerge Object Types (1)', () => {
       const doc = create()
@@ -68,8 +62,6 @@ describe('Automerge', () => {
       // text is initialized with a string
 
       const notes = doc.putObject("/", "notes", "Hello world!")
-
-      doc.free()
     })
     it('Automerge Object Types (2)', () => {
       const doc = create()
@@ -91,8 +83,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.materialize("/"), {
          config: { align: "right", archived: false, cycles: [ 10, 19, 21 ] }
       })
-
-      doc.free()
     })
     it('Maps (1)', () => {
       const doc = create()
@@ -107,8 +97,6 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc.keys(mymap),["bytes","foo","sub"])
       assert.deepEqual(doc.materialize("_root"), { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {} }})
-
-      doc.free()
     })
     it('Lists (1)', () => {
       const doc = create()
@@ -123,8 +111,6 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc.materialize(items),[ "bat", [ 1 ,2 ], { hello : "world" }, true, "bag", "brick" ])
       assert.deepEqual(doc.length(items),6)
-
-      doc.free()
     })
     it('Text (1)', () => {
       const doc = create("aaaaaa")
@@ -138,8 +124,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.text(notes), "Hello \ufffceveryone")
       assert.deepEqual(doc.get(notes, 6), obj)
       assert.deepEqual(doc.get(obj, "hi"), "there")
-
-      doc.free()
     })
     it('Querying Data (1)', () => {
       const doc1 = create("aabbcc")
@@ -160,8 +144,6 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc1.get("_root","key3"), "doc2val")
       assert.deepEqual(doc1.getAll("_root","key3"),[[ "str", "doc1val", "3@aabbcc"], ["str", "doc2val", "3@ffaaff"]])
-
-      doc1.free(); doc2.free()
     })
     it('Counters (1)', () => {
       const doc1 = create("aaaaaa")
@@ -178,8 +160,6 @@ describe('Automerge', () => {
       doc1.merge(doc2)
 
       assert.deepEqual(doc1.materialize("_root"), { number: 10, total: 33 })
-
-      doc1.free(); doc2.free()
     })
     it('Transactions (1)', () => {
       const doc = create()
@@ -202,8 +182,6 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc.get("_root", "key"),"val2")
       assert.deepEqual(doc.pendingOps(),0)
-
-      doc.free()
     })
     it('Viewing Old Versions of the Document (1)', () => {
       const doc = create()
@@ -220,8 +198,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.get("_root","key",heads2), "val2")
       assert.deepEqual(doc.get("_root","key",heads1), "val1")
       assert.deepEqual(doc.get("_root","key",[]), undefined)
-
-      doc.free()
     })
     it('Forking And Merging (1)', () => {
       const doc1 = create()
@@ -236,8 +212,6 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc1.materialize("_root"), { key1: "val1", key2: "val2", key3: "val3" })
       assert.deepEqual(doc2.materialize("_root"), { key1: "val1", key3: "val3" })
-
-      doc1.free(); doc2.free()
     })
     it('Saving And Loading (1)', () => {
       const doc1 = create()
@@ -270,8 +244,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc2.materialize("_root"), { key1: "value1", key2: "value2" })
       assert.deepEqual(doc3.materialize("_root"), { key1: "value1", key2: "value2" })
       assert.deepEqual(doc4.materialize("_root"), { key1: "value1", key2: "value2" })
-
-      doc1.free(); doc2.free(); doc3.free(); doc4.free()
     })
     //it.skip('Syncing (1)', () => { })
   })

--- a/crates/automerge-wasm/test/test.ts
+++ b/crates/automerge-wasm/test/test.ts
@@ -31,14 +31,12 @@ describe('Automerge', () => {
     it('should create, clone and free', () => {
       const doc1 = create()
       const doc2 = doc1.clone()
-      doc1.free()
       doc2.free()
     })
 
     it('should be able to start and commit', () => {
       const doc = create()
       doc.commit()
-      doc.free()
     })
 
     it('getting a nonexistent prop does not throw an error', () => {
@@ -46,7 +44,6 @@ describe('Automerge', () => {
       const root = "_root"
       const result = doc.getWithType(root, "hello")
       assert.deepEqual(result, undefined)
-      doc.free()
     })
 
     it('should be able to set and get a simple value', () => {
@@ -105,8 +102,6 @@ describe('Automerge', () => {
 
       result = doc.getWithType(root, "null")
       assert.deepEqual(result, ["null", null]);
-
-      doc.free()
     })
 
     it('should be able to use bytes', () => {
@@ -117,7 +112,6 @@ describe('Automerge', () => {
       assert.deepEqual(value1, ["bytes", new Uint8Array([10, 11, 12])]);
       const value2 = doc.getWithType("_root", "data2")
       assert.deepEqual(value2, ["bytes", new Uint8Array([13, 14, 15])]);
-      doc.free()
     })
 
     it('should be able to make subobjects', () => {
@@ -134,7 +128,6 @@ describe('Automerge', () => {
 
       result = doc.getWithType(submap, "number")
       assert.deepEqual(result, ["uint", 6])
-      doc.free()
     })
 
     it('should be able to make lists', () => {
@@ -157,7 +150,6 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc.getWithType(sublist, 2), ["str", "b v2"])
       assert.deepEqual(doc.length(sublist), 4)
-      doc.free()
     })
 
     it('lists have insert, set, splice, and push ops', () => {
@@ -180,8 +172,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.materialize(sublist), ["z", "d", "e", "f", "c", new Date(3)])
       assert.deepEqual(doc.length(sublist), 6)
       assert.deepEqual(doc.materialize("/", heads), { letters: ["b", "a", "c"] })
-
-      doc.free()
     })
 
     it('should be able delete non-existent props', () => {
@@ -200,7 +190,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.keys("_root"), ["bip"])
       assert.deepEqual(doc.keys("_root", [hash1]), ["bip", "foo"])
       assert.deepEqual(doc.keys("_root", [hash2]), ["bip"])
-      doc.free()
     })
 
     it('should be able to del', () => {
@@ -211,7 +200,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.getWithType(root, "xxx"), ["str", "xxx"])
       doc.delete(root, "xxx");
       assert.deepEqual(doc.getWithType(root, "xxx"), undefined)
-      doc.free()
     })
 
     it('should be able to use counters', () => {
@@ -224,7 +212,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.getWithType(root, "counter"), ["counter", 20])
       doc.increment(root, "counter", -5);
       assert.deepEqual(doc.getWithType(root, "counter"), ["counter", 15])
-      doc.free()
     })
 
     it('should be able to splice text', () => {
@@ -241,7 +228,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.getWithType(text, 10), ["str", "d"])
       assert.deepEqual(doc.getWithType(text, 11), ["str", "!"])
       assert.deepEqual(doc.getWithType(text, 12), ["str", "?"])
-      doc.free()
     })
 
     it('should be able to insert objects into text', () => {
@@ -283,10 +269,6 @@ describe('Automerge', () => {
       assert.deepEqual(docA.keys("_root"), docB.keys("_root"));
       assert.deepEqual(docA.save(), docB.save());
       assert.deepEqual(docA.save(), docC.save());
-      doc.free()
-      docA.free()
-      docB.free()
-      docC.free()
     })
 
     it('should be able to splice text', () => {
@@ -302,7 +284,6 @@ describe('Automerge', () => {
       assert.strictEqual(doc.length(text, [hash1]), 11)
       assert.strictEqual(doc.text(text, [hash2]), "hello big bad world")
       assert.strictEqual(doc.length(text, [hash2]), 19)
-      doc.free()
     })
 
     it('local inc increments all visible counters in a map', () => {
@@ -332,10 +313,6 @@ describe('Automerge', () => {
       const save1 = doc1.save()
       const doc4 = load(save1)
       assert.deepEqual(doc4.save(), save1);
-      doc1.free()
-      doc2.free()
-      doc3.free()
-      doc4.free()
     })
 
     it('local inc increments all visible counters in a sequence', () => {
@@ -366,10 +343,6 @@ describe('Automerge', () => {
       const save = doc1.save()
       const doc4 = load(save)
       assert.deepEqual(doc4.save(), save);
-      doc1.free()
-      doc2.free()
-      doc3.free()
-      doc4.free()
     })
 
     it('paths can be used instead of objids', () => {
@@ -411,7 +384,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc.materialize(l2), { zip: ["a", "b"] })
       assert.deepEqual(doc.materialize(l1), [{ zip: ["a", "b"] }, { foo: "bar" }, [1, 2, 3]])
       assert.deepEqual(doc.materialize(l4), new String("hello world"))
-      doc.free()
     })
 
     it('only returns an object id when objects are created', () => {
@@ -434,7 +406,6 @@ describe('Automerge', () => {
       assert.deepEqual(r7, "7@aaaa");
       assert.deepEqual(r8, null);
       //assert.deepEqual(r9,["12@aaaa","13@aaaa"]);
-      doc.free()
     })
 
     it('objects without properties are preserved', () => {
@@ -452,8 +423,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc2.getWithType("_root", "c"), ["map", c])
       assert.deepEqual(doc2.keys(c), ["d"])
       assert.deepEqual(doc2.getWithType(c, "d"), ["str", "dd"])
-      doc1.free()
-      doc2.free()
     })
 
     it('should allow you to forkAt a heads', () => {
@@ -505,8 +474,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc2.popPatches(), [
         { action: 'put', path: ['hello'], value: 'world', conflict: false }
       ])
-      doc1.free()
-      doc2.free()
     })
 
     it('should include nested object creation', () => {
@@ -519,8 +486,6 @@ describe('Automerge', () => {
         { action: 'put', path: [ 'birds', 'friday' ], value: {}, conflict: false },
         { action: 'put', path: [ 'birds', 'friday', 'robins' ], value: 3, conflict: false},
       ])
-      doc1.free()
-      doc2.free()
     })
 
     it('should delete map keys', () => {
@@ -534,8 +499,6 @@ describe('Automerge', () => {
         { action: 'put', path: [ 'favouriteBird' ], value: 'Robin', conflict: false },
         { action: 'del', path: [ 'favouriteBird' ] }
       ])
-      doc1.free()
-      doc2.free()
     })
 
     it('should include list element insertion', () => {
@@ -547,8 +510,6 @@ describe('Automerge', () => {
         { action: 'put', path: [ 'birds' ], value: [], conflict: false },
         { action: 'splice', path: [ 'birds', 0 ], values: ['Goldfinch', 'Chaffinch'] },
       ])
-      doc1.free()
-      doc2.free()
     })
 
     it('should insert nested maps into a list', () => {
@@ -563,8 +524,6 @@ describe('Automerge', () => {
         { action: 'put', path: [ 'birds', 0, 'species' ], value: 'Goldfinch', conflict: false },
         { action: 'put', path: [ 'birds', 0, 'count', ], value: 3, conflict: false }
       ])
-      doc1.free()
-      doc2.free()
     })
 
     it('should calculate list indexes based on visible elements', () => {
@@ -581,8 +540,6 @@ describe('Automerge', () => {
         { action: 'del', path: ['birds', 0] },
         { action: 'splice', path: ['birds', 1], values: ['Greenfinch'] }
       ])
-      doc1.free()
-      doc2.free()
     })
 
     it('should handle concurrent insertions at the head of a list', () => {
@@ -610,7 +567,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc4.popPatches(), [
         { action: 'splice', path: ['values',0], values:['a','b','c','d'] },
       ])
-      doc1.free(); doc2.free(); doc3.free(); doc4.free()
     })
 
     it('should handle concurrent insertions beyond the head', () => {
@@ -638,7 +594,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc4.popPatches(), [
         { action: 'splice', path: ['values', 2], values: ['c','d','e','f'] },
       ])
-      doc1.free(); doc2.free(); doc3.free(); doc4.free()
     })
 
     it('should handle conflicts on root object keys', () => {
@@ -662,7 +617,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['bird'], value: 'Goldfinch', conflict: false },
         { action: 'put', path: ['bird'], value: 'Goldfinch', conflict: true },
       ])
-      doc1.free(); doc2.free(); doc3.free(); doc4.free()
     })
 
     it('should handle three-way conflicts', () => {
@@ -701,7 +655,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['bird'], value: 'Goldfinch', conflict: true },
         { action: 'put', path: ['bird'], value: 'Goldfinch', conflict: true }
       ])
-      doc1.free(); doc2.free(); doc3.free()
     })
 
     it('should allow a conflict to be resolved', () => {
@@ -720,7 +673,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['bird'], value: 'Chaffinch', conflict: true },
         { action: 'put', path: ['bird'], value: 'Goldfinch', conflict: false }
       ])
-      doc1.free(); doc2.free(); doc3.free()
     })
 
     it('should handle a concurrent map key overwrite and delete', () => {
@@ -744,7 +696,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc2.popPatches(), [
         { action: 'put', path: ['bird'], value: 'Goldfinch', conflict: false }
       ])
-      doc1.free(); doc2.free()
     })
 
     it('should handle a conflict on a list element', () => {
@@ -773,7 +724,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['birds',0], value: 'Redwing', conflict: false },
         { action: 'put', path: ['birds',0], value: 'Redwing', conflict: true }
       ])
-      doc1.free(); doc2.free(); doc3.free(); doc4.free()
     })
 
     it('should handle a concurrent list element overwrite and delete', () => {
@@ -808,7 +758,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['birds',0], value: 'Ring-necked parakeet', conflict: false },
         { action: 'put', path: ['birds',2], value: 'Redwing', conflict: true }
       ])
-      doc1.free(); doc2.free(); doc3.free(); doc4.free()
     })
 
     it('should handle deletion of a conflict value', () => {
@@ -832,7 +781,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc3.popPatches(), [
         { action: 'put', path: ['bird'], value: 'Robin', conflict: false }
       ])
-      doc1.free(); doc2.free(); doc3.free()
     })
 
     it('should handle conflicting nested objects', () => {
@@ -854,7 +802,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['birds'], value: {}, conflict: true },
         { action: 'splice', path: ['birds',0], values: ['Parakeet'] }
       ])
-      doc1.free(); doc2.free()
     })
 
     it('should support date objects', () => {
@@ -866,7 +813,6 @@ describe('Automerge', () => {
       assert.deepEqual(doc2.popPatches(), [
         { action: 'put', path: ['createdAt'], value: now, conflict: false }
       ])
-      doc1.free(); doc2.free()
     })
 
     it('should capture local put ops', () => {
@@ -885,7 +831,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['map'], value: {}, conflict: false },
         { action: 'put', path: ['list'], value: [], conflict: false },
       ])
-      doc1.free()
     })
 
     it('should capture local insert ops', () => {
@@ -906,7 +851,6 @@ describe('Automerge', () => {
         { action: 'splice', path: ['list', 2], values: [{}] },
         { action: 'splice', path: ['list', 2], values: [[]] },
       ])
-      doc1.free()
     })
 
     it('should capture local push ops', () => {
@@ -921,7 +865,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['list'], value: [], conflict: false },
         { action: 'splice', path: ['list',0], values: [1,{},[]] },
       ])
-      doc1.free()
     })
 
     it('should capture local splice ops', () => {
@@ -937,7 +880,6 @@ describe('Automerge', () => {
         { action: 'del', path: ['list',1] },
         { action: 'del', path: ['list',1] },
       ])
-      doc1.free()
     })
 
     it('should capture local increment ops', () => {
@@ -950,7 +892,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['counter'], value: 2, conflict: false },
         { action: 'inc', path: ['counter'], value: 4 },
       ])
-      doc1.free()
     })
 
 
@@ -967,7 +908,6 @@ describe('Automerge', () => {
         { action: 'del', path: ['key1'], },
         { action: 'del', path: ['key2'], },
       ])
-      doc1.free()
     })
 
     it('should support counters in a map', () => {
@@ -982,7 +922,6 @@ describe('Automerge', () => {
         { action: 'put', path: ['starlings'], value: 2, conflict: false },
         { action: 'inc', path: ['starlings'], value: 1 }
       ])
-      doc1.free(); doc2.free()
     })
 
     it('should support counters in a list', () => {
@@ -1003,7 +942,6 @@ describe('Automerge', () => {
         { action: 'inc', path: ['list',0], value: 2 },
         { action: 'inc', path: ['list',0], value: -5 },
       ])
-      doc1.free(); doc2.free()
     })
 
     it('should delete a counter from a map') // TODO
@@ -1554,7 +1492,6 @@ describe('Automerge', () => {
         const n2up = n2.clone('89abcdef');
         n2up.put("_root", "x", `${i} @ n2`); n2up.commit("", 0)
         if (new BloomFilter(n1up.getHeads()).containsHash(n2up.getHeads()[0])) {
-          n1.free(); n2.free()
           n1 = n1up; n2 = n2up; break
         }
       }
@@ -1603,7 +1540,6 @@ describe('Automerge', () => {
 
           n1hash2 = n1us2.getHeads()[0]; n2hash2 = n2us2.getHeads()[0]
           if (new BloomFilter([n1hash1, n1hash2]).containsHash(n2hash1)) {
-            n1.free(); n2.free()
             n1 = n1us2; n2 = n2us2; break
           }
         }
@@ -1696,7 +1632,6 @@ describe('Automerge', () => {
         n1hash3 = n1us3.getHeads()[0]; n2hash3 = n2us3.getHeads()[0]
 
         if (new BloomFilter([n1hash1, n1hash2, n1hash3]).containsHash(n2hash2)) {
-          n1.free(); n2.free();
           n1 = n1us3; n2 = n2us3; break
         }
       }

--- a/wrappers/javascript/src/index.ts
+++ b/wrappers/javascript/src/index.ts
@@ -379,11 +379,17 @@ export function equals(val1: unknown, val2: unknown) : boolean {
 }
 
 export function encodeSyncState(state: SyncState) : Uint8Array {
-  return ApiHandler.encodeSyncState(ApiHandler.importSyncState(state))
+  const sync = ApiHandler.importSyncState(state)
+  const result = ApiHandler.encodeSyncState(sync)
+  sync.free()
+  return result
 }
 
 export function decodeSyncState(state: Uint8Array) : SyncState {
-  return ApiHandler.exportSyncState(ApiHandler.decodeSyncState(state))
+  let sync = ApiHandler.decodeSyncState(state)
+  let result = ApiHandler.exportSyncState(sync)
+  sync.free()
+  return result
 }
 
 export function generateSyncMessage<T>(doc: Doc<T>, inState: SyncState) : [ SyncState, SyncMessage | null ] {


### PR DESCRIPTION
Moved from `wasm-pack` to `wasm-bindgen-cli`. 

Updated wasm README and tests. 

Found a bug in `--weak-refs` when exporting top level functions that take ownership of arguments.  I changed the behavior of `exportSyncState()` and `encodeSyncState()` to not consume the object and updated `automerge-js` to free them manually.  

Using the `-Oz` flag for `wasm-opt`.  It seems to work pretty well but there are dozens of other flags we might want to look into.

The build process now makes files with different names - I updated `package.json` to point to the new names instead of adding file renaming to the build process.
 