### PR TITLE
Return an error from automerge-c on empty commit

### DIFF
--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -151,8 +151,7 @@ pub unsafe extern "C" fn AMcreate(actor_id: *const AMactorId) -> *mut AMresult {
 /// \param[in] message A UTF-8 string view as an `AMbyteSpan` struct.
 /// \param[in] timestamp A pointer to a 64-bit integer or `NULL`.
 /// \return A pointer to an `AMresult` struct containing an `AMchangeHashes`
-///         with one element if there were operations to commit, or void if
-///         there were no operations to commit.
+///         with one element, or an error if there were no operations to commit.
 /// \pre \p doc `!= NULL`.
 /// \warning The returned `AMresult` struct must be deallocated with `AMfree()`
 ///          in order to prevent a memory leak.
@@ -174,7 +173,10 @@ pub unsafe extern "C" fn AMcommit(
     if let Some(timestamp) = timestamp.as_ref() {
         options.set_time(*timestamp);
     }
-    to_result(doc.commit_with(options))
+    match doc.commit_with(options) {
+        Some(change_hash) => to_result(change_hash),
+        None => AMresult::err("Commit is empty").into(),
+    }
 }
 
 /// \memberof AMdoc

--- a/rust/automerge-c/src/result.rs
+++ b/rust/automerge-c/src/result.rs
@@ -372,15 +372,6 @@ impl From<am::ChangeHash> for AMresult {
     }
 }
 
-impl From<Option<am::ChangeHash>> for AMresult {
-    fn from(c: Option<am::ChangeHash>) -> Self {
-        match c {
-            Some(c) => c.into(),
-            None => AMresult::Void,
-        }
-    }
-}
-
 impl From<am::Keys<'_, '_>> for AMresult {
     fn from(keys: am::Keys<'_, '_>) -> Self {
         AMresult::Strings(keys.collect())

--- a/rust/automerge-c/test/ported_wasm/sync_tests.c
+++ b/rust/automerge-c/test/ported_wasm/sync_tests.c
@@ -172,12 +172,19 @@ static void test_repos_with_equal_heads_do_not_need_a_reply_message(void **state
                                        cmocka_cb).obj_id;
     /* n1.commit("", 0)                                                      */
     AMfree(AMcommit(test_state->n1, AMstr(""), &TIME_0));
+
     /* for (let i = 0; i < 10; i++) {                                        */
     for (size_t i = 0; i != 10; ++i) {
         /* n1.insert(list, i, i)                                             */
-        AMfree(AMlistPutUint(test_state->n1, AM_ROOT, i, true, i));
+        AMpush(&test_state->stack,
+            AMlistPutUint(test_state->n1, list, i, true, i),
+            AM_VALUE_VOID,
+            cmocka_cb);
         /* n1.commit("", 0)                                                  */
-        AMfree(AMcommit(test_state->n1, AMstr(""), &TIME_0));
+        AMpush(&test_state->stack,
+            AMcommit(test_state->n1, AMstr(""), &TIME_0),
+            AM_VALUE_CHANGE_HASHES,
+            cmocka_cb);
     /* {                                                                     */
     }
     /* n2.applyChanges(n1.getChanges([]))                                    */


### PR DESCRIPTION
Ref #451

Before this change it was unclear why commit would sometimes return void.