### PR TITLE
automerge-cli: remove a bunch of bad dependencies

### DIFF
--- a/rust/automerge-c/Cargo.toml
+++ b/rust/automerge-c/Cargo.toml
@@ -19,4 +19,4 @@ libc = "^0.2"
 smol_str = "^0.1.21"
 
 [build-dependencies]
-cbindgen = "^0.20"
+cbindgen = "^0.24"

--- a/rust/automerge-cli/Cargo.toml
+++ b/rust/automerge-cli/Cargo.toml
@@ -13,17 +13,18 @@ bench = false
 doc = false
 
 [dependencies]
-clap = {version = "~3.1", features = ["derive"]}
+clap = {version = "~4", features = ["derive"]}
 serde_json = "^1.0"
 anyhow = "1.0"
-atty = "^0.2"
 thiserror = "^1.0"
 combine = "^4.5"
 maplit = "^1.0"
-colored_json = "^2.1"
 tracing-subscriber = "~0.3"
 
 automerge = { path = "../automerge" }
+is-terminal = "0.4.1"
+termcolor = "1.1.3"
+serde = "1.0.150"
 
 [dev-dependencies]
 duct = "^0.13"

--- a/rust/automerge-cli/src/color_json.rs
+++ b/rust/automerge-cli/src/color_json.rs
@@ -1,0 +1,348 @@
+use std::io::Write;
+
+use serde::Serialize;
+use serde_json::ser::Formatter;
+use termcolor::{Buffer, BufferWriter, Color, ColorSpec, WriteColor};
+
+struct Style {
+    /// style of object brackets
+    object_brackets: ColorSpec,
+    /// style of array brackets
+    array_brackets: ColorSpec,
+    /// style of object
+    key: ColorSpec,
+    /// style of string values
+    string_value: ColorSpec,
+    /// style of integer values
+    integer_value: ColorSpec,
+    /// style of float values
+    float_value: ColorSpec,
+    /// style of bool values
+    bool_value: ColorSpec,
+    /// style of the `nil` value
+    nil_value: ColorSpec,
+    /// should the quotation get the style of the inner string/key?
+    string_include_quotation: bool,
+}
+
+impl Default for Style {
+    fn default() -> Self {
+        Self {
+            object_brackets: ColorSpec::new().set_bold(true).clone(),
+            array_brackets: ColorSpec::new().set_bold(true).clone(),
+            key: ColorSpec::new()
+                .set_fg(Some(Color::Blue))
+                .set_bold(true)
+                .clone(),
+            string_value: ColorSpec::new().set_fg(Some(Color::Green)).clone(),
+            integer_value: ColorSpec::new(),
+            float_value: ColorSpec::new(),
+            bool_value: ColorSpec::new(),
+            nil_value: ColorSpec::new(),
+            string_include_quotation: true,
+        }
+    }
+}
+
+/// Write pretty printed, colored json to stdout
+pub(crate) fn print_colored_json(value: &serde_json::Value) -> std::io::Result<()> {
+    let formatter = ColoredFormatter {
+        formatter: serde_json::ser::PrettyFormatter::new(),
+        style: Style::default(),
+        in_object_key: false,
+    };
+    let mut ignored_writer = Vec::new();
+    let mut ser = serde_json::Serializer::with_formatter(&mut ignored_writer, formatter);
+    value
+        .serialize(&mut ser)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+}
+
+struct ColoredFormatter<F: Formatter> {
+    formatter: F,
+    style: Style,
+    in_object_key: bool,
+}
+
+fn write_colored<H>(color: ColorSpec, handler: H) -> std::io::Result<()>
+where
+    H: FnOnce(&mut Buffer) -> std::io::Result<()>,
+{
+    let buf = BufferWriter::stdout(termcolor::ColorChoice::Auto);
+    let mut buffer = buf.buffer();
+    buffer.set_color(&color)?;
+    handler(&mut buffer)?;
+    buffer.reset()?;
+    buf.print(&buffer)?;
+    Ok(())
+}
+
+impl<F: Formatter> Formatter for ColoredFormatter<F> {
+    fn write_null<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.nil_value.clone(), |w| {
+            self.formatter.write_null(w)
+        })
+    }
+
+    fn write_bool<W>(&mut self, _writer: &mut W, value: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.bool_value.clone(), |w| {
+            self.formatter.write_bool(w, value)
+        })
+    }
+
+    fn write_i8<W>(&mut self, _writer: &mut W, value: i8) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_i8(w, value)
+        })
+    }
+
+    fn write_i16<W>(&mut self, _writer: &mut W, value: i16) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_i16(w, value)
+        })
+    }
+
+    fn write_i32<W>(&mut self, _writer: &mut W, value: i32) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_i32(w, value)
+        })
+    }
+
+    fn write_i64<W>(&mut self, _writer: &mut W, value: i64) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_i64(w, value)
+        })
+    }
+
+    fn write_u8<W>(&mut self, _writer: &mut W, value: u8) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_u8(w, value)
+        })
+    }
+
+    fn write_u16<W>(&mut self, _writer: &mut W, value: u16) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_u16(w, value)
+        })
+    }
+
+    fn write_u32<W>(&mut self, _writer: &mut W, value: u32) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_u32(w, value)
+        })
+    }
+
+    fn write_u64<W>(&mut self, _writer: &mut W, value: u64) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_u64(w, value)
+        })
+    }
+
+    fn write_f32<W>(&mut self, _writer: &mut W, value: f32) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.float_value.clone(), |w| {
+            self.formatter.write_f32(w, value)
+        })
+    }
+
+    fn write_f64<W>(&mut self, _writer: &mut W, value: f64) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.float_value.clone(), |w| {
+            self.formatter.write_f64(w, value)
+        })
+    }
+
+    fn write_number_str<W>(&mut self, _writer: &mut W, value: &str) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.integer_value.clone(), |w| {
+            self.formatter.write_number_str(w, value)
+        })
+    }
+
+    fn begin_string<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        if self.style.string_include_quotation {
+            let style = if self.in_object_key {
+                &self.style.key
+            } else {
+                &self.style.string_value
+            };
+            write_colored(style.clone(), |w| self.formatter.begin_string(w))
+        } else {
+            self.formatter.begin_string(_writer)
+        }
+    }
+
+    fn end_string<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        if self.style.string_include_quotation {
+            let style = if self.in_object_key {
+                &self.style.key
+            } else {
+                &self.style.string_value
+            };
+            write_colored(style.clone(), |w| self.formatter.end_string(w))
+        } else {
+            self.formatter.end_string(_writer)
+        }
+    }
+
+    fn write_string_fragment<W>(&mut self, _writer: &mut W, fragment: &str) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        let style = if self.in_object_key {
+            &self.style.key
+        } else {
+            &self.style.string_value
+        };
+        write_colored(style.clone(), |w| w.write_all(fragment.as_bytes()))
+    }
+
+    fn write_char_escape<W>(
+        &mut self,
+        _writer: &mut W,
+        char_escape: serde_json::ser::CharEscape,
+    ) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        let style = if self.in_object_key {
+            &self.style.key
+        } else {
+            &self.style.string_value
+        };
+        write_colored(style.clone(), |w| {
+            self.formatter.write_char_escape(w, char_escape)
+        })
+    }
+
+    fn begin_array<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.array_brackets.clone(), |w| {
+            self.formatter.begin_array(w)
+        })
+    }
+
+    fn end_array<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.array_brackets.clone(), |w| {
+            self.formatter.end_array(w)
+        })
+    }
+
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.formatter.begin_array_value(writer, first)
+    }
+
+    fn end_array_value<W>(&mut self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.formatter.end_array_value(writer)
+    }
+
+    fn begin_object<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.object_brackets.clone(), |w| {
+            self.formatter.begin_object(w)
+        })
+    }
+
+    fn end_object<W>(&mut self, _writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_colored(self.style.object_brackets.clone(), |w| {
+            self.formatter.end_object(w)
+        })
+    }
+
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.in_object_key = true;
+        self.formatter.begin_object_key(writer, first)
+    }
+
+    fn end_object_key<W>(&mut self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.in_object_key = false;
+        self.formatter.end_object_key(writer)
+    }
+
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.in_object_key = false;
+        self.formatter.begin_object_value(writer)
+    }
+
+    fn end_object_value<W>(&mut self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.in_object_key = false;
+        self.formatter.end_object_value(writer)
+    }
+
+    fn write_raw_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        self.formatter.write_raw_fragment(writer, fragment)
+    }
+}

