### PR TITLE
Move automerge/tests::helpers to crate automerge-test

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "automerge",
     "automerge-c",
     "automerge-cli",
+    "automerge-test",
     "automerge-wasm",
     "edit-trace",
 ]

--- a/rust/automerge-test/Cargo.toml
+++ b/rust/automerge-test/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "automerge-test"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/automerge/automerge-rs"
+rust-version = "1.57.0"
+description = "Utilities for testing automerge libraries"
+readme = "../README.md"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+automerge = { path = "../automerge"}
+smol_str = { version = "^0.1.21", features=["serde"] }
+serde = { version = "^1.0", features=["derive"] }
+decorum = "0.3.1"
+serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features=true }

--- a/rust/automerge-test/README.md
+++ b/rust/automerge-test/README.md
@@ -1,0 +1,3 @@
+# `automerge-test`
+
+Utilities for making assertions about automerge documents

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -43,10 +43,10 @@ pretty_assertions = "1.0.0"
 proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
 serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features=true }
 maplit = { version = "^1.0" }
-decorum = "0.3.1"
 criterion = "0.3.5"
 test-log = { version = "0.2.10", features=["trace"], default-features = false}
 tracing-subscriber = {version = "0.3.9", features = ["fmt", "env-filter"] }
+automerge-test = { path = "../automerge-test" }
 
 [[bench]]
 name = "range"

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -7,11 +7,10 @@ use automerge::{
 // set up logging for all the tests
 use test_log::test;
 
-mod helpers;
 #[allow(unused_imports)]
-use helpers::{
-    mk_counter, new_doc, new_doc_with_actor, pretty_print, realize, realize_obj, sorted_actors,
-    RealizedObject,
+use automerge_test::{
+    assert_doc, assert_obj, list, map, mk_counter, new_doc, new_doc_with_actor, pretty_print,
+    realize, realize_obj, sorted_actors, RealizedObject,
 };
 use pretty_assertions::assert_eq;
 


### PR DESCRIPTION
The `assert_doc` and `assert_obj` macros in automerge/tests::helpers are useful for writing tests for any application working with automerge documents. Typically however, you only want these utilities in tests so rather than packaging them in the main `automerge` crate move them to a new crate (in the spirit of `tokio_test`)