### PR TITLE
revert compiler flags to max opt

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,11 +11,11 @@ resolver = "2"
 [profile.release]
 debug = true
 lto = true
-opt-level = 'z'
+opt-level = 3
 
 [profile.bench]
 debug = true
 
 [profile.release.package.automerge-wasm]
 debug = false
-opt-level = 'z'
+opt-level = 3

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -34,7 +34,7 @@
     "target": "rimraf ./$TARGET && yarn compile && yarn bindgen && yarn opt",
     "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
     "bindgen": "wasm-bindgen --no-typescript --weak-refs --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
-    "opt": "wasm-opt -Oz $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
+    "opt": "wasm-opt -O4 $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
     "test": "ts-mocha -p tsconfig.json --type-check --bail --full-trace test/*.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
We lost about 30% performance when moving from opt level 3 to 'z'.  Reverting it.