### PR TITLE
Update action name on `IncPatch` type

### DIFF
--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -104,7 +104,7 @@ export type PutPatch = {
 }
 
 export type IncPatch = {
-  action: 'put'
+  action: 'inc'
   path: Prop[],
   value: number
 }


### PR DESCRIPTION
The `IncPatch` type currently has its action as 'put', but the patch provided following a counter increment contains an 'inc' action.