### PR TITLE
Add From<SmolStr> for ScalarValue::Str

### DIFF
--- a/rust/automerge/src/value.rs
+++ b/rust/automerge/src/value.rs
@@ -266,6 +266,12 @@ impl<'a> From<String> for Value<'a> {
     }
 }
 
+impl<'a> From<SmolStr> for Value<'a> {
+    fn from(s: SmolStr) -> Self {
+        Value::Scalar(Cow::Owned(ScalarValue::Str(s)))
+    }
+}
+
 impl<'a> From<char> for Value<'a> {
     fn from(c: char) -> Self {
         Value::Scalar(Cow::Owned(ScalarValue::Str(SmolStr::new(c.to_string()))))


### PR DESCRIPTION
This makes it easier to use `SmolStr`s directly and pass them into automerge.