### PR TITLE
Add AMobjObjType()

### DIFF
--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -143,11 +143,11 @@ pub unsafe extern "C" fn AMcreate(actor_id: *const AMactorId) -> *mut AMresult {
 
 /// \memberof AMdoc
 /// \brief Commits the current operations on a document with an optional
-///        message and/or time override as seconds since the epoch.
+///        message and/or *nix timestamp (milliseconds).
 ///
 /// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] message A UTF-8 string or `NULL`.
-/// \param[in] time A pointer to a `time_t` value or `NULL`.
+/// \param[in] timestamp A pointer to a 64-bit integer or `NULL`.
 /// \return A pointer to an `AMresult` struct containing an `AMchangeHashes`
 ///         with one element.
 /// \pre \p doc `!= NULL`.
@@ -160,15 +160,15 @@ pub unsafe extern "C" fn AMcreate(actor_id: *const AMactorId) -> *mut AMresult {
 pub unsafe extern "C" fn AMcommit(
     doc: *mut AMdoc,
     message: *const c_char,
-    time: *const libc::time_t,
+    timestamp: *const i64,
 ) -> *mut AMresult {
     let doc = to_doc_mut!(doc);
     let mut options = CommitOptions::default();
     if !message.is_null() {
         options.set_message(to_str(message));
     }
-    if let Some(time) = time.as_ref() {
-        options.set_time(*time);
+    if let Some(timestamp) = timestamp.as_ref() {
+        options.set_time(*timestamp);
     }
     to_result(doc.commit_with(options))
 }

--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 
 use crate::actor_id::AMactorId;
 use crate::change_hashes::AMchangeHashes;
-use crate::obj::AMobjId;
+use crate::obj::{AMobjId, AMobjType};
 use crate::result::{to_result, AMresult, AMvalue};
 use crate::sync::{to_sync_message, AMsyncMessage, AMsyncState};
 
@@ -543,6 +543,31 @@ pub unsafe extern "C" fn AMobjSize(
         }
     } else {
         0
+    }
+}
+
+/// \memberof AMdoc
+/// \brief Gets the type of an object.
+///
+/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
+/// \return An `AMobjType`.
+/// \pre \p doc `!= NULL`.
+/// \internal
+///
+/// # Safety
+/// doc must be a valid pointer to an AMdoc
+/// obj_id must be a valid pointer to an AMobjId or std::ptr::null()
+#[no_mangle]
+pub unsafe extern "C" fn AMobjObjType(doc: *const AMdoc, obj_id: *const AMobjId) -> AMobjType {
+    if let Some(doc) = doc.as_ref() {
+        let obj_id = to_obj_id!(obj_id);
+        match doc.object_type(obj_id) {
+            None => AMobjType::Unknown,
+            Some(obj_type) => obj_type.into(),
+        }
+    } else {
+        AMobjType::Unknown
     }
 }
 

--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -563,11 +563,11 @@ pub unsafe extern "C" fn AMobjObjType(doc: *const AMdoc, obj_id: *const AMobjId)
     if let Some(doc) = doc.as_ref() {
         let obj_id = to_obj_id!(obj_id);
         match doc.object_type(obj_id) {
-            None => AMobjType::Unknown,
+            None => AMobjType::Void,
             Some(obj_type) => obj_type.into(),
         }
     } else {
-        AMobjType::Unknown
+        AMobjType::Void
     }
 }
 

--- a/rust/automerge-c/src/doc/list.rs
+++ b/rust/automerge-c/src/doc/list.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 
 use crate::change_hashes::AMchangeHashes;
 use crate::doc::{to_doc, to_doc_mut, to_obj_id, to_str, AMdoc};
-use crate::obj::{AMobjId, AMobjType};
+use crate::obj::{to_obj_type, AMobjId, AMobjType};
 use crate::result::{to_result, AMresult};
 
 pub mod item;
