### PR TITLE
Update patch types

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -41,7 +41,8 @@ import type {
 export type {
   PutPatch,
   DelPatch,
-  SplicePatch,
+  SpliceTextPatch,
+  InsertPatch,
   IncPatch,
   SyncMessage,
 } from "@automerge/automerge-wasm"

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -70,7 +70,8 @@ export type Conflicts = { [key: string]: AutomergeValue }
 export type {
   PutPatch,
   DelPatch,
-  SplicePatch,
+  SpliceTextPatch,
+  InsertPatch,
   IncPatch,
   SyncMessage,
 } from "@automerge/automerge-wasm"

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -115,7 +115,7 @@ export type DelPatch = {
   length?: number,
 }
 
-export type SplicePatch = {
+export type SpliceTextPatch = {
   action: 'splice'
   path: Prop[],
   value: string,

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -94,7 +94,7 @@ export type Op = {
   pred: string[],
 }
 
-export type Patch =  PutPatch | DelPatch | SplicePatch | IncPatch | InsertPatch;
+export type Patch =  PutPatch | DelPatch | SpliceTextPatch | IncPatch | InsertPatch;
 
 export type PutPatch = {
   action: 'put'

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -94,7 +94,7 @@ export type Op = {
   pred: string[],
 }
 
-export type Patch =  PutPatch | DelPatch | SplicePatch | IncPatch;
+export type Patch =  PutPatch | DelPatch | SplicePatch | IncPatch | InsertPatch;
 
 export type PutPatch = {
   action: 'put'
@@ -117,6 +117,12 @@ export type DelPatch = {
 
 export type SplicePatch = {
   action: 'splice'
+  path: Prop[],
+  value: string,
+}
+
+export type InsertPatch = {
+  action: 'insert'
   path: Prop[],
   values: Value[],
 }


### PR DESCRIPTION
Added new `InsertPatch` type, which now applies to inserts on `Text` and `List`/`Sequence` elements.
Added new `SpliceTextPatch` type which is produced when text is added to a `TextV2` string element.
Removed `SplicePatch` type, which no longer exists.