### PR TITLE
Use AMbyteSpan for AM{list,map}PutBytes

### DIFF
--- a/rust/automerge-c/src/byte_span.rs
+++ b/rust/automerge-c/src/byte_span.rs
@@ -124,3 +124,18 @@ impl TryFrom<&AMbyteSpan> for &str {
         }
     }
 }
+
+/// \brief Creates an AMbyteSpan from a pointer + length
+///
+/// \param[in] src  A pointer to a span of bytes
+/// \param[in] count The number of bytes in the span
+/// \return An `AMbyteSpan` struct
+/// \internal
+///
+/// #Safety
+/// AMbytes does not retain the underlying storage, so you must discard the
+/// return value before freeing the bytes.
+#[no_mangle]
+pub unsafe extern "C" fn AMbytes(src: *const u8, count: usize) -> AMbyteSpan {
+    AMbyteSpan { src, count }
+}

--- a/rust/automerge-c/src/doc/list.rs
+++ b/rust/automerge-c/src/doc/list.rs
@@ -238,14 +238,13 @@ pub unsafe extern "C" fn AMlistPutBytes(
     obj_id: *const AMobjId,
     index: usize,
     insert: bool,
-    src: *const u8,
-    count: usize,
+    val: AMbyteSpan,
 ) -> *mut AMresult {
     let doc = to_doc_mut!(doc);
     let obj_id = to_obj_id!(obj_id);
     let (index, insert) = adjust!(index, insert, doc.length(obj_id));
     let mut value = Vec::new();
-    value.extend_from_slice(std::slice::from_raw_parts(src, count));
+    value.extend_from_slice(std::slice::from_raw_parts(val.src, val.count));
     to_result(if insert {
         doc.insert(obj_id, index, value)
     } else {

--- a/rust/automerge-c/src/doc/map.rs
+++ b/rust/automerge-c/src/doc/map.rs
@@ -198,13 +198,12 @@ pub unsafe extern "C" fn AMmapPutBytes(
     doc: *mut AMdoc,
     obj_id: *const AMobjId,
     key: AMbyteSpan,
-    src: *const u8,
-    count: usize,
+    val: AMbyteSpan,
 ) -> *mut AMresult {
     let doc = to_doc_mut!(doc);
     let key = to_str!(key);
     let mut vec = Vec::new();
-    vec.extend_from_slice(std::slice::from_raw_parts(src, count));
+    vec.extend_from_slice(std::slice::from_raw_parts(val.src, val.count));
     to_result(doc.put(to_obj_id!(obj_id), key, vec))
 }
 

--- a/rust/automerge-c/test/list_tests.c
+++ b/rust/automerge-c/test/list_tests.c
@@ -61,8 +61,7 @@ static void test_AMlistPutBytes_ ## mode(void **state) {                      \
                           AM_ROOT,                                            \
                           0,                                                  \
                           !strcmp(#mode, "insert"),                           \
-                          bytes_value,                                        \
-                          BYTES_SIZE));                                       \
+                          AMbytes(bytes_value, BYTES_SIZE}));                 \
     AMbyteSpan const bytes = AMpush(                                          \
         &group_state->stack,                                                  \
         AMlistGet(group_state->doc, AM_ROOT, 0, NULL),                        \

--- a/rust/automerge-c/test/list_tests.c
+++ b/rust/automerge-c/test/list_tests.c
@@ -61,7 +61,7 @@ static void test_AMlistPutBytes_ ## mode(void **state) {                      \
                           AM_ROOT,                                            \
                           0,                                                  \
                           !strcmp(#mode, "insert"),                           \
-                          AMbytes(bytes_value, BYTES_SIZE}));                 \
+                          AMbytes(bytes_value, BYTES_SIZE)));                 \
     AMbyteSpan const bytes = AMpush(                                          \
         &group_state->stack,                                                  \
         AMlistGet(group_state->doc, AM_ROOT, 0, NULL),                        \

--- a/rust/automerge-c/test/map_tests.c
+++ b/rust/automerge-c/test/map_tests.c
@@ -58,8 +58,7 @@ static void test_AMmapPutBytes(void **state) {
     AMfree(AMmapPutBytes(group_state->doc,
                          AM_ROOT,
                          KEY,
-                         BYTES_VALUE,
-                         BYTES_SIZE));
+                         AMbytes(BYTES_VALUE, BYTES_SIZE)));
     AMbyteSpan const bytes = AMpush(&group_state->stack,
                                     AMmapGet(group_state->doc, AM_ROOT, KEY, NULL),
                                     AM_VALUE_BYTES,

--- a/rust/automerge-c/test/ported_wasm/basic_tests.c
+++ b/rust/automerge-c/test/ported_wasm/basic_tests.c
@@ -201,10 +201,10 @@ static void test_should_be_able_to_use_bytes(void** state) {
     AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* doc.put("_root", "data1", new Uint8Array([10, 11, 12]));              */
     static uint8_t const DATA1[] = {10, 11, 12};
-    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data1"), AMbytes(DATA1, sizeof(DATA1)));
+    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data1"), AMbytes(DATA1, sizeof(DATA1))));
     /* doc.put("_root", "data2", new Uint8Array([13, 14, 15]), "bytes");     */
     static uint8_t const DATA2[] = {13, 14, 15};
-    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data2"), AMbytes(DATA2, sizeof(DATA2)));
+    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data2"), AMbytes(DATA2, sizeof(DATA2))));
     /* const value1 = doc.getWithType("_root", "data1")                      */
     AMbyteSpan const value1 = AMpush(&stack,
                                      AMmapGet(doc, AM_ROOT, AMstr("data1"), NULL),

--- a/rust/automerge-c/test/ported_wasm/basic_tests.c
+++ b/rust/automerge-c/test/ported_wasm/basic_tests.c
@@ -201,10 +201,10 @@ static void test_should_be_able_to_use_bytes(void** state) {
     AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* doc.put("_root", "data1", new Uint8Array([10, 11, 12]));              */
     static uint8_t const DATA1[] = {10, 11, 12};
-    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data1"), DATA1, sizeof(DATA1)));
+    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data1"), AMbytes(DATA1, sizeof(DATA1)));
     /* doc.put("_root", "data2", new Uint8Array([13, 14, 15]), "bytes");     */
     static uint8_t const DATA2[] = {13, 14, 15};
-    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data2"), DATA2, sizeof(DATA2)));
+    AMfree(AMmapPutBytes(doc, AM_ROOT, AMstr("data2"), AMbytes(DATA2, sizeof(DATA2)));
     /* const value1 = doc.getWithType("_root", "data1")                      */
     AMbyteSpan const value1 = AMpush(&stack,
                                      AMmapGet(doc, AM_ROOT, AMstr("data1"), NULL),


### PR DESCRIPTION
After #457  there was an inconsistency between AMmapPutString (which took an AMbyteSpan) and AMmapPutBytes (which took a pointer + length).

Either is fine, but we should do the same in both places. I chose this path to make it clear that the value passed in was an automerge value, and to be symmetric with AMvalue.bytes when you do an AMmapGet().

I did not update other APIs (like load) that take a pointer + length, as that is idiomatic usage for C, and these functions are not operating on byte values stored in automerge.

/cc @jkankiewicz @orionz 