@@ -418,6 +418,7 @@ pub unsafe extern "C" fn AMlistPutNull(
 ///         `AMobjId` struct.
 /// \pre \p doc `!= NULL`.
 /// \pre `0 <=` \p index `<= AMobjSize(`\p obj_id`)` or \p index `== SIZE_MAX`.
+/// \pre \p obj_type != `AM_OBJ_TYPE_VOID`.
 /// \warning The returned `AMresult` struct must be deallocated with `AMfree()`
 ///          in order to prevent a memory leak.
 /// \internal
@@ -435,7 +436,7 @@ pub unsafe extern "C" fn AMlistPutObject(
     let doc = to_doc_mut!(doc);
     let obj_id = to_obj_id!(obj_id);
     let (index, insert) = adjust!(index, insert, doc.length(obj_id));
-    let object = obj_type.into();
+    let object = to_obj_type!(obj_type);
     to_result(if insert {
         doc.insert_object(obj_id, index, object)
     } else {
@@ -486,7 +487,8 @@ pub unsafe extern "C" fn AMlistPutStr(
 }
 
 /// \memberof AMdoc
-/// \brief Puts an epoch timestamp as the value at an index in a list object.
+/// \brief Puts a *nix timestamp (milliseconds) as the value at an index in a
+///        list object.
 ///
 /// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.

--- a/rust/automerge-c/src/doc/list.rs
+++ b/rust/automerge-c/src/doc/list.rs
@@ -486,7 +486,7 @@ pub unsafe extern "C" fn AMlistPutStr(
 }
 
 /// \memberof AMdoc
-/// \brief Puts a Lamport timestamp as the value at an index in a list object.
+/// \brief Puts an epoch timestamp as the value at an index in a list object.
 ///
 /// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.

--- a/rust/automerge-c/src/doc/map.rs
+++ b/rust/automerge-c/src/doc/map.rs
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn AMmapPutStr(
 }
 
 /// \memberof AMdoc
-/// \brief Puts a Lamport timestamp as the value of a key in a map object.
+/// \brief Puts a epoch timestamp as the value of a key in a map object.
 ///
 /// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.

--- a/rust/automerge-c/src/doc/map.rs
+++ b/rust/automerge-c/src/doc/map.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 use crate::change_hashes::AMchangeHashes;
 use crate::doc::utils::to_str;
 use crate::doc::{to_doc, to_doc_mut, to_obj_id, AMdoc};
-use crate::obj::{AMobjId, AMobjType};
+use crate::obj::{to_obj_type, AMobjId, AMobjType};
 use crate::result::{to_result, AMresult};
 
 pub mod item;
@@ -268,6 +268,7 @@ pub unsafe extern "C" fn AMmapPutNull(
 ///         `AMobjId` struct.
 /// \pre \p doc `!= NULL`.
 /// \pre \p key `!= NULL`.
+/// \pre \p obj_type != `AM_OBJ_TYPE_VOID`.
 /// \warning The returned `AMresult` struct must be deallocated with `AMfree()`
 ///          in order to prevent a memory leak.
 /// \internal
@@ -283,7 +284,7 @@ pub unsafe extern "C" fn AMmapPutObject(
     obj_type: AMobjType,
 ) -> *mut AMresult {
     let doc = to_doc_mut!(doc);
-    to_result(doc.put_object(to_obj_id!(obj_id), to_str(key), obj_type.into()))
+    to_result(doc.put_object(to_obj_id!(obj_id), to_str(key), to_obj_type!(obj_type)))
 }
 
 /// \memberof AMdoc
@@ -373,7 +374,8 @@ pub unsafe extern "C" fn AMmapPutStr(
 }
 
 /// \memberof AMdoc
-/// \brief Puts a epoch timestamp as the value of a key in a map object.
+/// \brief Puts a *nix timestamp (milliseconds) as the value of a key in a map
+///        object.
 ///
 /// \param[in,out] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.

--- a/rust/automerge-c/src/obj.rs
+++ b/rust/automerge-c/src/obj.rs
@@ -3,7 +3,6 @@ use std::cell::RefCell;
 use std::ops::Deref;
 
 use crate::actor_id::AMactorId;
-use crate::result::AMresult;
 
 pub mod item;
 pub mod items;

--- a/rust/automerge-c/src/obj.rs
+++ b/rust/automerge-c/src/obj.rs
@@ -3,9 +3,23 @@ use std::cell::RefCell;
 use std::ops::Deref;
 
 use crate::actor_id::AMactorId;
+use crate::result::AMresult;
 
 pub mod item;
 pub mod items;
+
+macro_rules! to_obj_type {
+    ($am_obj_type:expr) => {{
+        match $am_obj_type {
+            AMobjType::Map => am::ObjType::Map,
+            AMobjType::List => am::ObjType::List,
+            AMobjType::Text => am::ObjType::Text,
+            AMobjType::Void => return AMresult::err("Invalid AMobjType value").into(),
+        }
+    }};
+}
+
+pub(crate) use to_obj_type;
 
 /// \struct AMobjId
 /// \installed_headerfile
@@ -159,17 +173,6 @@ impl From<am::ObjType> for AMobjType {
             am::ObjType::Map | am::ObjType::Table => AMobjType::Map,
             am::ObjType::List => AMobjType::List,
             am::ObjType::Text => AMobjType::Text,
-        }
-    }
-}
-
-impl From<AMobjType> for am::ObjType {
-    fn from(o: AMobjType) -> Self {
-        match o {
-            AMobjType::Map => am::ObjType::Map,
-            AMobjType::List => am::ObjType::List,
-            AMobjType::Text => am::ObjType::Text,
-            AMobjType::Void => todo!(),
         }
     }
 }

--- a/rust/automerge-c/src/obj.rs
+++ b/rust/automerge-c/src/obj.rs
@@ -142,9 +142,9 @@ pub unsafe extern "C" fn AMobjIdIndex(obj_id: *const AMobjId) -> usize {
 /// \brief The type of an object value.
 #[repr(u8)]
 pub enum AMobjType {
-    /// An unknown type.
+    /// A void.
     /// \note This tag is unalphabetized to evaluate as false.
-    Unknown = 0,
+    Void = 0,
     /// A list.
     List,
     /// A key-value map.
@@ -156,9 +156,8 @@ pub enum AMobjType {
 impl From<am::ObjType> for AMobjType {
     fn from(o: am::ObjType) -> Self {
         match o {
-            am::ObjType::Map => AMobjType::Map,
+            am::ObjType::Map | am::ObjType::Table => AMobjType::Map,
             am::ObjType::List => AMobjType::List,
-            am::ObjType::Table => todo!(),
             am::ObjType::Text => AMobjType::Text,
         }
     }
@@ -170,7 +169,7 @@ impl From<AMobjType> for am::ObjType {
             AMobjType::Map => am::ObjType::Map,
             AMobjType::List => am::ObjType::List,
             AMobjType::Text => am::ObjType::Text,
-            AMobjType::Unknown => todo!(),
+            AMobjType::Void => todo!(),
         }
     }
 }

--- a/rust/automerge-c/src/obj.rs
+++ b/rust/automerge-c/src/obj.rs
@@ -142,12 +142,26 @@ pub unsafe extern "C" fn AMobjIdIndex(obj_id: *const AMobjId) -> usize {
 /// \brief The type of an object value.
 #[repr(u8)]
 pub enum AMobjType {
+    /// An unknown type.
+    /// \note This tag is unalphabetized to evaluate as false.
+    Unknown = 0,
     /// A list.
-    List = 1,
+    List,
     /// A key-value map.
     Map,
     /// A list of Unicode graphemes.
     Text,
+}
+
+impl From<am::ObjType> for AMobjType {
+    fn from(o: am::ObjType) -> Self {
+        match o {
+            am::ObjType::Map => AMobjType::Map,
+            am::ObjType::List => AMobjType::List,
+            am::ObjType::Table => todo!(),
+            am::ObjType::Text => AMobjType::Text,
+        }
+    }
 }
 
 impl From<AMobjType> for am::ObjType {
@@ -156,6 +170,7 @@ impl From<AMobjType> for am::ObjType {
             AMobjType::Map => am::ObjType::Map,
             AMobjType::List => am::ObjType::List,
             AMobjType::Text => am::ObjType::Text,
+            AMobjType::Unknown => todo!(),
         }
     }
 }

--- a/rust/automerge-c/src/result.rs
+++ b/rust/automerge-c/src/result.rs
@@ -85,7 +85,7 @@ use crate::sync::{AMsyncMessage, AMsyncState};
 /// The variant discriminator.
 ///
 /// \var AMvalue::timestamp
-/// A Lamport timestamp.
+/// An epoch timestamp.
 ///
 /// \var AMvalue::uint
 /// A 64-bit unsigned integer.
@@ -133,7 +133,7 @@ pub enum AMvalue<'a> {
     SyncMessage(&'a AMsyncMessage),
     /// A synchronization state variant.
     SyncState(&'a mut AMsyncState),
-    /// A Lamport timestamp variant.
+    /// An epoch timestamp variant.
     Timestamp(i64),
     /// A 64-bit unsigned integer variant.
     Uint(u64),

--- a/rust/automerge-c/src/result.rs
+++ b/rust/automerge-c/src/result.rs
@@ -85,7 +85,7 @@ use crate::sync::{AMsyncMessage, AMsyncState};
 /// The variant discriminator.
 ///
 /// \var AMvalue::timestamp
-/// An epoch timestamp.
+/// A *nix timestamp (milliseconds).
 ///
 /// \var AMvalue::uint
 /// A 64-bit unsigned integer.
@@ -133,7 +133,7 @@ pub enum AMvalue<'a> {
     SyncMessage(&'a AMsyncMessage),
     /// A synchronization state variant.
     SyncState(&'a mut AMsyncState),
-    /// An epoch timestamp variant.
+    /// A *nix timestamp (milliseconds) variant.
     Timestamp(i64),
     /// A 64-bit unsigned integer variant.
     Uint(u64),

--- a/rust/automerge-c/test/list_tests.c
+++ b/rust/automerge-c/test/list_tests.c
@@ -95,17 +95,33 @@ static void test_AMlistPutNull_ ## mode(void **state) {                       \
 #define static_void_test_AMlistPutObject(label, mode)                         \
 static void test_AMlistPutObject_ ## label ## _ ## mode(void **state) {       \
     GroupState* group_state = *state;                                         \
-    AMobjId const* const obj_id = AMpush(                                     \
-        &group_state->stack,                                                  \
-        AMlistPutObject(group_state->doc,                                     \
-                        AM_ROOT,                                              \
-                        0,                                                    \
-                        !strcmp(#mode, "insert"),                             \
-                        AMobjType_tag(#label)),                               \
-        AM_VALUE_OBJ_ID,                                                      \
-        cmocka_cb).obj_id;                                                    \
-    assert_non_null(obj_id);                                                  \
-    assert_int_equal(AMobjSize(group_state->doc, obj_id, NULL), 0);           \
+    AMobjType const obj_type = AMobjType_tag(#label);                         \
+    if (obj_type != AM_OBJ_TYPE_VOID) {                                       \
+        AMobjId const* const obj_id = AMpush(                                 \
+            &group_state->stack,                                              \
+            AMlistPutObject(group_state->doc,                                 \
+                            AM_ROOT,                                          \
+                            0,                                                \
+                            !strcmp(#mode, "insert"),                         \
+                            obj_type),                                        \
+            AM_VALUE_OBJ_ID,                                                  \
+            cmocka_cb).obj_id;                                                \
+        assert_non_null(obj_id);                                              \
+        assert_int_equal(AMobjObjType(group_state->doc, obj_id), obj_type);   \
+        assert_int_equal(AMobjSize(group_state->doc, obj_id, NULL), 0);       \
+    }                                                                         \
+    else {                                                                    \
+        AMpush(&group_state->stack,                                           \
+               AMlistPutObject(group_state->doc,                              \
+                               AM_ROOT,                                       \
+                               0,                                             \
+                               !strcmp(#mode, "insert"),                      \
+                               obj_type),                                     \
+               AM_VALUE_VOID,                                                 \
+               NULL);                                                         \
+        assert_int_not_equal(AMresultStatus(group_state->stack->result),      \
+                                            AM_STATUS_OK);                    \
+    }                                                                         \
     AMfree(AMpop(&group_state->stack));                                       \
 }
 
@@ -165,6 +181,10 @@ static_void_test_AMlistPutObject(Text, insert)
 
 static_void_test_AMlistPutObject(Text, update)
 
+static_void_test_AMlistPutObject(Void, insert)
+
+static_void_test_AMlistPutObject(Void, update)
+
 static_void_test_AMlistPutStr(insert, "Hello, world!")
 
 static_void_test_AMlistPutStr(update, "Hello, world!")
@@ -186,7 +206,6 @@ static void test_insert_at_index(void** state) {
         AMlistPutObject(doc, AM_ROOT, 0, true, AM_OBJ_TYPE_LIST),
         AM_VALUE_OBJ_ID,
         cmocka_cb).obj_id;
-    assert_int_equal(AMobjObjType(doc, list), AM_OBJ_TYPE_LIST);
     /* Insert both at the same index. */
     AMfree(AMlistPutUint(doc, list, 0, true, 0));
     AMfree(AMlistPutUint(doc, list, 0, true, 1));
@@ -366,6 +385,8 @@ int run_list_tests(void) {
         cmocka_unit_test(test_AMlistPutObject(Map, update)),
         cmocka_unit_test(test_AMlistPutObject(Text, insert)),
         cmocka_unit_test(test_AMlistPutObject(Text, update)),
+        cmocka_unit_test(test_AMlistPutObject(Void, insert)),
+        cmocka_unit_test(test_AMlistPutObject(Void, update)),
         cmocka_unit_test(test_AMlistPutStr(insert)),
         cmocka_unit_test(test_AMlistPutStr(update)),
         cmocka_unit_test(test_AMlistPut(Timestamp, insert)),

--- a/rust/automerge-c/test/list_tests.c
+++ b/rust/automerge-c/test/list_tests.c
@@ -186,6 +186,7 @@ static void test_insert_at_index(void** state) {
         AMlistPutObject(doc, AM_ROOT, 0, true, AM_OBJ_TYPE_LIST),
         AM_VALUE_OBJ_ID,
         cmocka_cb).obj_id;
+    assert_int_equal(AMobjObjType(doc, list), AM_OBJ_TYPE_LIST);
     /* Insert both at the same index. */
     AMfree(AMlistPutUint(doc, list, 0, true, 0));
     AMfree(AMlistPutUint(doc, list, 0, true, 1));

--- a/rust/automerge-c/test/macro_utils.c
+++ b/rust/automerge-c/test/macro_utils.c
@@ -17,8 +17,9 @@ AMvalueVariant AMvalue_discriminant(char const* suffix) {
 }
 
 AMobjType AMobjType_tag(char const* obj_type_label) {
-    if (!strcmp(obj_type_label, "List"))      return AM_OBJ_TYPE_LIST;
-    else if (!strcmp(obj_type_label, "Map"))  return AM_OBJ_TYPE_MAP;
-    else if (!strcmp(obj_type_label, "Text")) return AM_OBJ_TYPE_TEXT;
+    if (!strcmp(obj_type_label, "List"))         return AM_OBJ_TYPE_LIST;
+    else if (!strcmp(obj_type_label, "Map"))     return AM_OBJ_TYPE_MAP;
+    else if (!strcmp(obj_type_label, "Text"))    return AM_OBJ_TYPE_TEXT;
+    else if (!strcmp(obj_type_label, "Unknown")) return AM_OBJ_TYPE_UNKNOWN;
     else return 0;
 }

--- a/rust/automerge-c/test/macro_utils.c
+++ b/rust/automerge-c/test/macro_utils.c
@@ -17,9 +17,9 @@ AMvalueVariant AMvalue_discriminant(char const* suffix) {
 }
 
 AMobjType AMobjType_tag(char const* obj_type_label) {
-    if (!strcmp(obj_type_label, "List"))         return AM_OBJ_TYPE_LIST;
-    else if (!strcmp(obj_type_label, "Map"))     return AM_OBJ_TYPE_MAP;
-    else if (!strcmp(obj_type_label, "Text"))    return AM_OBJ_TYPE_TEXT;
-    else if (!strcmp(obj_type_label, "Unknown")) return AM_OBJ_TYPE_UNKNOWN;
+    if (!strcmp(obj_type_label, "List"))      return AM_OBJ_TYPE_LIST;
+    else if (!strcmp(obj_type_label, "Map"))  return AM_OBJ_TYPE_MAP;
+    else if (!strcmp(obj_type_label, "Text")) return AM_OBJ_TYPE_TEXT;
+    else if (!strcmp(obj_type_label, "Void")) return AM_OBJ_TYPE_VOID;
     else return 0;
 }

--- a/rust/automerge-c/test/ported_wasm/basic_tests.c
+++ b/rust/automerge-c/test/ported_wasm/basic_tests.c
@@ -711,7 +711,7 @@ static void test_should_be_able_to_insert_objects_into_text(void** state) {
     assert_string_equal(AMpush(&stack,
                                AMtext(doc, text, NULL),
                                AM_VALUE_STR,
-                               cmocka_cb).str, "Hello \ufffcworld");
+                               cmocka_cb).str, u8"Hello \ufffcworld");
     /* assert.deepEqual(doc.getWithType(text, 6), ["map", obj]);             */
     assert_true(AMobjIdEqual(AMpush(&stack,
                                     AMlistGet(doc, text, 6, NULL),


### PR DESCRIPTION
@orionz, @alexjg and @ConradIrwin, I've done the following to ease writing language bindings based upon the C API:
* Exposed `autocommit::AutoCommit::object_type()` as `AMobjObjType()`.
* Replaced the phrase "Lamport timestamp" with "epoch timestamp" within the documentation.