### PR TITLE
Improve docs for building automerge-c on a mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ in that time.
 
 In general we try and respect semver.
 
-### JavaScript 
+### JavaScript
 
 An alpha release of the javascript package is currently available as
 `@automerge/automerge@2.0.0-alpha.n` where `n` is an integer. We are gathering
-feedback on the API and looking to release a `2.0.0` in the next few weeks. 
+feedback on the API and looking to release a `2.0.0` in the next few weeks.
 
 ### Rust
 
@@ -54,32 +54,79 @@ not well documented. We will be returning to this over the next few months but
 for now you will need to be comfortable reading the tests and asking questions
 to figure out how to use it.
 
-
 ## Repository Organisation
 
-* `./rust` - the rust  rust implementation and also the Rust components of
+- `./rust` - the rust rust implementation and also the Rust components of
   platform specific wrappers (e.g. `automerge-wasm` for the WASM API or
   `automerge-c` for the C FFI bindings)
-* `./javascript` - The javascript library which uses `automerge-wasm`
+- `./javascript` - The javascript library which uses `automerge-wasm`
   internally but presents a more idiomatic javascript interface
-* `./scripts` - scripts which are useful to maintenance of the repository.
+- `./scripts` - scripts which are useful to maintenance of the repository.
   This includes the scripts which are run in CI.
-* `./img` - static assets for use in `.md` files
+- `./img` - static assets for use in `.md` files
 
 ## Building
 
 To build this codebase you will need:
 
 - `rust`
-- `wasm-bindgen-cli`
-- `wasm-opt`
 - `node`
 - `yarn`
 - `cmake`
+- `cmocka`
+
+You will also need to install the following with `cargo install`
+
+- `wasm-bindgen-cli`
+- `wasm-opt`
+- `cargo-deny`
+
+And ensure you have added the `wasm32-unknown-unknown` target for rust cross-compilation.
 
 The various subprojects (the rust code, the wrapper projects) have their own
 build instructions, but to run the tests that will be run in CI you can run
-`./scripts/ci/run`. 
+`./scripts/ci/run`.
+
+### For macOS
+
+These instructions worked to build locally on macOS 13.1 (arm64) as of
+Nov 29th 2022.
+
+```bash
+# clone the repo
+git clone https://github.com/automerge/automerge-rs
+cd automerge-rs
+
+# install rustup
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# install homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# install cmake, node, cmocka
+brew install cmake node cmocka
+
+# install yarn
+npm install --global yarn
+
+# install rust dependencies
+cargo install wasm-bindgen-cli wasm-opt cargo-deny
+
+# add wasm target in addition to current architecture
+rustup target add wasm32-unknown-unknown
+
+# Run ci script
+./scripts/ci/run
+```
+
+If your build fails to find `cmocka.h` you may need to teach it about homebrew's
+installation location:
+
+```
+export CPATH=/opt/homebrew/include
+export LIBRARY_PATH=/opt/homebrew/lib
+./scripts/ci/run
+```
 
 ## Contributing
 

--- a/rust/automerge-c/README.md
+++ b/rust/automerge-c/README.md
@@ -6,7 +6,7 @@ for other language bindings that have good support for calling into C functions.
 See the main README for instructions on getting your environment set up, then
 you can use `./scripts/ci/cmake-build Release static` to build automerge-c.
 
-It will output two platform-dependant files:
+It will output two files:
 
 - ./build/Cargo/target/include/automerge-c/automerge.h
 - ./build/Cargo/target/release/libautomerge.a
@@ -17,6 +17,24 @@ by configuring the compiler to reference these directories.
 
 - `export LDFLAGS=-L./build/Cargo/target/release -lautomerge`
 - `export CFLAGS=-I./build/Cargo/target/include`
