### PR TITLE
automerge-rs: Add `ExId::to_bytes`

### DIFF
--- a/rust/automerge/src/exid.rs
+++ b/rust/automerge/src/exid.rs
@@ -1,3 +1,4 @@
+use crate::storage::parse;
 use crate::ActorId;
 use serde::Serialize;
 use serde::Serializer;
@@ -9,6 +10,102 @@ use std::hash::{Hash, Hasher};
 pub enum ExId {
     Root,
     Id(u64, ActorId, usize),
+}
+
+const SERIALIZATION_VERSION_TAG: u8 = 0;
+const TYPE_ROOT: u8 = 0;
+const TYPE_ID: u8 = 1;
+
+impl ExId {
+    /// Serialize the ExId to a byte array.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // The serialized format is
+        //
+        // .--------------------------------.
+        // | version   | type   | data      |
+        // +--------------------------------+
+        // |  4 bytes  |4 bytes | variable  |
+        // '--------------------------------'
+        //
+        // Version is currently always `0`
+        //
+        // `data` depends on the type
+        //
+        // * If the type is `TYPE_ROOT` (0) then there is no data
+        // * If the type is `TYPE_ID` (1) then the data is
+        //
+        // .-------------------------------------------------------.
+        // | actor ID len | actor ID bytes | counter | actor index |
+        // '-------------------------------------------------------'
+        //
+        // Where the actor ID len, counter, and actor index are all uLEB encoded
+        // integers. The actor ID bytes is just an array of bytes.
+        //
+        match self {
+            ExId::Root => {
+                let val: u8 = SERIALIZATION_VERSION_TAG | (TYPE_ROOT << 4);
+                vec![val]
+            }
+            ExId::Id(id, actor, counter) => {
+                let actor_bytes = actor.to_bytes();
+                let mut bytes = Vec::with_capacity(actor_bytes.len() + 4 + 4);
+                let tag = SERIALIZATION_VERSION_TAG | (TYPE_ID << 4);
+                bytes.push(tag);
+                leb128::write::unsigned(&mut bytes, actor_bytes.len() as u64).unwrap();
+                bytes.extend_from_slice(actor_bytes);
+                leb128::write::unsigned(&mut bytes, *counter as u64).unwrap();
+                leb128::write::unsigned(&mut bytes, *id).unwrap();
+                bytes
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ObjIdFromBytesError {
+    #[error("no version tag")]
+    NoVersion,
+    #[error("invalid version tag")]
+    InvalidVersion(u8),
+    #[error("invalid type tag")]
+    InvalidType(u8),
+    #[error("invalid Actor ID length: {0}")]
+    ParseActorLen(String),
+    #[error("Not enough bytes in actor ID")]
+    ParseActor,
+    #[error("invalid counter: {0}")]
+    ParseCounter(String),
+    #[error("invalid actor index hint: {0}")]
+    ParseActorIdxHint(String),
+}
+
+impl<'a> TryFrom<&'a [u8]> for ExId {
+    type Error = ObjIdFromBytesError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        let i = parse::Input::new(value);
+        let (i, tag) = parse::take1::<()>(i).map_err(|_| ObjIdFromBytesError::NoVersion)?;
+        let version = tag & 0b1111;
+        if version != SERIALIZATION_VERSION_TAG {
+            return Err(ObjIdFromBytesError::InvalidVersion(version));
+        }
+        let type_tag = tag >> 4;
+        match type_tag {
+            TYPE_ROOT => Ok(ExId::Root),
+            TYPE_ID => {
+                let (i, len) = parse::leb128_u64::<parse::leb128::Error>(i)
+                    .map_err(|e| ObjIdFromBytesError::ParseActorLen(e.to_string()))?;
+                let (i, actor) = parse::take_n::<()>(len as usize, i)
+                    .map_err(|_| ObjIdFromBytesError::ParseActor)?;
+                let (i, counter) = parse::leb128_u64::<parse::leb128::Error>(i)
+                    .map_err(|e| ObjIdFromBytesError::ParseCounter(e.to_string()))?;
+                let (_i, actor_idx_hint) = parse::leb128_u64::<parse::leb128::Error>(i)
+                    .map_err(|e| ObjIdFromBytesError::ParseActorIdxHint(e.to_string()))?;
+                Ok(Self::Id(actor_idx_hint, actor.into(), counter as usize))
+            }
+            other => Err(ObjIdFromBytesError::InvalidType(other)),
+        }
+    }
 }
 
 impl PartialEq for ExId {
@@ -78,5 +175,43 @@ impl Serialize for ExId {
 impl AsRef<ExId> for ExId {
     fn as_ref(&self) -> &ExId {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExId;
+    use proptest::prelude::*;
+
+    use crate::ActorId;
+
+    fn gen_actorid() -> impl Strategy<Value = ActorId> {
+        proptest::collection::vec(any::<u8>(), 0..100).prop_map(ActorId::from)
+    }
+
+    prop_compose! {
+        fn gen_non_root_objid()(actor in gen_actorid(), counter in any::<usize>(), idx in any::<usize>()) -> ExId {
+            ExId::Id(idx as u64, actor, counter)
+        }
+    }
+
+    fn gen_obji() -> impl Strategy<Value = ExId> {
+        prop_oneof![Just(ExId::Root), gen_non_root_objid()]
+    }
+
+    proptest! {
+        #[test]
+        fn objid_roundtrip(objid in gen_obji()) {
+            let bytes = objid.to_bytes();
+            let objid2 = ExId::try_from(&bytes[..]).unwrap();
+            assert_eq!(objid, objid2);
+        }
+    }
+
+    #[test]
+    fn test_root_roundtrip() {
+        let bytes = ExId::Root.to_bytes();
+        let objid2 = ExId::try_from(&bytes[..]).unwrap();
+        assert_eq!(ExId::Root, objid2);
     }
 }

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -93,7 +93,7 @@ pub use change::{Change, LoadError as LoadChangeError};
 pub use error::AutomergeError;
 pub use error::InvalidActorId;
 pub use error::InvalidChangeHashSlice;
-pub use exid::ExId as ObjId;
+pub use exid::{ExId as ObjId, ObjIdFromBytesError};
 pub use keys::Keys;
 pub use keys_at::KeysAt;
 pub use legacy::Change as ExpandedChange;


### PR DESCRIPTION
The `ExId` structure has some internal details which make lookups for object IDs which were produced by the document doing the looking up faster. These internal details are quite specific to the implementation so we don't want to expose them as a public API. On the other hand, we need to be able to serialize `ExId`s so that FFI clients can hold on to them without referencing memory which is owned by the document (ahem, looking at you Java).

Introduce `ExId::to_bytes` and `TryFrom<&[u8]> ExId` implementing a canonical serialization which includes a version tag, giveing us compatibility options if we decide to change the implementation.