### PR TITLE
Various CI script fixes

### DIFF
--- a/javascript/.prettierignore
+++ b/javascript/.prettierignore
@@ -1,3 +1,4 @@
 e2e/verdacciodb
 dist
 docs
+deno_dist

--- a/javascript/scripts/denoify-replacer.mjs
+++ b/javascript/scripts/denoify-replacer.mjs
@@ -12,7 +12,7 @@ makeThisModuleAnExecutableReplacer(
       case "@automerge/automerge-wasm":
         {
           const moduleRoot =
-            process.env.MODULE_ROOT ||
+            process.env.ROOT_MODULE ||
             `https://deno.land/x/automerge_wasm@${version}`
           /*
            *We expect not to run against statements like

--- a/scripts/ci/cmake-build
+++ b/scripts/ci/cmake-build
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eoux pipefail
 
-THIS_SCRIPT=$(dirname "$0");
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 # \note CMake's default build types are "Debug", "MinSizeRel", "Release" and
 # "RelWithDebInfo" but custom ones can also be defined so we pass it verbatim.
 BUILD_TYPE=$1;

--- a/scripts/ci/deno_tests
+++ b/scripts/ci/deno_tests
@@ -1,17 +1,21 @@
-THIS_SCRIPT=$(dirname "$0");
+#!/usr/bin/env bash
+set -eou pipefail
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WASM_PROJECT=$THIS_SCRIPT/../../rust/automerge-wasm;
 JS_PROJECT=$THIS_SCRIPT/../../javascript;
+E2E_PROJECT=$THIS_SCRIPT/../../javascript/e2e;
 
-echo "Running Wasm Deno tests";
-yarn --cwd $WASM_PROJECT install;
-yarn --cwd $WASM_PROJECT build;
-deno test $WASM_PROJECT/deno-tests/deno.ts --allow-read;
-
-cp $WASM_PROJECT/index.d.ts $WASM_PROJECT/deno;
+echo "building wasm and js"
+yarn --cwd $E2E_PROJECT install;
+yarn --cwd $E2E_PROJECT e2e buildjs;
+cp $WASM_PROJECT/index.d.ts $WASM_PROJECT/deno/;
 sed -i '1i /// <reference types="./index.d.ts" />' $WASM_PROJECT/deno/automerge_wasm.js;
 
+echo "Running Wasm Deno tests";
+deno test $WASM_PROJECT/deno-tests/deno.ts --allow-read;
+
 echo "Running JS Deno tests";
-yarn --cwd $JS_PROJECT install;
 ROOT_MODULE=$WASM_PROJECT/deno yarn --cwd $JS_PROJECT deno:build;
 yarn --cwd $JS_PROJECT deno:test;
 

--- a/scripts/ci/fmt_js
+++ b/scripts/ci/fmt_js
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -eoux pipefail
 
-yarn --cwd javascript prettier -c .
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+yarn --cwd $THIS_SCRIPT/../../javascript prettier -c .
 

--- a/scripts/ci/js_tests
+++ b/scripts/ci/js_tests
@@ -1,6 +1,8 @@
-set -e
+#!/usr/bin/env bash
+set -eoux pipefail
 
-THIS_SCRIPT=$(dirname "$0");
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WASM_PROJECT=$THIS_SCRIPT/../../rust/automerge-wasm;
 JS_PROJECT=$THIS_SCRIPT/../../javascript;
 E2E_PROJECT=$THIS_SCRIPT/../../javascript/e2e;

--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eoux pipefail
 
-cd rust
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+cd $THIS_SCRIPT/../../rust
 # Force clippy to consider all local sources
 # https://github.com/rust-lang/rust-clippy/issues/4612
 find . -name "*.rs" -not -path "./target/*" -exec touch "{}" +

--- a/scripts/ci/rust-docs
+++ b/scripts/ci/rust-docs
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eoux pipefail
 
-cd rust
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+cd $THIS_SCRIPT/../../rust
 RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links -D warnings" \
 cargo doc --no-deps --workspace --document-private-items

--- a/scripts/ci/wasm_tests
+++ b/scripts/ci/wasm_tests
@@ -1,4 +1,5 @@
-THIS_SCRIPT=$(dirname "$0");
+# see https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+THIS_SCRIPT="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WASM_PROJECT=$THIS_SCRIPT/../../rust/automerge-wasm;
 
 yarn --cwd $WASM_PROJECT install;


### PR DESCRIPTION
Some of the scripts in scripts/ci were not reliable detecting the path they were operating in. Additionally the deno_tests script was not correctly picking up the ROOT_MODULE environment variable. Add more robust path handling and fix the deno_tests script.