### PR TITLE
fix: don't panic when generating parents for hidden objects

### DIFF
--- a/rust/automerge/src/op_set.rs
+++ b/rust/automerge/src/op_set.rs
@@ -89,15 +89,17 @@ impl OpSetInternal {
         })
     }
 
-    pub(crate) fn export_key(&self, obj: ObjId, key: Key, encoding: ListEncoding) -> Prop {
+    pub(crate) fn export_key(&self, obj: ObjId, key: Key, encoding: ListEncoding) -> Option<Prop> {
         match key {
-            Key::Map(m) => Prop::Map(self.m.props.get(m).into()),
+            Key::Map(m) => self.m.props.safe_get(m).map(|s| Prop::Map(s.to_string())),
             Key::Seq(opid) => {
-                let i = self
-                    .search(&obj, query::ElemIdPos::new(opid, encoding))
-                    .index()
-                    .unwrap();
-                Prop::Seq(i)
+                if opid.is_head() {
+                    Some(Prop::Seq(0))
+                } else {
+                    self.search(&obj, query::ElemIdPos::new(opid, encoding))
+                        .index()
+                        .map(Prop::Seq)
+                }
             }
         }
     }

--- a/rust/automerge/src/query.rs
+++ b/rust/automerge/src/query.rs
@@ -114,7 +114,7 @@ pub(crate) struct Index {
     pub(crate) visible16: usize,
     pub(crate) visible8: usize,
     /// Set of opids found in this node and below.
-    pub(crate) ops: HashSet<OpId, FxBuildHasher>,
+    ops: HashSet<OpId, FxBuildHasher>,
 }
 
 impl Index {
@@ -138,6 +138,11 @@ impl Index {
 
     pub(crate) fn has_visible(&self, seen: &Key) -> bool {
         self.visible.contains_key(seen)
+    }
+
+    /// Whether `opid` is in this node or any below it
+    pub(crate) fn has_op(&self, opid: &OpId) -> bool {
+        self.ops.contains(opid)
     }
 
     pub(crate) fn change_vis<'a>(


### PR DESCRIPTION
Problem: the `OpSet::export_key` method uses `query::ElemIdPos` to determine the index of sequence elements when exporting a key. This query returned `None` for invisible elements. The `Parents` iterator which is used to generate paths to objects in patches in `automerge-wasm` used `export_key`. The end result is that applying a remote change which deletes an object in a sequence would panic as it tries to generate a path for an invisible object.

Solution: modify `query::ElemIdPos` to include invisible objects. This does mean that the path generated will refer to the previous visible object in the sequence as it's index, but this is probably fine as for an invisible object the path shouldn't be used anyway.

While we're here also change the return value of `OpSet::export_key` to an `Option` and make `query::Index::ops` private as obeisance to the Lady of the Golden Blade.