### PR TITLE
Allow loading CLI changes without verifying heads

### DIFF
--- a/rust/automerge-cli/src/examine.rs
+++ b/rust/automerge-cli/src/examine.rs
@@ -1,7 +1,7 @@
 use automerge as am;
 use thiserror::Error;
 
-use crate::color_json::print_colored_json;
+use crate::{color_json::print_colored_json, SkipVerifyFlag};
 
 #[derive(Error, Debug)]
 pub enum ExamineError {
@@ -22,16 +22,18 @@ pub enum ExamineError {
     },
 }
 
-pub fn examine(
+pub(crate) fn examine(
     mut input: impl std::io::Read,
     mut output: impl std::io::Write,
+    skip: SkipVerifyFlag,
     is_tty: bool,
 ) -> Result<(), ExamineError> {
     let mut buf: Vec<u8> = Vec::new();
     input
         .read_to_end(&mut buf)
         .map_err(|e| ExamineError::ReadingChanges { source: e })?;
-    let doc = am::Automerge::load(&buf)
+    let doc = skip
+        .load(&buf)
         .map_err(|e| ExamineError::ApplyingInitialChanges { source: e })?;
     let uncompressed_changes: Vec<_> = doc
         .get_changes(&[])

--- a/rust/automerge-cli/src/examine_sync.rs
+++ b/rust/automerge-cli/src/examine_sync.rs
@@ -1,0 +1,38 @@
+use automerge::sync::ReadMessageError;
+
+use crate::color_json::print_colored_json;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExamineSyncError {
+    #[error("Error reading message: {0}")]
+    ReadMessage(#[source] std::io::Error),
+
+    #[error("error writing message: {0}")]
+    WriteMessage(#[source] std::io::Error),
+
+    #[error("error writing json to output: {0}")]
+    WriteJson(#[source] serde_json::Error),
+
+    #[error("Error parsing message: {0}")]
+    ParseMessage(#[from] ReadMessageError),
+}
+
+pub(crate) fn examine_sync<W: std::io::Write>(
+    mut input: Box<dyn std::io::Read>,
+    output: W,
+    is_tty: bool,
+) -> Result<(), ExamineSyncError> {
+    let mut buf: Vec<u8> = Vec::new();
+    input
+        .read_to_end(&mut buf)
+        .map_err(ExamineSyncError::ReadMessage)?;
+
+    let message = automerge::sync::Message::decode(&buf)?;
+    let json = serde_json::to_value(&message).unwrap();
+    if is_tty {
+        print_colored_json(&json).map_err(ExamineSyncError::WriteMessage)?;
+    } else {
+        serde_json::to_writer(output, &json).map_err(ExamineSyncError::WriteJson)?;
+    }
+    Ok(())
+}

--- a/rust/automerge-cli/src/main.rs
+++ b/rust/automerge-cli/src/main.rs
@@ -9,6 +9,7 @@ use is_terminal::IsTerminal;
 
 mod color_json;
 mod examine;
+mod examine_sync;
 mod export;
 mod import;
 mod merge;
@@ -114,6 +115,9 @@ enum Command {
         skip_verifying_heads: SkipVerifyFlag,
     },
 
+    /// Read an automerge sync messaage and print a JSON representation of it
+    ExamineSync { input_file: Option<PathBuf> },
+
     /// Read one or more automerge documents and output a merged, compacted version of them
     Merge {
         /// The file to write to. If omitted assumes stdout
@@ -203,6 +207,18 @@ fn main() -> Result<()> {
                 skip_verifying_heads,
                 std::io::stdout().is_terminal(),
             ) {
+                Ok(()) => {}
+                Err(e) => {
+                    eprintln!("Error: {:?}", e);
+                }
+            }
+            Ok(())
+        }
+        Command::ExamineSync { input_file } => {
+            let in_buffer = open_file_or_stdin(input_file)?;
+            let out_buffer = std::io::stdout();
+            match examine_sync::examine_sync(in_buffer, out_buffer, std::io::stdout().is_terminal())
+            {
                 Ok(()) => {}
                 Err(e) => {
                     eprintln!("Error: {:?}", e);

--- a/rust/automerge/src/storage.rs
+++ b/rust/automerge/src/storage.rs
@@ -14,6 +14,7 @@ pub(crate) use {
     chunk::{CheckSum, Chunk, ChunkType, Header},
     columns::{Columns, MismatchingColumn, RawColumn, RawColumns},
     document::{AsChangeMeta, AsDocOp, ChangeMetadata, CompressConfig, DocOp, Document},
+    load::VerificationMode,
 };
 
 fn shift_range(range: Range<usize>, by: usize) -> Range<usize> {

--- a/rust/automerge/src/storage/load.rs
+++ b/rust/automerge/src/storage/load.rs
@@ -8,7 +8,7 @@ use crate::{
 mod change_collector;
 mod reconstruct_document;
 pub(crate) use reconstruct_document::{
-    reconstruct_document, DocObserver, LoadedObject, Reconstructed,
+    reconstruct_document, DocObserver, LoadedObject, Reconstructed, VerificationMode,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -84,7 +84,7 @@ fn load_next_change<'a>(
             let Reconstructed {
                 changes: new_changes,
                 ..
-            } = reconstruct_document(&d, NullObserver)
+            } = reconstruct_document(&d, VerificationMode::DontCheck, NullObserver)
                 .map_err(|e| Error::InflateDocument(Box::new(e)))?;
             changes.extend(new_changes);
         }


### PR DESCRIPTION
This is useful when debugging corrupted documents. While we're here I also

* Fixed the broken colored JSON implementation I pushed a few days ago
* Added an `examine-sync` command for dumping the contents of sync messages