--- a/rust/automerge-cli/src/examine.rs
+++ b/rust/automerge-cli/src/examine.rs
@@ -1,6 +1,8 @@
 use automerge as am;
 use thiserror::Error;
 
+use crate::color_json::print_colored_json;
+
 #[derive(Error, Debug)]
 pub enum ExamineError {
     #[error("Error reading change file: {:?}", source)]
@@ -39,7 +41,7 @@ pub fn examine(
         .collect();
     if is_tty {
         let json_changes = serde_json::to_value(uncompressed_changes).unwrap();
-        colored_json::write_colored_json(&json_changes, &mut output).unwrap();
+        print_colored_json(&json_changes).unwrap();
         writeln!(output).unwrap();
     } else {
         let json_changes = serde_json::to_string_pretty(&uncompressed_changes).unwrap();

--- a/rust/automerge-cli/src/export.rs
+++ b/rust/automerge-cli/src/export.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use automerge as am;
 
+use crate::color_json::print_colored_json;
+
 pub(crate) fn map_to_json(doc: &am::Automerge, obj: &am::ObjId) -> serde_json::Value {
     let keys = doc.keys(obj);
     let mut map = serde_json::Map::new();
@@ -84,7 +86,7 @@ pub fn export_json(
 
     let state_json = get_state_json(input_data)?;
     if is_tty {
-        colored_json::write_colored_json(&state_json, &mut writer).unwrap();
+        print_colored_json(&state_json).unwrap();
         writeln!(writer).unwrap();
     } else {
         writeln!(

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -42,7 +42,7 @@ pretty_assertions = "1.0.0"
 proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
 serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features=true }
 maplit = { version = "^1.0" }
-criterion = "0.3.5"
+criterion = "0.4.0"
 test-log = { version = "0.2.10", features=["trace"], default-features = false}
 tracing-subscriber = {version = "0.3.9", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -46,7 +46,6 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     #"RUSTSEC-0000-0000",
-    "RUSTSEC-2021-0127", # serde_cbor is unmaintained, but we only use it in criterion for benchmarks
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -100,10 +99,6 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # this is a LGPL like license in the CLI
-    # since this is an application not a library people would link to it should be fine
-    { allow = ["EPL-2.0"], name = "colored_json" },
-
     # The Unicode-DFS--2016 license is necessary for unicode-ident because they
     # use data from the unicode tables to generate the tables which are
     # included in the application. We do not distribute those data files so
@@ -177,21 +172,14 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    # These are transitive depdendencies of criterion, which is only included for benchmarking anyway
-    { name = "itoa", version = "0.4.8" },
-    { name = "textwrap", version = "0.11.0" },
-    { name = "clap", version = "2.34.0" },
-
-    # These are transitive depdendencies of cbindgen
-    { name = "strsim", version = "0.8.0" },
-    { name = "heck", version = "0.3.3" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate 
 # detection. Unlike skip, it also includes the entire tree of transitive 
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+    # // We only ever use criterion in benchmarks
+    { name = "criterion", version = "0.4.0", depth=10},
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/rust/edit-trace/Cargo.toml
+++ b/rust/edit-trace/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 [dependencies]
 automerge = { path = "../automerge" }
-criterion = "0.3.5"
+criterion = "0.4.0"
 json = "0.12.4"
 rand = "^0.8"
 


### PR DESCRIPTION
Automerge CLI depends transitively (via and old version of `clap` and via `colored_json` on `atty` and `ansi_term`. These crates are both marked as unmaintained and this generates irritating `cargo deny` messages. To avoid this, implement colored JSON ourselves using the `termcolor` crate - colored JSON is pretty mechanical. Also update criterion and cbindgen dependencies and ignore the criterion tree in deny.toml as we only ever use it in benchmarks.

All that's left now is a warning about atty in cbindgen, we'll just have to wait for cbindgen to fix that, it's a build time dependency anyway so it's not really an issue.