### PR TITLE
Dont send duplicate sync messages

### DIFF
--- a/rust/automerge-wasm/src/interop.rs
+++ b/rust/automerge-wasm/src/interop.rs
@@ -51,6 +51,7 @@ impl From<am::sync::State> for JS {
         Reflect::set(&result, &"theirNeed".into(), &their_need.0).unwrap();
         Reflect::set(&result, &"theirHave".into(), &their_have).unwrap();
         Reflect::set(&result, &"sentHashes".into(), &sent_hashes.0).unwrap();
+        Reflect::set(&result, &"inFlight".into(), &state.in_flight.into()).unwrap();
         JS(result)
     }
 }
@@ -178,6 +179,10 @@ impl TryFrom<JS> for am::sync::State {
         let their_need = js_get(&value, "theirNeed")?.into();
         let their_have = js_get(&value, "theirHave")?.try_into()?;
         let sent_hashes = js_get(&value, "sentHashes")?.try_into()?;
+        let in_flight = js_get(&value, "inFlight")?
+            .0
+            .as_bool()
+            .ok_or_else(|| JsValue::from_str("SyncState.inFLight must be a boolean"))?;
         Ok(am::sync::State {
             shared_heads,
             last_sent_heads,
@@ -185,6 +190,7 @@ impl TryFrom<JS> for am::sync::State {
             their_need,
             their_have,
             sent_hashes,
+            in_flight,
         })
     }
 }

--- a/rust/automerge/src/sync/state.rs
+++ b/rust/automerge/src/sync/state.rs
@@ -31,6 +31,15 @@ pub struct State {
     pub their_need: Option<Vec<ChangeHash>>,
     pub their_have: Option<Vec<Have>>,
     pub sent_hashes: BTreeSet<ChangeHash>,
+
+    /// `generate_sync_message` should return `None` if there are no new changes to send. In
+    /// particular, if there are changes in flight which the other end has not yet acknowledged we
+    /// do not wish to generate duplicate sync messages. This field tracks whether the changes we
+    /// expect to send to the peer based on this sync state have been sent or not. If
+    /// `in_flight` is `false` then `generate_sync_message` will return a new message (provided
+    /// there are in fact changes to send). If it is `true` then we don't. This flag is cleared
+    /// in `receive_sync_message`.
+    pub in_flight: bool,
 }
 
 /// A summary of the changes that the sender of the message already has.
@@ -84,6 +93,7 @@ impl State {
                 their_need: None,
                 their_have: Some(Vec::new()),
                 sent_hashes: BTreeSet::new(),
+                in_flight: false,
             },
         ))
     }


### PR DESCRIPTION
The API of Automerge::generate_sync_message requires that the user keep track of in flight messages themselves if they want to avoid sending duplicate messages. To avoid this add a flag to `automerge::sync::State` to track if there are any in flight messages and return `None` from `generate_sync_message` if there are.