### PR TITLE
Automerge.clone(heads)

### DIFF
--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -13,14 +13,16 @@ describe('Automerge', () => {
             Automerge.free(doc2)
         })
 
-        it('should be able to clone with an actorId and at a specifc heads', () => {
+        it('should be able to make a view with specifc heads', () => {
             let doc1 = Automerge.init()
             let doc2 = Automerge.change(doc1, (d) => d.value = 1)
             let heads2 = Automerge.getHeads(doc2)
             let doc3 = Automerge.change(doc2, (d) => d.value = 2)
-            let doc2_v2 = Automerge.clone(doc3, "aabbcc", heads2)
+            let doc2_v2 = Automerge.view(doc3, heads2)
             assert.deepEqual(doc2, doc2_v2)
-            assert.equal(Automerge.getActorId(doc2_v2), "aabbcc")
+            let doc2_v2_clone = Automerge.clone(doc2, "aabbcc")
+            assert.deepEqual(doc2, doc2_v2_clone)
+            assert.equal(Automerge.getActorId(doc2_v2_clone), "aabbcc")
         })
 
         it('handle basic set and read on root object', () => {

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -7,6 +7,20 @@ describe('Automerge', () => {
         it('should init clone and free', () => {
             let doc1 = Automerge.init()
             let doc2 = Automerge.clone(doc1);
+
+            // this is only needed if weakrefs are not supported
+            Automerge.free(doc1)
+            Automerge.free(doc2)
+        })
+
+        it('should be able to clone with an actorId and at a specifc heads', () => {
+            let doc1 = Automerge.init()
+            let doc2 = Automerge.change(doc1, (d) => d.value = 1)
+            let heads2 = Automerge.getHeads(doc2)
+            let doc3 = Automerge.change(doc2, (d) => d.value = 2)
+            let doc2_v2 = Automerge.clone(doc3, "aabbcc", heads2)
+            assert.deepEqual(doc2, doc2_v2)
+            assert.equal(Automerge.getActorId(doc2_v2), "aabbcc")
         })
 
         it('handle basic set and read on root object', () => {

--- a/javascript/test/legacy_tests.ts
+++ b/javascript/test/legacy_tests.ts
@@ -231,14 +231,14 @@ describe('Automerge', () => {
             s2 = Automerge.change(s1, doc2 => doc2.two = 2)
             doc1.one = 1
           })
-        }, /Attempting to use an outdated Automerge document/)
+        }, /Attempting to change an outdated document/)
       })
 
       it('should not allow the same base document to be used for multiple changes', () => {
         assert.throws(() => {
           Automerge.change(s1, doc => doc.one = 1)
           Automerge.change(s1, doc => doc.two = 2)
-        }, /Attempting to use an outdated Automerge document/)
+        }, /Attempting to change an outdated document/)
       })
 
       it('should allow a document to be cloned', () => {

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -199,12 +199,11 @@ export class Automerge {
   getMissingDeps(heads?: Heads): Heads;
 
   // memory management
-  free(): void;
-  clone(actor?: string): Automerge;
-  fork(actor?: string): Automerge;
-  forkAt(heads: Heads, actor?: string): Automerge;
+  free(): void; // only needed if weak-refs are unsupported
+  clone(actor?: string): Automerge; // TODO - remove, this is dangerous
+  fork(actor?: string, heads?: Heads): Automerge;
 
-  // dump internal state to console.log
+  // dump internal state to console.log - for debugging
   dump(): void;
 
   // experimental api can go here

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -425,7 +425,7 @@ describe('Automerge', () => {
       assert.deepEqual(doc2.getWithType(c, "d"), ["str", "dd"])
     })
 
-    it('should allow you to forkAt a heads', () => {
+    it('should allow you to fork at a heads', () => {
       const A = create("aaaaaa")
       A.put("/", "key1", "val1");
       A.put("/", "key2", "val2");
@@ -436,8 +436,8 @@ describe('Automerge', () => {
       A.merge(B)
       const heads2 = A.getHeads();
       A.put("/", "key5", "val5");
-      assert.deepEqual(A.forkAt(heads1).materialize("/"), A.materialize("/", heads1))
-      assert.deepEqual(A.forkAt(heads2).materialize("/"), A.materialize("/", heads2))
+      assert.deepEqual(A.fork(undefined, heads1).materialize("/"), A.materialize("/", heads1))
+      assert.deepEqual(A.fork(undefined, heads2).materialize("/"), A.materialize("/", heads2))
     })
 
     it('should handle merging text conflicts then saving & loading', () => {


### PR DESCRIPTION
Added the ability to pass heads into the Automerge.clone() method.

While doing so decided to merge the wasm `doc.fork()` and `doc.forkAt()` methods into one.
