### PR TITLE
Allow changing a cloned document

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -207,7 +207,11 @@ export function clone<T>(doc: Doc<T>, _opts?: ActorId | InitOptions<T>): Doc<T> 
     const heads = state.heads
     const opts = importOpts(_opts)
     const handle = state.handle.fork(opts.actor, heads)
-    return handle.applyPatches(doc, { ... state, heads, handle })
+
+    // `change` uses the presence of state.heads to determine if we are in a view
+    // set it to undefined to indicate that this is a full fat document
+    const {heads: oldHeads, ...stateSansHeads} = state
+    return handle.applyPatches(doc, { ... stateSansHeads, handle })
 }
 
 /** Explicity free the memory backing a document. Note that this is note

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -25,6 +25,17 @@ describe('Automerge', () => {
             assert.equal(Automerge.getActorId(doc2_v2_clone), "aabbcc")
         })
 
+        it("should allow you to change a clone of a view", () => {
+            let doc1 = Automerge.init<any>()
+            doc1 = Automerge.change(doc1, d => d.key = "value")
+            let heads = Automerge.getHeads(doc1)
+            doc1 = Automerge.change(doc1, d => d.key = "value2")
+            let fork = Automerge.clone(Automerge.view(doc1, heads))
+            assert.deepEqual(fork, {key: "value"})
+            fork = Automerge.change(fork, d => d.key = "value3")
+            assert.deepEqual(fork, {key: "value3"})
+        })
+
         it('handle basic set and read on root object', () => {
             let doc1 = Automerge.init()
             let doc2 = Automerge.change(doc1, (d) => {


### PR DESCRIPTION
The logic for `clone` which was updated to support cloning a viewed document inadverantly left the heads of the cloned document state in place, which meant that cloned documents could not be `change`d. Set state.heads to undefined when cloning to allow changing them.