### PR TITLE
Fix and simplify lebsize calculations

### DIFF
--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1413,6 +1413,12 @@ fn invalid_deflate_stream() {
 }
 
 #[test]
+fn negative_64() {
+    let mut doc = Automerge::new();
+    assert!(doc.transact(|d| { d.put(ROOT, "a", -64_i64) }).is_ok())
+}
+
+#[test]
 fn bad_change_on_optree_node_boundary() {
     let mut doc = Automerge::new();
     doc.transact::<_, _, AutomergeError>(|d| {


### PR DESCRIPTION
Before this change numbits_i64() was incorrect for every value of the
form 0 - 2^x. This only manifested in a visible error if x%7 == 6 (so
for -64, -8192, etc.) at which point `lebsize` would return a value one
too large, causing a panic in commit().
