### PR TITLE
bail after 100 patches, im:: clocks

### DIFF
--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -574,6 +574,12 @@ impl Automerge {
         let mut object = object
             .dyn_into::<Object>()
             .map_err(|_| error::ApplyPatch::NotObjectd)?;
+
+        if self.doc.observer().has_overflowed() {
+            self.doc.observer().enable(true);
+            return Ok(self.export_object(&am::ROOT, Datatype::Map, None, &meta)?);
+        }
+
         let patches = self.doc.observer().take_patches();
         let callback = callback.dyn_into::<Function>().ok();
 

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -31,6 +31,7 @@ dot = { version = "0.1.4", optional = true }
 js-sys = { version = "^0.3", optional = true }
 wasm-bindgen = { version = "^0.2", optional = true }
 rand = { version = "^0.8.4", optional = true }
+im = "15.1.0"
 
 [dependencies.web-sys]
 version = "^0.3.55"

--- a/rust/automerge/src/clock.rs
+++ b/rust/automerge/src/clock.rs
@@ -1,6 +1,6 @@
 use crate::types::OpId;
 use fxhash::FxBuildHasher;
-use std::{cmp::Ordering, collections::HashMap};
+use std::cmp::Ordering;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ClockData {
@@ -19,7 +19,7 @@ impl PartialOrd for ClockData {
 
 /// Vector clock mapping actor indices to the max op counter of the changes created by that actor.
 #[derive(Default, Debug, Clone, PartialEq)]
-pub(crate) struct Clock(HashMap<usize, ClockData, FxBuildHasher>);
+pub(crate) struct Clock(im::hashmap::HashMap<usize, ClockData, FxBuildHasher>);
 
 // A general clock is greater if it has one element the other does not or has a counter higher than
 // the other for a given actor.


### PR DESCRIPTION
Currently I bail on patches when 100 have queued and then just reconstruct the document from scratch.  For sure we need a better heuristic than that but this is a first draft and solves a serious issue. 

Pre-computing a clock for every change when clocks have hundreds of actors was spending a lot of time copying memory around.  I switched to immutable HashMap to share common data and got a very large speedup.   There are a bunch of other low hanging optimizations but I think we need to see if we can figure out how to be performant without pre-computed clocks.