### PR TITLE
Transaction empty

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -301,7 +301,10 @@ export function change<T>(doc: Doc<T>, options: string | ChangeOptions<T> | Chan
     }
 }
 
-function progressDocument<T>(doc: Doc<T>, heads: Heads, callback?: PatchCallback<T>): Doc<T> {
+function progressDocument<T>(doc: Doc<T>, heads: Heads | null, callback?: PatchCallback<T>): Doc<T> {
+    if (heads == null) {
+        return doc
+    }
     let state = _state(doc)
     let nextState = {...state, heads: undefined};
     let nextDoc = state.handle.applyPatches(doc, nextState, callback)
@@ -358,7 +361,7 @@ function _change<T>(doc: Doc<T>, options: ChangeOptions<T>, callback: ChangeFn<T
  * depends on those merged changes so that you can sign the new change with all
  * of the merged changes as part of the new change.
  */
-export function emptyChange<T>(doc: Doc<T>, options: string | ChangeOptions<T>) {
+export function emptyChange<T>(doc: Doc<T>, options: string | ChangeOptions<T> | void) {
     if (options === undefined) {
         options = {}
     }
@@ -376,7 +379,7 @@ export function emptyChange<T>(doc: Doc<T>, options: string | ChangeOptions<T>) 
     }
 
     const heads = state.handle.getHeads()
-    state.handle.commit(options.message, options.time)
+    state.handle.emptyChange(options.message, options.time)
     return progressDocument(doc, heads)
 }
 

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -246,6 +246,22 @@ describe('Automerge', () => {
         })
     })
 
+    describe('emptyChange', () => {
+        it('should generate a hash', () => {
+            let doc = Automerge.init()
+            doc = Automerge.change<any>(doc, d => {
+                d.key = "value"
+            })
+            let _ = Automerge.save(doc)
+            let headsBefore = Automerge.getHeads(doc)
+            headsBefore.sort()
+            doc = Automerge.emptyChange(doc, "empty change")
+            let headsAfter = Automerge.getHeads(doc)
+            headsAfter.sort()
+            assert.notDeepEqual(headsBefore, headsAfter)
+        })
+    })
+
     describe('proxy lists', () => {
         it('behave like arrays', () => {
           let doc = Automerge.from({

--- a/rust/automerge-c/src/result.rs
+++ b/rust/automerge-c/src/result.rs
@@ -372,6 +372,15 @@ impl From<am::ChangeHash> for AMresult {
     }
 }
 
+impl From<Option<am::ChangeHash>> for AMresult {
+    fn from(c: Option<am::ChangeHash>) -> Self {
+        match c {
+            Some(c) => c.into(),
+            None => AMresult::Void,
+        }
+    }
+}
+
 impl From<am::Keys<'_, '_>> for AMresult {
     fn from(keys: am::Keys<'_, '_>) -> Self {
         AMresult::Strings(keys.collect())

--- a/rust/automerge-c/test/ported_wasm/basic_tests.c
+++ b/rust/automerge-c/test/ported_wasm/basic_tests.c
@@ -37,7 +37,7 @@ static void test_start_and_commit(void** state) {
     /* const doc = create()                                                  */
     AMdoc* const doc = AMpush(&stack, AMcreate(NULL), AM_VALUE_DOC, cmocka_cb).doc;
     /* doc.commit()                                                          */
-    AMpush(&stack, AMcommit(doc, AMstr(NULL), NULL), AM_VALUE_CHANGE_HASHES, cmocka_cb);
+    AMpush(&stack, AMemptyChange(doc, AMstr(NULL), NULL), AM_VALUE_CHANGE_HASHES, cmocka_cb);
 }
 
 /**

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -168,7 +168,8 @@ export class Automerge {
   toJS(): MaterializeValue;
 
   // transactions
-  commit(message?: string, time?: number): Hash;
+  commit(message?: string, time?: number): Hash | null;
+  emptyChange(message?: string, time?: number): Hash;
   merge(other: Automerge): Heads;
   getActorId(): Actor;
   pendingOps(): number;

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -131,7 +131,10 @@ impl Automerge {
             commit_opts.set_time(time as i64);
         }
         let hash = self.doc.commit_with(commit_opts);
-        JsValue::from_str(&hex::encode(hash.0))
+        match hash {
+            Some(h) => JsValue::from_str(&hex::encode(h.0)),
+            None => JsValue::NULL,
+        }
     }
 
     pub fn merge(&mut self, other: &mut Automerge) -> Result<Array, JsValue> {
@@ -773,6 +776,14 @@ impl Automerge {
                 }
             }
         }
+    }
+
+    #[wasm_bindgen(js_name = emptyChange)]
+    pub fn empty_change(&mut self, message: Option<String>, time: Option<f64>) -> JsValue {
+        let time = time.map(|f| f as i64);
+        let options = CommitOptions { message, time };
+        let hash = self.doc.empty_change(options);
+        JsValue::from_str(&hex::encode(hash))
     }
 }
 

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -188,7 +188,9 @@ describe('Automerge', () => {
       const hash2 = doc.commit()
 
       assert.deepEqual(doc.keys("_root"), ["bip"])
+      assert.ok(hash1)
       assert.deepEqual(doc.keys("_root", [hash1]), ["bip", "foo"])
+      assert.ok(hash2)
       assert.deepEqual(doc.keys("_root", [hash2]), ["bip"])
     })
 
@@ -280,9 +282,12 @@ describe('Automerge', () => {
       const hash2 = doc.commit();
       assert.strictEqual(doc.text(text), "hello big bad world")
       assert.strictEqual(doc.length(text), 19)
+      assert.ok(hash1)
       assert.strictEqual(doc.text(text, [hash1]), "hello world")
       assert.strictEqual(doc.length(text, [hash1]), 11)
+      assert.ok(hash2)
       assert.strictEqual(doc.text(text, [hash2]), "hello big bad world")
+      assert.ok(hash2)
       assert.strictEqual(doc.length(text, [hash2]), 19)
     })
 

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -127,7 +127,9 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
 
     fn ensure_transaction_open(&mut self) {
         if self.transaction.is_none() {
-            self.transaction = Some((self.observation.branch(), self.doc.transaction_inner()));
+            let args = self.doc.transaction_args();
+            let inner = TransactionInner::new(args);
+            self.transaction = Some((self.observation.branch(), inner))
         }
     }
 

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -31,7 +31,7 @@ impl<O: Observation> AutoCommitWithObs<O> {
     }
 }
 
-impl<O: OpObserver> Default for AutoCommitWithObs<Observed<O>> {
+impl<O: OpObserver + Default> Default for AutoCommitWithObs<Observed<O>> {
     fn default() -> Self {
         let op_observer = O::default();
         AutoCommitWithObs {

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -256,6 +256,15 @@ impl Automerge {
         }
     }
 
+    /// Generate an empty change
+    ///
+    /// The main reason to do this is if you want to create a "merge commit", which is a change
+    /// that has all the current heads of the document as dependencies.
+    pub fn empty_commit(&mut self, opts: CommitOptions) -> ChangeHash {
+        let args = self.transaction_args();
+        Transaction::empty(self, args, opts)
+    }
+
     /// Fork this document at the current point for use by a different actor.
     pub fn fork(&self) -> Self {
         let mut f = self.clone();

--- a/rust/automerge/src/automerge/tests.rs
+++ b/rust/automerge/src/automerge/tests.rs
@@ -1080,8 +1080,8 @@ fn delete_nothing_in_map_is_noop() {
     // deleting a missing key in a map should just be a noop
     assert!(tx.delete(ROOT, "a",).is_ok());
     tx.commit();
-    let last_change = doc.get_last_local_change().unwrap();
-    assert_eq!(last_change.len(), 0);
+    let last_change = doc.get_last_local_change();
+    assert!(last_change.is_none());
 
     let bytes = doc.save();
     assert!(Automerge::load(&bytes,).is_ok());

--- a/rust/automerge/src/op_observer.rs
+++ b/rust/automerge/src/op_observer.rs
@@ -4,7 +4,7 @@ use crate::Prop;
 use crate::Value;
 
 /// An observer of operations applied to the document.
-pub trait OpObserver: Default + Clone {
+pub trait OpObserver {
     /// A new value has been inserted into the given object.
     ///
     /// - `parents`: A parents iterator that can be used to collect path information
@@ -64,9 +64,7 @@ pub trait OpObserver: Default + Clone {
     /// Called by AutoCommit when creating a new transaction.  Observer branch
     /// will be merged on `commit()` or thrown away on `rollback()`
     ///
-    fn branch(&self) -> Self {
-        Self::default()
-    }
+    fn branch(&self) -> Self;
 
     /// Merge observed information from a transaction.
     ///
@@ -108,6 +106,8 @@ impl OpObserver for () {
     fn delete(&mut self, _parents: Parents<'_>, _objid: ExId, _prop: Prop) {}
 
     fn merge(&mut self, _other: &Self) {}
+
+    fn branch(&self) -> Self {}
 }
 
 /// Capture operations into a [`Vec`] and store them as patches.
@@ -182,6 +182,10 @@ impl OpObserver for VecOpObserver {
 
     fn merge(&mut self, other: &Self) {
         self.patches.extend_from_slice(other.patches.as_slice())
+    }
+
+    fn branch(&self) -> Self {
+        Self::default()
     }
 }
 

--- a/rust/automerge/src/transaction.rs
+++ b/rust/automerge/src/transaction.rs
@@ -7,7 +7,7 @@ mod transactable;
 
 pub use self::commit::CommitOptions;
 pub use self::transactable::Transactable;
-pub(crate) use inner::TransactionInner;
+pub(crate) use inner::{TransactionArgs, TransactionInner};
 pub use manual_transaction::Transaction;
 pub use observation::{Observation, Observed, UnObserved};
 pub use result::Failure;

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -10,16 +10,49 @@ use crate::{AutomergeError, ObjType, OpType, ScalarValue};
 
 #[derive(Debug, Clone)]
 pub(crate) struct TransactionInner {
-    pub(crate) actor: usize,
+    actor: usize,
+    seq: u64,
+    start_op: NonZeroU64,
+    time: i64,
+    message: Option<String>,
+    deps: Vec<ChangeHash>,
+    operations: Vec<(ObjId, Prop, Op)>,
+}
+
+/// Arguments required to create a new transaction
+pub(crate) struct TransactionArgs {
+    /// The index of the actor ID this transaction will create ops for in the
+    /// [`OpSetMetadata::actors`]
+    pub(crate) actor_index: usize,
+    /// The sequence number of the change this transaction will create
     pub(crate) seq: u64,
+    /// The start op of the change this transaction will create
     pub(crate) start_op: NonZeroU64,
-    pub(crate) time: i64,
-    pub(crate) message: Option<String>,
+    /// The dependencies of the change this transaction will create
     pub(crate) deps: Vec<ChangeHash>,
-    pub(crate) operations: Vec<(ObjId, Prop, Op)>,
 }
 
 impl TransactionInner {
+    pub(crate) fn new(
+        TransactionArgs {
+            actor_index: actor,
+            seq,
+            start_op,
+            deps,
+        }: TransactionArgs,
+    ) -> Self {
+        TransactionInner {
+            actor,
+            seq,
+            // SAFETY: this unwrap is safe as we always add 1
+            start_op,
+            time: 0,
+            message: None,
+            operations: vec![],
+            deps,
+        }
+    }
+
     pub(crate) fn pending_ops(&self) -> usize {
         self.operations.len()
     }

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -39,6 +39,16 @@ impl<'a, Obs: observation::Observation> Transaction<'a, Obs> {
     }
 }
 
+impl<'a> Transaction<'a, observation::UnObserved> {
+    pub(crate) fn empty(
+        doc: &'a mut Automerge,
+        args: TransactionArgs,
+        opts: CommitOptions,
+    ) -> ChangeHash {
+        TransactionInner::empty(doc, args, opts.message, opts.time)
+    }
+}
+
 impl<'a, Obs: OpObserver> Transaction<'a, observation::Observed<Obs>> {
     pub fn observer(&mut self) -> &mut Obs {
         self.observation.as_mut().unwrap().observer()

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -5,7 +5,7 @@ use crate::{Automerge, ChangeHash, KeysAt, ObjType, OpObserver, Prop, ScalarValu
 use crate::{AutomergeError, Keys};
 use crate::{ListRange, ListRangeAt, MapRange, MapRangeAt};
 
-use super::{observation, CommitOptions, Transactable, TransactionInner};
+use super::{observation, CommitOptions, Transactable, TransactionArgs, TransactionInner};
 
 /// A transaction on a document.
 /// Transactions group operations into a single change so that no other operations can happen
@@ -23,10 +23,20 @@ use super::{observation, CommitOptions, Transactable, TransactionInner};
 pub struct Transaction<'a, Obs: observation::Observation> {
     // this is an option so that we can take it during commit and rollback to prevent it being
     // rolled back during drop.
-    pub(crate) inner: Option<TransactionInner>,
+    inner: Option<TransactionInner>,
     // As with `inner` this is an `Option` so we can `take` it during `commit`
-    pub(crate) observation: Option<Obs>,
-    pub(crate) doc: &'a mut Automerge,
+    observation: Option<Obs>,
+    doc: &'a mut Automerge,
+}
+
+impl<'a, Obs: observation::Observation> Transaction<'a, Obs> {
+    pub(crate) fn new(doc: &'a mut Automerge, args: TransactionArgs, obs: Obs) -> Self {
+        Self {
+            inner: Some(TransactionInner::new(args)),
+            doc,
+            observation: Some(obs),
+        }
+    }
 }
 
 impl<'a, Obs: OpObserver> Transaction<'a, observation::Observed<Obs>> {

--- a/rust/automerge/src/transaction/observation.rs
+++ b/rust/automerge/src/transaction/observation.rs
@@ -13,7 +13,7 @@ pub trait Observation: private::Sealed {
     type CommitResult;
 
     fn observer(&mut self) -> Option<&mut Self::Obs>;
-    fn make_result(self, hash: ChangeHash) -> Self::CommitResult;
+    fn make_result(self, hash: Option<ChangeHash>) -> Self::CommitResult;
     fn branch(&self) -> Self;
     fn merge(&mut self, other: &Self);
 }
@@ -33,12 +33,12 @@ impl<O: OpObserver> Observed<O> {
 
 impl<Obs: OpObserver> Observation for Observed<Obs> {
     type Obs = Obs;
-    type CommitResult = (Obs, ChangeHash);
+    type CommitResult = (Obs, Option<ChangeHash>);
     fn observer(&mut self) -> Option<&mut Self::Obs> {
         Some(&mut self.0)
     }
 
-    fn make_result(self, hash: ChangeHash) -> Self::CommitResult {
+    fn make_result(self, hash: Option<ChangeHash>) -> Self::CommitResult {
         (self.0, hash)
     }
 
@@ -61,12 +61,12 @@ impl UnObserved {
 
 impl Observation for UnObserved {
     type Obs = ();
-    type CommitResult = ChangeHash;
+    type CommitResult = Option<ChangeHash>;
     fn observer(&mut self) -> Option<&mut Self::Obs> {
         None
     }
 
-    fn make_result(self, hash: ChangeHash) -> Self::CommitResult {
+    fn make_result(self, hash: Option<ChangeHash>) -> Self::CommitResult {
         hash
     }
 

--- a/rust/automerge/src/transaction/result.rs
+++ b/rust/automerge/src/transaction/result.rs
@@ -5,8 +5,8 @@ use crate::ChangeHash;
 pub struct Success<O, Obs> {
     /// The result of the transaction.
     pub result: O,
-    /// The hash of the change, also the head of the document.
-    pub hash: ChangeHash,
+    /// The hash of the change, will be `None` if the transaction did not create any operations
+    pub hash: Option<ChangeHash>,
     pub op_observer: Obs,
 }
 


### PR DESCRIPTION
Transactions with no ops in them are generally undesirable. They take up space in the change log but do nothing else. They are not useless though, it may occasionally be necessary to create an empty change in order to list all the current heads of the document as dependents of the empty change.
    
The current API makes no distinction between empty changes and non-empty changes. If the user calls `Transaction::commit` a change is created regardless of whether there are ops to commit. To provide a more useful API modify `commit` so that if there is a no-op transaction then no changes are created, but provide explicit methods to create an empty change via `Transaction::empty_change`, `Automerge::empty_change` and `Autocommit::empty_change`. Also make these APIs available in Javascript and C.

@orionz  it would be great if you could check that the JS bindings make sense
@jkankiewicz I had to modify the C code a bit, please check I've not done anything silly

Closes #463 