+
+If you'd like to cross compile the library for different platforms you can do so
+using [cross](https://github.com/cross-rs/cross). For example:
+
+- `cross build --manifest-path rust/automerge-c/Cargo.toml -r --target aarch64-unknown-linux-gnu`
+
+This will output a shared library in the directory `rust/target/aarch64-unknown-linux-gnu/release/`.
+
+You can replace `aarch64-unknown-linux-gnu` with any [cross supported targets](https://github.com/cross-rs/cross#supported-targets). The targets below are known to work, though other targets are expected to work too:
+
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+
+As a caveat, the header file is currently 32/64-bit dependant. You can re-use it
+for all 64-bit architectures, but you must generate a specific header for 32-bit
+targets.
 
 # Usage
 

--- a/rust/automerge-c/README.md
+++ b/rust/automerge-c/README.md
@@ -1,97 +1,140 @@
+automerge-c exposes an API to C that can either be used directly or as a basis
+for other language bindings that have good support for calling into C functions.
 
-## Methods we need to support
+# Building
 
-### Basic management 
+See the main README for instructions on getting your environment set up, then
+you can use `./scripts/ci/cmake-build Release static` to build automerge-c.
 
-  1. `AMcreate()`
-  1. `AMclone(doc)`
-  1. `AMfree(doc)`
-  1. `AMconfig(doc, key, val)` // set actor
-  1. `actor = get_actor(doc)`
+It will output two platform-dependant files:
 
-### Transactions
+- ./build/Cargo/target/include/automerge-c/automerge.h
+- ./build/Cargo/target/release/libautomerge.a
 
-  1. `AMpendingOps(doc)`
-  1. `AMcommit(doc, message, time)`
-  1. `AMrollback(doc)`
+To use these in your application you must arrange for your C compiler to find
+these files, either by moving them to the right location on your computer, or
+by configuring the compiler to reference these directories.
 
-### Write 
+- `export LDFLAGS=-L./build/Cargo/target/release -lautomerge`
+- `export CFLAGS=-I./build/Cargo/target/include`
 
-  1. `AMset{Map|List}(doc, obj, prop, value)`
-  1. `AMinsert(doc, obj, index, value)`
-  1. `AMpush(doc, obj, value)`
-  1. `AMdel{Map|List}(doc, obj, prop)`
-  1. `AMinc{Map|List}(doc, obj, prop, value)`
-  1. `AMspliceText(doc, obj, start, num_del, text)`
+# Usage
 
-### Read (the heads argument is optional and can be on an `at` variant)
+For full reference, read through `automerge.h`, or to get started quickly look
+at the
+[examples](https://github.com/automerge/automerge-rs/tree/main/rust/automerge-c/examples).
 
-  1. `AMkeys(doc, obj, heads)`
-  1. `AMlength(doc, obj, heads)`
-  1. `AMlistRange(doc, obj, heads)`
-  1. `AMmapRange(doc, obj, heads)`
-  1. `AMvalues(doc, obj, heads)`
-  1. `AMtext(doc, obj, heads)`
+Almost all operations in automerge-c act on an AMdoc struct which you can get
+from `AMcreate()` or `AMload()`. Operations on a given doc are not thread safe
+so you must use a mutex or similar to avoid calling more than one function with
+the same AMdoc pointer concurrently.
 
-### Sync
+As with all functions that either allocate memory, or could fail if given
+invalid input, `AMcreate()` returns an `AMresult`. The `AMresult` contains the
+returned doc (or error message), and must be freed with `AMfree()` after you are
+done to avoid leaking memory.
 
-  1. `AMgenerateSyncMessage(doc, state)`
-  1. `AMreceiveSyncMessage(doc, state, message)`
-  1. `AMinitSyncState()`
+```
+#include <automerge-c/automerge.h>
+#include <stdio.h>
 
-### Save / Load
+int main(int argc, char** argv) {
+  AMresult *docResult = AMcreate(NULL);
 
-  1. `AMload(data)`
-  1. `AMloadIncremental(doc, data)`
-  1. `AMsave(doc)`
-  1. `AMsaveIncremental(doc)`
+  if (AMresultStatus(docResult) != AM_STATUS_OK) {
+    printf("failed to create doc: %s", AMerrorMessage(docResult).src);
+    goto cleanup;
+  }
 
-### Low Level Access
+  AMdoc *doc = AMresultValue(docResult).doc;
 
-  1. `AMapplyChanges(doc, changes)`
-  1. `AMgetChanges(doc, deps)`
-  1. `AMgetChangesAdded(doc1, doc2)`
-  1. `AMgetHeads(doc)`
-  1. `AMgetLastLocalChange(doc)`
-  1. `AMgetMissingDeps(doc, heads)`
+  // useful code goes here!
 
-### Encode/Decode
+cleanup:
+  AMfree(docResult);
+}
+```
 
-  1. `AMencodeChange(change)`
-  1. `AMdecodeChange(change)`
-  1. `AMencodeSyncMessage(change)`
-  1. `AMdecodeSyncMessage(change)`
-  1. `AMencodeSyncState(change)`
-  1. `AMdecodeSyncState(change)`
+If you are writing code in C directly, you can use the `AMpush()` helper
+function to reduce the boilerplate of error handling and freeing for you (see
+examples/quickstart.c).
 
-## Open Question - Memory management
+If you are wrapping automerge-c in another language, particularly one that has a
+garbage collector, you can call `AMfree` within a finalizer to ensure that memory
+is reclaimed when it is no longer needed.
 
-Most of these calls return one or more items of arbitrary length.  Doing memory management in C is tricky.  This is my proposed solution...
+An AMdoc wraps an automerge document which are very similar to JSON documents.
+Automerge documents consist of a mutable root, which is always a map from string
+keys to values. Values can have the following types:
 
-### 
+- A number of type double / int64_t / uint64_t
+- An explicit true / false / nul
+- An immutable utf-8 string (AMbyteSpan)
+- An immutable array of arbitrary bytes (AMbyteSpan)
+- A mutable map from string keys to values (AMmap)
+- A mutable list of values (AMlist)
+- A mutable string (AMtext)
 
-  ```
-    // returns 1 or zero opids
-    n = automerge_set(doc, "_root", "hello", datatype, value);
-    if (n) {
-      automerge_pop(doc, &obj, len);
-    }
+If you read from a location in the document with no value a value with
+`.tag == AM_VALUE_VOID` will be returned, but you cannot write such a value explicitly.
 
-    // returns n values
-    n = automerge_values(doc, "_root", "hello");
-    for (i = 0; i<n ;i ++) {
-      automerge_pop_value(doc, &value, &datatype, len);
-    }
-  ```
+Under the hood, automerge references mutable objects by the internal object id,
+and `AM_ROOT` is always the object id of the root value.
 
-  There would be one pop method per object type.  Users allocs and frees the buffers.  Multiple return values would result in multiple pops. Too small buffers would error and allow retry.
+There is a function to put each type of value into either a map or a list, and a
+function to read the current value from a list. As (in general) collaborators
+may edit the document at any time, you cannot guarantee that the type of the
+value at a given part of the document will stay the same. As a result reading
+from the document will return an `AMvalue` union that you can inspect to
+determine its type.
 
+Strings in automerge-c are represented using an `AMbyteSpan` which contains a
+pointer and a length. Strings must be valid utf-8 and may contain null bytes.
+As a convenience you can use `AMstr()` to get the representation of a
+null-terminated C string as an `AMbyteSpan`.
 
-### Formats
+Putting all of that together, to read and write from the root of the document
+you can do this:
 
-Actors - We could do (bytes,len) or a hex encoded string?.  
-ObjIds - We could do flat bytes of the ExId struct but lets do human readable strings for now - the struct would be faster but opque
-Heads - Might as well make it a flat buffer `(n, hash, hash, ...)`
-Changes - Put them all in a flat concatenated buffer
-Encode/Decode - to json strings?
+```
+#include <automerge-c/automerge.h>
+#include <stdio.h>
 
+int main(int argc, char** argv) {
+  // ...previous example...
+  AMdoc *doc = AMresultValue(docResult).doc;
+
+  AMresult *putResult = AMmapPutStr(doc, AM_ROOT, AMstr("key"), AMstr("value"));
+  if (AMresultStatus(putResult) != AM_STATUS_OK) {
+    printf("failed to put: %s", AMerrorMessage(putResult).src);
+    goto cleanup;
+  }
+
+  AMresult *getResult = AMmapGet(doc, AM_ROOT, AMstr("key"), NULL);
+  if (AMresultStatus(getResult) != AM_STATUS_OK) {
+    printf("failed to get: %s", AMerrorMessage(getResult).src);
+    goto cleanup;
+  }
+
+  AMvalue got = AMresultValue(getResult);
+  if (got.tag != AM_VALUE_STR) {
+    printf("expected to read a string!");
+    goto cleanup;
+  }
+
+  printf("Got %zu-character string `%s`", got.str.count, got.str.src);
+
+cleanup:
+  AMfree(getResult);
+  AMfree(putResult);
+  AMfree(docResult);
+}
+```
+
+Functions that do not return an `AMresult` (for example `AMmapItemValue()`) do
+not allocate memory, but continue to reference memory that was previously
+allocated. It's thus important to keep the original `AMresult` alive (in this
+case the one returned by `AMmapRange()`) until after you are done with the return
+values of these functions.
+
+Beyond that, good luck!

--- a/scripts/ci/cmake-build
+++ b/scripts/ci/cmake-build
@@ -6,7 +6,7 @@ THIS_SCRIPT=$(dirname "$0");
 # "RelWithDebInfo" but custom ones can also be defined so we pass it verbatim.
 BUILD_TYPE=$1;
 LIB_TYPE=$2;
-if [ "${LIB_TYPE,,}" == "shared" ]; then
+if [ "$(echo "${LIB_TYPE}" | tr '[:upper:]' '[:lower:]')" == "shared" ]; then
     SHARED_TOGGLE="ON"
 else
     SHARED_TOGGLE="OFF"


### PR DESCRIPTION
I've added a bunch of documentation on setting up the build environment (which was challenging to me as a rust newbie), and some more detailed documentation for automerge-c (to clarify expectations around concurrency, types, strings with null characters, etc.).