### PR TITLE
Add workflow to generate a `wasm` release when pushing new version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,96 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check_if_wasm_version_upgraded:
+    name: Check if WASM version has been upgraded
+    runs-on: ubuntu-latest
+    outputs:
+      wasm_version: ${{ steps.version-updated.outputs.current-package-version }}
+      wasm_has_updated: ${{ steps.version-updated.outputs.has-updated }}
+    steps:
+      - uses: JiPaix/package-json-updated-action@v1.0.3
+        id: version-updated
+        with:
+          path: rust/automerge-wasm/package.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_PATH: ${{ github.workspace }}/rust/automerge-wasm/package.json
+  publish-wasm:
+    runs-on: ubuntu-latest
+    needs:
+      - check_if_wasm_version_upgraded
+    # We create release only if the version in the package.json has been upgraded
+    if: needs.check_if_wasm_version_upgraded.outputs.wasm_has_updated
+    steps:
+      - uses: denoland/setup-deno@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Get rid of local github workflows
+        run: rm -r .github/workflows
+      - name: Remove tmp_branch if it exists
+        run: git push origin :tmp_branch || true
+      - run: git checkout -b tmp_branch
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli wasm-opt
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - name: run wasm js tests
+        id: wasm_js_tests
+        run: ./scripts/ci/wasm_tests
+      - name: run wasm deno tests
+        id: wasm_deno_tests
+        run: ./scripts/ci/deno_tests
+      - name: Collate deno release files
+        if: steps.wasm_js_tests.outcome == 'success' && steps.wasm_deno_tests.outcome == 'success'
+        run: |
+          mkdir $GITHUB_WORKSPACE/deno_wasm_dist
+          cp $GITHUB_WORKSPACE/rust/automerge-wasm/deno/* $GITHUB_WORKSPACE/deno_wasm_dist
+          cp $GITHUB_WORKSPACE/rust/automerge-wasm/index.d.ts $GITHUB_WORKSPACE/deno_wasm_dist
+          sed -i '1i /// <reference types="./index.d.ts" />' $GITHUB_WORKSPACE/deno_wasm_dist/automerge_wasm.js
+      - name: Create npm release
+        if: steps.wasm_js_tests.outcome == 'success' && steps.wasm_deno_tests.outcome == 'success'
+        run: |
+          if [ "$(npm --prefix $GITHUB_WORKSPACE/rust/automerge-wasm show . version)" = "$VERSION" ]; then
+            echo "This version is already published"
+            exit 0
+          fi
+          EXTRA_ARGS="--access public"
+          if [[ $VERSION == *"alpha."* ]] || [[ $VERSION == *"beta."* ]] || [[ $VERSION == *"rc."* ]]; then
+            echo "Is pre-release version"
+            EXTRA_ARGS="$EXTRA_ARGS --tag next"
+          fi
+          if [ "$NODE_AUTH_TOKEN" = "" ]; then
+            echo "Can't publish on NPM, You need a NPM_TOKEN secret."
+            false
+          fi
+          npm --prefix $GITHUB_WORKSPACE/rust/automerge-wasm publish $EXTRA_ARGS
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          VERSION: ${{ needs.check_if_wasm_version_upgraded.outputs.wasm_version }}
+      - name: Commit wasm deno release files
+        run: |
+          git config --global user.name "actions"
+          git config --global user.email actions@github.com
+          git add $GITHUB_WORKSPACE/deno_wasm_dist
+          git commit -am "Add deno release files"
+          git push origin tmp_branch
+      - name: Tag wasm release
+        if: steps.wasm_js_tests.outcome == 'success' && steps.wasm_deno_tests.outcome == 'success'
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Automerge Wasm v${{ needs.check_if_wasm_version_upgraded.outputs.wasm_version }}
+          tag_name: js/automerge-wasm-${{ needs.check_if_wasm_version_upgraded.outputs.wasm_version }}
+          target_commitish: tmp_branch
+          generate_release_notes: false
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove tmp_branch
+        run: git push origin :tmp_branch
+


### PR DESCRIPTION
This is a first step to automating `automerge` releases for both npm and deno. Changing the version number in the wasm `package.json` file will trigger a build and then push code to both npm and deno.land.