### PR TITLE
consolidate inserts and deletes more aggressively into a single splice

### DIFF
--- a/javascript/examples/create-react-app/package.json
+++ b/javascript/examples/create-react-app/package.json
@@ -8,7 +8,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@automerge/automerge": "2.0.0-alpha.5",
+    "@automerge/automerge": "2.0.0-alpha.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/javascript/examples/vite/package.json
+++ b/javascript/examples/vite/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@automerge/automerge": "2.0.0-alpha.5"
+    "@automerge/automerge": "2.0.0-alpha.7"
   },
   "devDependencies": {
     "typescript": "^4.6.4",

--- a/javascript/examples/webpack/package.json
+++ b/javascript/examples/webpack/package.json
@@ -10,7 +10,7 @@
   },
   "author": "",
   "dependencies": {
-    "@automerge/automerge": "2.0.0-alpha.5"
+    "@automerge/automerge": "2.0.0-alpha.7"
   },
   "devDependencies": {
     "serve": "^13.0.2",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,7 +4,7 @@
     "Orion Henry <orion@inkandswitch.com>",
     "Martin Kleppmann"
   ],
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-alpha.7",
   "description": "Javascript implementation of automerge, backed by @automerge/automerge-wasm",
   "homepage": "https://github.com/automerge/automerge-rs/tree/main/wrappers/javascript",
   "repository": "github:automerge/automerge-rs",
@@ -58,7 +58,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@automerge/automerge-wasm": "0.1.11",
+    "@automerge/automerge-wasm": "0.1.12",
     "uuid": "^8.3"
   }
 }

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -8,7 +8,7 @@
   "description": "wasm-bindgen bindings to the automerge rust implementation",
   "homepage": "https://github.com/automerge/automerge-rs/tree/main/automerge-wasm",
   "repository": "github:automerge/automerge-rs",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "MIT",
   "files": [
     "README.md",

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -561,8 +561,7 @@ describe('Automerge', () => {
       assert.deepEqual([0, 1, 2, 3].map(i => (doc3.getWithType('1@aaaa', i) || [])[1]), ['a', 'b', 'c', 'd'])
       assert.deepEqual([0, 1, 2, 3].map(i => (doc4.getWithType('1@aaaa', i) || [])[1]), ['a', 'b', 'c', 'd'])
       assert.deepEqual(doc3.popPatches(), [
-        { action: 'splice', path: ['values', 0], values:['c','d'] },
-        { action: 'splice', path: ['values', 0], values:['a','b'] },
+        { action: 'splice', path: ['values', 0], values:['a','b','c','d'] },
       ])
       assert.deepEqual(doc4.popPatches(), [
         { action: 'splice', path: ['values',0], values:['a','b','c','d'] },
@@ -588,8 +587,7 @@ describe('Automerge', () => {
       assert.deepEqual([0, 1, 2, 3, 4, 5].map(i => (doc3.getWithType('1@aaaa', i) || [])[1]), ['a', 'b', 'c', 'd', 'e', 'f'])
       assert.deepEqual([0, 1, 2, 3, 4, 5].map(i => (doc4.getWithType('1@aaaa', i) || [])[1]), ['a', 'b', 'c', 'd', 'e', 'f'])
       assert.deepEqual(doc3.popPatches(), [
-        { action: 'splice', path: ['values', 2], values: ['e','f'] },
-        { action: 'splice', path: ['values', 2], values: ['c','d'] },
+        { action: 'splice', path: ['values', 2], values: ['c','d','e','f'] },
       ])
       assert.deepEqual(doc4.popPatches(), [
         { action: 'splice', path: ['values', 2], values: ['c','d','e','f'] },
@@ -845,11 +843,7 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc1.popPatches(), [
         { action: 'put', path: ['list'], value: [], conflict: false },
-        { action: 'splice', path: ['list', 0], values: [1]  },
-        { action: 'splice', path: ['list', 0], values: [2] },
-        { action: 'splice', path: ['list', 2], values: [3] },
-        { action: 'splice', path: ['list', 2], values: [{}] },
-        { action: 'splice', path: ['list', 2], values: [[]] },
+        { action: 'splice', path: ['list', 0], values: [2,1,[],{},3]  },
       ])
     })
 
@@ -876,9 +870,7 @@ describe('Automerge', () => {
 
       assert.deepEqual(doc1.popPatches(), [
         { action: 'put', path: ['list'],  value: [], conflict: false },
-        { action: 'splice', path: ['list',0], values: [1,2,3,4] },
-        { action: 'del', path: ['list',1] },
-        { action: 'del', path: ['list',1] },
+        { action: 'splice', path: ['list',0], values: [1,4] },
       ])
     })
 


### PR DESCRIPTION
One of the blutack documents was making 1700 patches on load - now it makes 2.  Was able to consolidate all of the inserts and deletes into a single patch.