### PR TITLE
Update rust uuid dependency to v1.2.1

### DIFF
--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -28,7 +28,7 @@ serde = "^1.0"
 serde_json = "^1.0"
 rand = { version = "^0.8.4" }
 getrandom = { version = "^0.2.2", features=["js"] }
-uuid = { version = "^0.8.2", features=["v4", "wasm-bindgen", "serde"] }
+uuid = { version = "^1.2.1", features=["v4", "js", "serde"] }
 serde-wasm-bindgen = "0.4.3"
 serde_bytes = "0.11.5"
 hex = "^0.4.3"

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 [features]
 optree-visualisation = ["dot", "rand"]
-wasm = ["js-sys", "wasm-bindgen", "web-sys", "uuid/wasm-bindgen"]
+wasm = ["js-sys", "wasm-bindgen", "web-sys", "uuid/js"]
 
 [dependencies]
 hex = "^0.4.3"
@@ -20,7 +20,7 @@ sha2 = "^0.10.0"
 thiserror = "^1.0.16"
 itertools = "^0.10.3"
 flate2 = "^1.0.22"
-uuid = { version = "^0.8.2", features=["v4", "serde"] }
+uuid = { version = "^1.2.1", features=["v4", "serde"] }
 smol_str = { version = "^0.1.21", features=["serde"] }
 tracing = { version = "^0.1.29" }
 fxhash = "^0.2.1"


### PR DESCRIPTION
This PR updates the rust uuid dependency to the latest version `1.2.1`. [According to the docs](https://docs.rs/uuid/1.2.1/uuid/index.html#webassembly) WebAssembly is now enabled through the `js` feature rather than `wasm-bindgen`.

All rust crates seem to compile just fine and passes all tests (using `--workspace --all-features`) without any further changes, but maybe someone with a bit more knowledge should try it as well (also maybe for the js side?).