### PR TITLE
automerge-rs: Introduce ReadDoc and SyncDoc traits and add documentation

### DIFF
--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -1,5 +1,7 @@
 use automerge as am;
+use automerge::sync::SyncDoc;
 use automerge::transaction::{CommitOptions, Transactable};
+use automerge::ReadDoc;
 use std::ops::{Deref, DerefMut};
 
 use crate::actor_id::{to_actor_id, AMactorId};
@@ -291,7 +293,7 @@ pub unsafe extern "C" fn AMgenerateSyncMessage(
 ) -> *mut AMresult {
     let doc = to_doc_mut!(doc);
     let sync_state = to_sync_state_mut!(sync_state);
-    to_result(doc.generate_sync_message(sync_state.as_mut()))
+    to_result(doc.sync().generate_sync_message(sync_state.as_mut()))
 }
 
 /// \memberof AMdoc
@@ -708,7 +710,10 @@ pub unsafe extern "C" fn AMreceiveSyncMessage(
     let doc = to_doc_mut!(doc);
     let sync_state = to_sync_state_mut!(sync_state);
     let sync_message = to_sync_message!(sync_message);
-    to_result(doc.receive_sync_message(sync_state.as_mut(), sync_message.as_ref().clone()))
+    to_result(
+        doc.sync()
+            .receive_sync_message(sync_state.as_mut(), sync_message.as_ref().clone()),
+    )
 }
 
 /// \memberof AMdoc

--- a/rust/automerge-c/src/doc/list.rs
+++ b/rust/automerge-c/src/doc/list.rs
@@ -1,5 +1,6 @@
 use automerge as am;
 use automerge::transaction::Transactable;
+use automerge::ReadDoc;
 
 use crate::byte_span::{to_str, AMbyteSpan};
 use crate::change_hashes::AMchangeHashes;

--- a/rust/automerge-c/src/doc/map.rs
+++ b/rust/automerge-c/src/doc/map.rs
@@ -1,5 +1,6 @@
 use automerge as am;
 use automerge::transaction::Transactable;
+use automerge::ReadDoc;
 
 use crate::byte_span::{to_str, AMbyteSpan};
 use crate::change_hashes::AMchangeHashes;

--- a/rust/automerge-cli/src/export.rs
+++ b/rust/automerge-cli/src/export.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use automerge as am;
+use automerge::ReadDoc;
 
 use crate::{color_json::print_colored_json, SkipVerifyFlag};
 

--- a/rust/automerge-test/src/lib.rs
+++ b/rust/automerge-test/src/lib.rs
@@ -4,6 +4,8 @@ use std::{
     hash::Hash,
 };
 
+use automerge::ReadDoc;
+
 use serde::ser::{SerializeMap, SerializeSeq};
 
 pub fn new_doc() -> automerge::AutoCommit {
@@ -48,7 +50,7 @@ pub fn sorted_actors() -> (automerge::ActorId, automerge::ActorId) {
 /// let title = doc.put(todo, "title", "water plants").unwrap();
 ///
 /// assert_doc!(
-///     &doc.document(),
+///     &doc,
 ///     map!{
 ///         "todos" => {
 ///             list![
@@ -67,6 +69,7 @@ pub fn sorted_actors() -> (automerge::ActorId, automerge::ActorId) {
 /// ```rust
 /// # use automerge_test::{assert_doc, map};
 /// # use automerge::transaction::Transactable;
+/// # use automerge::ReadDoc;
 ///
 /// let mut doc1 = automerge::AutoCommit::new();
 /// let mut doc2 = automerge::AutoCommit::new();
@@ -74,7 +77,7 @@ pub fn sorted_actors() -> (automerge::ActorId, automerge::ActorId) {
 /// doc2.put(automerge::ROOT, "field", "two").unwrap();
 /// doc1.merge(&mut doc2);
 /// assert_doc!(
-///     &doc1.document(),
+///     doc1.document(),
 ///     map!{
 ///         "field" => {
 ///             "one",
@@ -330,12 +333,12 @@ impl serde::Serialize for RealizedObject {
     }
 }
 
-pub fn realize(doc: &automerge::Automerge) -> RealizedObject {
+pub fn realize<R: ReadDoc>(doc: &R) -> RealizedObject {
     realize_obj(doc, &automerge::ROOT, automerge::ObjType::Map)
 }
 
-pub fn realize_prop<P: Into<automerge::Prop>>(
-    doc: &automerge::Automerge,
+pub fn realize_prop<R: ReadDoc, P: Into<automerge::Prop>>(
+    doc: &R,
     obj_id: &automerge::ObjId,
     prop: P,
 ) -> RealizedObject {
@@ -346,8 +349,8 @@ pub fn realize_prop<P: Into<automerge::Prop>>(
     }
 }
 
-pub fn realize_obj(
-    doc: &automerge::Automerge,
+pub fn realize_obj<R: ReadDoc>(
+    doc: &R,
     obj_id: &automerge::ObjId,
     objtype: automerge::ObjType,
 ) -> RealizedObject {
@@ -370,8 +373,8 @@ pub fn realize_obj(
     }
 }
 
-fn realize_values<K: Into<automerge::Prop>>(
-    doc: &automerge::Automerge,
+fn realize_values<R: ReadDoc, K: Into<automerge::Prop>>(
+    doc: &R,
     obj_id: &automerge::ObjId,
     key: K,
 ) -> BTreeSet<RealizedObject> {

--- a/rust/automerge-wasm/src/interop.rs
+++ b/rust/automerge-wasm/src/interop.rs
@@ -2,7 +2,7 @@ use crate::error::InsertObject;
 use crate::value::Datatype;
 use crate::{Automerge, TextRepresentation};
 use automerge as am;
-use automerge::transaction::Transactable;
+use automerge::ReadDoc;
 use automerge::ROOT;
 use automerge::{Change, ChangeHash, ObjType, Prop};
 use js_sys::{Array, Function, JsString, Object, Reflect, Symbol, Uint8Array};

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -29,7 +29,7 @@ use am::transaction::CommitOptions;
 use am::transaction::{Observed, Transactable, UnObserved};
 use am::ScalarValue;
 use automerge as am;
-use automerge::{Change, ObjId, Prop, TextEncoding, Value, ROOT};
+use automerge::{sync::SyncDoc, Change, ObjId, Prop, ReadDoc, TextEncoding, Value, ROOT};
 use js_sys::{Array, Function, Object, Uint8Array};
 use serde::ser::Serialize;
 use std::borrow::Cow;
@@ -746,13 +746,15 @@ impl Automerge {
     ) -> Result<(), error::ReceiveSyncMessage> {
         let message = message.to_vec();
         let message = am::sync::Message::decode(message.as_slice())?;
-        self.doc.receive_sync_message(&mut state.0, message)?;
+        self.doc
+            .sync()
+            .receive_sync_message(&mut state.0, message)?;
         Ok(())
     }
 
     #[wasm_bindgen(js_name = generateSyncMessage)]
     pub fn generate_sync_message(&mut self, state: &mut SyncState) -> JsValue {
-        if let Some(message) = self.doc.generate_sync_message(&mut state.0) {
+        if let Some(message) = self.doc.sync().generate_sync_message(&mut state.0) {
             Uint8Array::from(message.encode().as_slice()).into()
         } else {
             JsValue::null()

--- a/rust/automerge-wasm/src/observer.rs
+++ b/rust/automerge-wasm/src/observer.rs
@@ -6,7 +6,7 @@ use crate::{
     interop::{self, alloc, js_set},
     TextRepresentation,
 };
-use automerge::{Automerge, ObjId, OpObserver, Prop, ScalarValue, SequenceTree, Value};
+use automerge::{ObjId, OpObserver, Prop, ReadDoc, ScalarValue, SequenceTree, Value};
 use js_sys::{Array, Object};
 use wasm_bindgen::prelude::*;
 
@@ -30,9 +30,9 @@ impl Observer {
         old_enabled
     }
 
-    fn get_path(&mut self, doc: &Automerge, obj: &ObjId) -> Option<Vec<(ObjId, Prop)>> {
+    fn get_path<R: ReadDoc>(&mut self, doc: &R, obj: &ObjId) -> Option<Vec<(ObjId, Prop)>> {
         match doc.parents(obj) {
-            Ok(mut parents) => parents.visible_path(),
+            Ok(parents) => parents.visible_path(),
             Err(e) => {
                 automerge::log!("error generating patch : {:?}", e);
                 None
@@ -98,9 +98,9 @@ pub(crate) enum Patch {
 }
 
 impl OpObserver for Observer {
-    fn insert(
+    fn insert<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         obj: ObjId,
         index: usize,
         tagged_value: (Value<'_>, ObjId),
@@ -134,7 +134,7 @@ impl OpObserver for Observer {
         }
     }
 
-    fn splice_text(&mut self, doc: &Automerge, obj: ObjId, index: usize, value: &str) {
+    fn splice_text<R: ReadDoc>(&mut self, doc: &R, obj: ObjId, index: usize, value: &str) {
         if self.enabled {
             if self.text_rep == TextRepresentation::Array {
                 for (i, c) in value.chars().enumerate() {
@@ -182,7 +182,7 @@ impl OpObserver for Observer {
         }
     }
 
-    fn delete_seq(&mut self, doc: &Automerge, obj: ObjId, index: usize, length: usize) {
+    fn delete_seq<R: ReadDoc>(&mut self, doc: &R, obj: ObjId, index: usize, length: usize) {
         if self.enabled {
             match self.patches.last_mut() {
                 Some(Patch::SpliceText {
@@ -244,7 +244,7 @@ impl OpObserver for Observer {
         }
     }
 
-    fn delete_map(&mut self, doc: &Automerge, obj: ObjId, key: &str) {
+    fn delete_map<R: ReadDoc>(&mut self, doc: &R, obj: ObjId, key: &str) {
         if self.enabled {
             if let Some(path) = self.get_path(doc, &obj) {
                 let patch = Patch::DeleteMap {
@@ -257,9 +257,9 @@ impl OpObserver for Observer {
         }
     }
 
-    fn put(
+    fn put<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         obj: ObjId,
         prop: Prop,
         tagged_value: (Value<'_>, ObjId),
@@ -290,9 +290,9 @@ impl OpObserver for Observer {
         }
     }
 
-    fn expose(
+    fn expose<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         obj: ObjId,
         prop: Prop,
         tagged_value: (Value<'_>, ObjId),
@@ -323,7 +323,13 @@ impl OpObserver for Observer {
         }
     }
 
-    fn increment(&mut self, doc: &Automerge, obj: ObjId, prop: Prop, tagged_value: (i64, ObjId)) {
+    fn increment<R: ReadDoc>(
+        &mut self,
+        doc: &R,
+        obj: ObjId,
+        prop: Prop,
+        tagged_value: (i64, ObjId),
+    ) {
         if self.enabled {
             if let Some(path) = self.get_path(doc, &obj) {
                 let value = tagged_value.0;
@@ -337,6 +343,12 @@ impl OpObserver for Observer {
         }
     }
 
+    fn text_as_seq(&self) -> bool {
+        self.text_rep == TextRepresentation::Array
+    }
+}
+
+impl automerge::op_observer::BranchableObserver for Observer {
     fn merge(&mut self, other: &Self) {
         self.patches.extend_from_slice(other.patches.as_slice())
     }
@@ -347,10 +359,6 @@ impl OpObserver for Observer {
             enabled: self.enabled,
             text_rep: self.text_rep,
         }
-    }
-
-    fn text_as_seq(&self) -> bool {
-        self.text_rep == TextRepresentation::Array
     }
 }
 

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/automerge/automerge-rs"
 documentation = "https://automerge.org/automerge-rs/automerge/"
 rust-version = "1.57.0"
 description = "A JSON-like data structure (a CRDT) that can be modified concurrently by different users, and merged again automatically"
+readme = "./README.md"
 
 [features]
 optree-visualisation = ["dot", "rand"]

--- a/rust/automerge/README.md
+++ b/rust/automerge/README.md
@@ -1,0 +1,5 @@
+# Automerge
+
+Automerge is a library of data structures for building collaborative
+[local-first](https://www.inkandswitch.com/local-first/) applications. This is
+the Rust implementation. See [automerge.org](https://automerge.org/) 

--- a/rust/automerge/benches/range.rs
+++ b/rust/automerge/benches/range.rs
@@ -1,4 +1,4 @@
-use automerge::{transaction::Transactable, Automerge, ROOT};
+use automerge::{transaction::Transactable, Automerge, ReadDoc, ROOT};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn doc(n: u64) -> Automerge {
@@ -16,18 +16,8 @@ fn range(doc: &Automerge) {
     range.for_each(drop);
 }
 
-fn range_rev(doc: &Automerge) {
-    let range = doc.values(ROOT).rev();
-    range.for_each(drop);
-}
-
 fn range_at(doc: &Automerge) {
     let range = doc.values_at(ROOT, &doc.get_heads());
-    range.for_each(drop);
-}
-
-fn range_at_rev(doc: &Automerge) {
-    let range = doc.values_at(ROOT, &doc.get_heads()).rev();
     range.for_each(drop);
 }
 
@@ -37,14 +27,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function(&format!("range {}", n), |b| {
         b.iter(|| range(black_box(&doc)))
     });
-    c.bench_function(&format!("range rev {}", n), |b| {
-        b.iter(|| range_rev(black_box(&doc)))
-    });
     c.bench_function(&format!("range_at {}", n), |b| {
         b.iter(|| range_at(black_box(&doc)))
-    });
-    c.bench_function(&format!("range_at rev {}", n), |b| {
-        b.iter(|| range_at_rev(black_box(&doc)))
     });
 }
 

--- a/rust/automerge/benches/sync.rs
+++ b/rust/automerge/benches/sync.rs
@@ -1,4 +1,8 @@
-use automerge::{sync, transaction::Transactable, Automerge, ROOT};
+use automerge::{
+    sync::{self, SyncDoc},
+    transaction::Transactable,
+    Automerge, ROOT,
+};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 #[derive(Default)]

--- a/rust/automerge/examples/quickstart.rs
+++ b/rust/automerge/examples/quickstart.rs
@@ -2,7 +2,7 @@ use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
 use automerge::AutomergeError;
 use automerge::ObjType;
-use automerge::{Automerge, ROOT};
+use automerge::{Automerge, ReadDoc, ROOT};
 
 // Based on https://automerge.github.io/docs/quickstart
 fn main() {

--- a/rust/automerge/examples/watch.rs
+++ b/rust/automerge/examples/watch.rs
@@ -3,6 +3,7 @@ use automerge::transaction::Transactable;
 use automerge::Automerge;
 use automerge::AutomergeError;
 use automerge::Patch;
+use automerge::ReadDoc;
 use automerge::VecOpObserver;
 use automerge::ROOT;
 

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1,10 +1,12 @@
 use std::ops::RangeBounds;
 
 use crate::exid::ExId;
-use crate::op_observer::OpObserver;
+use crate::op_observer::{BranchableObserver, OpObserver};
+use crate::sync::SyncDoc;
 use crate::transaction::{CommitOptions, Transactable};
 use crate::{
-    sync, Keys, KeysAt, ListRange, ListRangeAt, MapRange, MapRangeAt, ObjType, Parents, ScalarValue,
+    sync, Keys, KeysAt, ListRange, ListRangeAt, MapRange, MapRangeAt, ObjType, Parents, ReadDoc,
+    ScalarValue,
 };
 use crate::{
     transaction::{Observation, Observed, TransactionInner, UnObserved},
@@ -12,6 +14,41 @@ use crate::{
 };
 
 /// An automerge document that automatically manages transactions.
+///
+/// An `AutoCommit` can optionally manage an [`OpObserver`]. This observer will be notified of all
+/// changes made by both remote and local changes. The type parameter `O` tracks whether this
+/// document is observed or not.
+///
+/// ## Creating, loading, merging and forking documents
+///
+/// A new document can be created with [`Self::new`], which will create a document with a random
+/// [`ActorId`]. Existing documents can be loaded with [`Self::load`].
+///
+/// If you have two documents and you want to merge the changes from one into the other you can use
+/// [`Self::merge`].
+///
+/// If you have a document you want to split into two concurrent threads of execution you can use
+/// [`Self::fork`]. If you want to split a document from ealier in its history you can use
+/// [`Self::fork_at`].
+///
+/// ## Reading values
+///
+/// [`Self`] implements [`ReadDoc`], which provides methods for reading values from the document.
+///
+/// ## Modifying a document
+///
+/// This type implements [`Transactable`] directly, so you can modify it using methods from [`Transactable`].
+///
+/// ## Synchronization
+///
+/// To synchronise call [`Self::sync`] which returns an implementation of [`SyncDoc`]
+///
+/// ## Observers
+///
+/// An `AutoCommit` can optionally manage an [`OpObserver`]. [`Self::new`] will return a document
+/// with no observer but you can set an observer using [`Self::with_observer`]. The observer must
+/// implement both [`OpObserver`] and [`BranchableObserver`]. If you have an observed autocommit
+/// then you can obtain a mutable reference to the observer with [`Self::observer`]
 #[derive(Debug, Clone)]
 pub struct AutoCommitWithObs<Obs: Observation> {
     doc: Automerge,
@@ -19,19 +56,12 @@ pub struct AutoCommitWithObs<Obs: Observation> {
     observation: Obs,
 }
 
+/// An autocommit document with no observer
+///
+/// See [`AutoCommitWithObs`]
 pub type AutoCommit = AutoCommitWithObs<UnObserved>;
 
-impl<O: Observation> AutoCommitWithObs<O> {
-    pub fn unobserved() -> AutoCommitWithObs<UnObserved> {
-        AutoCommitWithObs {
-            doc: Automerge::new(),
-            transaction: None,
-            observation: UnObserved::new(),
-        }
-    }
-}
-
-impl<O: OpObserver + Default> Default for AutoCommitWithObs<Observed<O>> {
+impl<O: OpObserver + BranchableObserver + Default> Default for AutoCommitWithObs<Observed<O>> {
     fn default() -> Self {
         let op_observer = O::default();
         AutoCommitWithObs {
@@ -61,7 +91,7 @@ impl AutoCommit {
     }
 }
 
-impl<Obs: OpObserver> AutoCommitWithObs<Observed<Obs>> {
+impl<Obs: OpObserver + BranchableObserver> AutoCommitWithObs<Observed<Obs>> {
     pub fn observer(&mut self) -> &mut Obs {
         self.ensure_transaction_closed();
         self.observation.observer()
@@ -89,7 +119,7 @@ impl<Obs: Observation + Clone> AutoCommitWithObs<Obs> {
 }
 
 impl<Obs: Observation> AutoCommitWithObs<Obs> {
-    pub fn with_observer<Obs2: OpObserver>(
+    pub fn with_observer<Obs2: OpObserver + BranchableObserver>(
         self,
         op_observer: Obs2,
     ) -> AutoCommitWithObs<Observed<Obs2>> {
@@ -125,6 +155,9 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         self.doc.get_actor()
     }
 
+    /// Change the text encoding of this view of the document
+    ///
+    /// This is a cheap operation, it just changes the way indexes are calculated
     pub fn with_encoding(mut self, encoding: TextEncoding) -> Self {
         self.doc.text_encoding = encoding;
         self
@@ -145,6 +178,13 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         }
     }
 
+    /// Load an incremental save of a document.
+    ///
+    /// Unlike `load` this imports changes into an existing document. It will work with both the
+    /// output of [`Self::save`] and [`Self::save_incremental`]
+    ///
+    /// The return value is the number of ops which were applied, this is not useful and will
+    /// change in future.
     pub fn load_incremental(&mut self, data: &[u8]) -> Result<usize, AutomergeError> {
         self.ensure_transaction_closed();
         // TODO - would be nice to pass None here instead of &mut ()
@@ -181,17 +221,24 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         }
     }
 
+    /// Save the entirety of this document in a compact form.
     pub fn save(&mut self) -> Vec<u8> {
         self.ensure_transaction_closed();
         self.doc.save()
     }
 
+    /// Save this document, but don't run it through DEFLATE afterwards
     pub fn save_nocompress(&mut self) -> Vec<u8> {
         self.ensure_transaction_closed();
         self.doc.save_nocompress()
     }
 
-    // should this return an empty vec instead of None?
+    /// Save the changes since the last call to [Self::save`]
+    ///
+    /// The output of this will not be a compressed document format, but a series of individual
+    /// changes. This is useful if you know you have only made a small change since the last `save`
+    /// and you want to immediately send it somewhere (e.g. you've inserted a single character in a
+    /// text object).
     pub fn save_incremental(&mut self) -> Vec<u8> {
         self.ensure_transaction_closed();
         self.doc.save_incremental()
@@ -202,6 +249,7 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         self.doc.get_missing_deps(heads)
     }
 
+    /// Get the last change made by this documents actor ID
     pub fn get_last_local_change(&mut self) -> Option<&Change> {
         self.ensure_transaction_closed();
         self.doc.get_last_local_change()
@@ -220,38 +268,22 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         self.doc.get_change_by_hash(hash)
     }
 
+    /// Get changes in `other` that are not in `self
     pub fn get_changes_added<'a>(&mut self, other: &'a mut Self) -> Vec<&'a Change> {
         self.ensure_transaction_closed();
         other.ensure_transaction_closed();
         self.doc.get_changes_added(&other.doc)
     }
 
+    #[doc(hidden)]
     pub fn import(&self, s: &str) -> Result<(ExId, ObjType), AutomergeError> {
         self.doc.import(s)
     }
 
+    #[doc(hidden)]
     pub fn dump(&mut self) {
         self.ensure_transaction_closed();
         self.doc.dump()
-    }
-
-    pub fn generate_sync_message(&mut self, sync_state: &mut sync::State) -> Option<sync::Message> {
-        self.ensure_transaction_closed();
-        self.doc.generate_sync_message(sync_state)
-    }
-
-    pub fn receive_sync_message(
-        &mut self,
-        sync_state: &mut sync::State,
-        message: sync::Message,
-    ) -> Result<(), AutomergeError> {
-        self.ensure_transaction_closed();
-        if let Some(observer) = self.observation.observer() {
-            self.doc
-                .receive_sync_message_with(sync_state, message, Some(observer))
-        } else {
-            self.doc.receive_sync_message(sync_state, message)
-        }
     }
 
     /// Return a graphviz representation of the opset.
@@ -305,6 +337,7 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         tx.commit(&mut self.doc, options.message, options.time)
     }
 
+    /// Remove any changes that have been made in the current transaction from the document
     pub fn rollback(&mut self) -> usize {
         self.transaction
             .take()
@@ -326,14 +359,24 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
         let args = self.doc.transaction_args();
         TransactionInner::empty(&mut self.doc, args, options.message, options.time)
     }
+
+    /// An implementation of [`crate::sync::SyncDoc`] for this autocommit
+    ///
+    /// This ensures that any outstanding transactions for this document are committed before
+    /// taking part in the sync protocol
+    pub fn sync(&mut self) -> impl SyncDoc + '_ {
+        self.ensure_transaction_closed();
+        SyncWrapper { inner: self }
+    }
 }
 
-impl<Obs: Observation> Transactable for AutoCommitWithObs<Obs> {
-    fn pending_ops(&self) -> usize {
-        self.transaction
-            .as_ref()
-            .map(|(_, t)| t.pending_ops())
-            .unwrap_or(0)
+impl<Obs: Observation> ReadDoc for AutoCommitWithObs<Obs> {
+    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
+        self.doc.parents(obj)
+    }
+
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<(ExId, Prop)>, AutomergeError> {
+        self.doc.path_to_object(obj)
     }
 
     fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_, '_> {
@@ -396,6 +439,69 @@ impl<Obs: Observation> Transactable for AutoCommitWithObs<Obs> {
 
     fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
         self.doc.object_type(obj)
+    }
+
+    fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
+        self.doc.text(obj)
+    }
+
+    fn text_at<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: &[ChangeHash],
+    ) -> Result<String, AutomergeError> {
+        self.doc.text_at(obj, heads)
+    }
+
+    fn get<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
+        self.doc.get(obj, prop)
+    }
+
+    fn get_at<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+        heads: &[ChangeHash],
+    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
+        self.doc.get_at(obj, prop, heads)
+    }
+
+    fn get_all<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
+        self.doc.get_all(obj, prop)
+    }
+
+    fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+        heads: &[ChangeHash],
+    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
+        self.doc.get_all_at(obj, prop, heads)
+    }
+
+    fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash> {
+        self.doc.get_missing_deps(heads)
+    }
+
+    fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&Change> {
+        self.doc.get_change_by_hash(hash)
+    }
+}
+
+impl<Obs: Observation> Transactable for AutoCommitWithObs<Obs> {
+    fn pending_ops(&self) -> usize {
+        self.transaction
+            .as_ref()
+            .map(|(_, t)| t.pending_ops())
+            .unwrap_or(0)
     }
 
     fn put<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
@@ -515,60 +621,52 @@ impl<Obs: Observation> Transactable for AutoCommitWithObs<Obs> {
         )
     }
 
-    fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
-        self.doc.text(obj)
-    }
-
-    fn text_at<O: AsRef<ExId>>(
-        &self,
-        obj: O,
-        heads: &[ChangeHash],
-    ) -> Result<String, AutomergeError> {
-        self.doc.text_at(obj, heads)
-    }
-
-    // TODO - I need to return these OpId's here **only** to get
-    // the legacy conflicts format of { [opid]: value }
-    // Something better?
-    fn get<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
-        self.doc.get(obj, prop)
-    }
-
-    fn get_at<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-        heads: &[ChangeHash],
-    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
-        self.doc.get_at(obj, prop, heads)
-    }
-
-    fn get_all<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
-        self.doc.get_all(obj, prop)
-    }
-
-    fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-        heads: &[ChangeHash],
-    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
-        self.doc.get_all_at(obj, prop, heads)
-    }
-
-    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
-        self.doc.parents(obj)
-    }
-
     fn base_heads(&self) -> Vec<ChangeHash> {
         self.doc.get_heads()
+    }
+}
+
+// A wrapper we return from `AutoCommit::sync` to ensure that transactions are closed before we
+// start syncing
+struct SyncWrapper<'a, Obs: Observation> {
+    inner: &'a mut AutoCommitWithObs<Obs>,
+}
+
+impl<'a, Obs: Observation> SyncDoc for SyncWrapper<'a, Obs> {
+    fn generate_sync_message(&self, sync_state: &mut sync::State) -> Option<sync::Message> {
+        self.inner.doc.generate_sync_message(sync_state)
+    }
+
+    fn receive_sync_message(
+        &mut self,
+        sync_state: &mut sync::State,
+        message: sync::Message,
+    ) -> Result<(), AutomergeError> {
+        self.inner.ensure_transaction_closed();
+        if let Some(observer) = self.inner.observation.observer() {
+            self.inner
+                .doc
+                .receive_sync_message_with(sync_state, message, observer)
+        } else {
+            self.inner.doc.receive_sync_message(sync_state, message)
+        }
+    }
+
+    fn receive_sync_message_with<Obs2: OpObserver>(
+        &mut self,
+        sync_state: &mut sync::State,
+        message: sync::Message,
+        op_observer: &mut Obs2,
+    ) -> Result<(), AutomergeError> {
+        if let Some(our_observer) = self.inner.observation.observer() {
+            let mut composed = crate::op_observer::compose(our_observer, op_observer);
+            self.inner
+                .doc
+                .receive_sync_message_with(sync_state, message, &mut composed)
+        } else {
+            self.inner
+                .doc
+                .receive_sync_message_with(sync_state, message, op_observer)
+        }
     }
 }

--- a/rust/automerge/src/automerge/tests.rs
+++ b/rust/automerge/src/automerge/tests.rs
@@ -1539,7 +1539,7 @@ fn observe_counter_change_application() {
 
 #[test]
 fn get_changes_heads_empty() {
-    let mut doc = AutoCommit::unobserved();
+    let mut doc = AutoCommit::new();
     doc.put(ROOT, "key1", 1).unwrap();
     doc.commit();
     doc.put(ROOT, "key2", 1).unwrap();

--- a/rust/automerge/src/autoserde.rs
+++ b/rust/automerge/src/autoserde.rs
@@ -1,18 +1,33 @@
 use serde::ser::{SerializeMap, SerializeSeq};
 
-use crate::{Automerge, ObjId, ObjType, Value};
+use crate::{ObjId, ObjType, ReadDoc, Value};
 
-/// A wrapper type which implements [`serde::Serialize`] for an [`Automerge`].
+/// A wrapper type which implements [`serde::Serialize`] for a [`ReadDoc`].
+///
+/// # Example
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use automerge::{AutoCommit, AutomergeError, Value, transaction::Transactable};
+/// let mut doc = AutoCommit::new();
+/// doc.put(automerge::ROOT, "key", "value")?;
+///
+/// let serialized = serde_json::to_string(&automerge::AutoSerde::from(&doc)).unwrap();
+///
+/// assert_eq!(serialized, r#"{"key":"value"}"#);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug)]
-pub struct AutoSerde<'a>(&'a Automerge);
+pub struct AutoSerde<'a, R: crate::ReadDoc>(&'a R);
 
-impl<'a> From<&'a Automerge> for AutoSerde<'a> {
-    fn from(a: &'a Automerge) -> Self {
+impl<'a, R: ReadDoc> From<&'a R> for AutoSerde<'a, R> {
+    fn from(a: &'a R) -> Self {
         AutoSerde(a)
     }
 }
 
-impl<'a> serde::Serialize for AutoSerde<'a> {
+impl<'a, R: crate::ReadDoc> serde::Serialize for AutoSerde<'a, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -25,12 +40,12 @@ impl<'a> serde::Serialize for AutoSerde<'a> {
     }
 }
 
-struct AutoSerdeMap<'a> {
-    doc: &'a Automerge,
+struct AutoSerdeMap<'a, R> {
+    doc: &'a R,
     obj: ObjId,
 }
 
-impl<'a> serde::Serialize for AutoSerdeMap<'a> {
+impl<'a, R: crate::ReadDoc> serde::Serialize for AutoSerdeMap<'a, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -51,12 +66,12 @@ impl<'a> serde::Serialize for AutoSerdeMap<'a> {
     }
 }
 
-struct AutoSerdeSeq<'a> {
-    doc: &'a Automerge,
+struct AutoSerdeSeq<'a, R> {
+    doc: &'a R,
     obj: ObjId,
 }
 
-impl<'a> serde::Serialize for AutoSerdeSeq<'a> {
+impl<'a, R: crate::ReadDoc> serde::Serialize for AutoSerdeSeq<'a, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -77,13 +92,13 @@ impl<'a> serde::Serialize for AutoSerdeSeq<'a> {
     }
 }
 
-struct AutoSerdeVal<'a> {
-    doc: &'a Automerge,
+struct AutoSerdeVal<'a, R> {
+    doc: &'a R,
     val: Value<'a>,
     obj: ObjId,
 }
 
-impl<'a> serde::Serialize for AutoSerdeVal<'a> {
+impl<'a, R: crate::ReadDoc> serde::Serialize for AutoSerdeVal<'a, R> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/rust/automerge/src/exid.rs
+++ b/rust/automerge/src/exid.rs
@@ -6,6 +6,10 @@ use std::cmp::{Ord, Ordering};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+/// An identifier for an object in a document
+///
+/// This can be persisted using `to_bytes` and `TryFrom<&[u8]>` breaking changes to the
+/// serialization format will be considered breaking changes for this library version.
 #[derive(Debug, Clone)]
 pub enum ExId {
     Root,
@@ -17,7 +21,10 @@ const TYPE_ROOT: u8 = 0;
 const TYPE_ID: u8 = 1;
 
 impl ExId {
-    /// Serialize the ExId to a byte array.
+    /// Serialize this object ID to a byte array.
+    ///
+    /// This serialization format is versioned and incompatible changes to it will be considered a
+    /// breaking change for the version of this library.
     pub fn to_bytes(&self) -> Vec<u8> {
         // The serialized format is
         //

--- a/rust/automerge/src/keys.rs
+++ b/rust/automerge/src/keys.rs
@@ -1,5 +1,9 @@
 use crate::{query, Automerge};
 
+/// An iterator over the keys of an object
+///
+/// This is returned by [`crate::ReadDoc::keys`] and method. The returned item is either
+/// the keys of a map, or the encoded element IDs of a sequence.
 #[derive(Debug)]
 pub struct Keys<'a, 'k> {
     keys: Option<query::Keys<'k>>,

--- a/rust/automerge/src/keys_at.rs
+++ b/rust/automerge/src/keys_at.rs
@@ -1,5 +1,9 @@
 use crate::{query, Automerge};
 
+/// An iterator over the keys of an object at a particular point in history
+///
+/// This is returned by [`crate::ReadDoc::keys_at`] method. The returned item is either the keys of a map,
+/// or the encoded element IDs of a sequence.
 #[derive(Debug)]
 pub struct KeysAt<'a, 'k> {
     keys: Option<query::KeysAt<'k>>,

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -1,3 +1,190 @@
+//! # Automerge
+//!
+//! Automerge is a library of data structures for building collaborative,
+//! [local-first](https://www.inkandswitch.com/local-first/) applications. The
+//! idea of automerge is to provide a data structure which is quite general,
+//! \- consisting of nested key/value maps and/or lists - which can be modified
+//! entirely locally but which can at any time be merged with other instances of
+//! the same data structure.
+//!
+//! In addition to the core data structure (which we generally refer to as a
+//! "document"), we also provide an implementation of a sync protocol (in
+//! [`crate::sync`]) which can be used over any reliable in-order transport; and
+//! an efficient binary storage format.
+//!
+//! This crate is organised around two representations of a document -
+//! [`Automerge`] and [`AutoCommit`]. The difference between the two is that
+//! [`AutoCommit`] manages transactions for you. Both of these representations
+//! implement [`ReadDoc`] for reading values from a document and
+//! [`sync::SyncDoc`] for taking part in the sync protocol. [`AutoCommit`]
+//! directly implements [`transaction::Transactable`] for making changes to a
+//! document, whilst [`Automerge`] requires you to explicitly create a
+//! [`transaction::Transaction`].
+//!
+//! NOTE: The API this library provides for modifying data is quite low level
+//! (somewhat analogous to directly creating JSON values rather than using
+//! `serde` derive macros or equivalent). If you're writing a Rust application which uses automerge
+//! you may want to look at [autosurgeon](https://github.com/automerge/autosurgeon).
+//!
+//! ## Data Model
+//!
+//! An automerge document is a map from strings to values
+//! ([`Value`]) where values can be either
+//!
+//! * A nested composite value which is either
+//!   * A map from strings to values ([`ObjType::Map`])
+//!   * A list of values ([`ObjType::List`])
+//!   * A text object (a sequence of unicode characters) ([`ObjType::Text`])
+//! * A primitive value ([`ScalarValue`]) which is one of
+//!   * A string
+//!   * A 64 bit floating point number
+//!   * A signed 64 bit integer
+//!   * An unsigned 64 bit integer
+//!   * A boolean
+//!   * A counter object (a 64 bit integer which merges by addition)
+//!     ([`ScalarValue::Counter`])
+//!   * A timestamp (a 64 bit integer which is milliseconds since the unix epoch)
+//!
+//! All composite values have an ID ([`ObjId`]) which is created when the value
+//! is inserted into the document or is the root object ID [`ROOT`]. Values in
+//! the document are then referred to by the pair (`object ID`, `key`). The
+//! `key` is represented by the [`Prop`] type and is either a string for a maps,
+//! or an index for sequences.
+//!
+//! ### Conflicts
+//!
+//! There are some things automerge cannot merge sensibly. For example, two
+//! actors concurrently setting the key "name" to different values. In this case
+//! automerge will pick a winning value in a random but deterministic way, but
+//! the conflicting value is still available via the [`ReadDoc::get_all`] method.
+//!
+//! ### Change hashes and historical values
+//!
+//! Like git, points in the history of a document are identified by hash. Unlike
+//! git there can be multiple hashes representing a particular point (because
+//! automerge supports concurrent changes). These hashes can be obtained using
+//! either [`Automerge::get_heads`] or [`AutoCommit::get_heads`] (note these
+//! methods are not part of [`ReadDoc`] because in the case of [`AutoCommit`] it
+//! requires a mutable reference to the document).
+//!
+//! These hashes can be used to read values from the document at a particular
+//! point in history using the various `*_at` methods on [`ReadDoc`] which take a
+//! slice of [`ChangeHash`] as an argument.
+//!
+//! ### Actor IDs
+//!
+//! Any change to an automerge document is made by an actor, represented by an
+//! [`ActorId`]. An actor ID is any random sequence of bytes but each change by
+//! the same actor ID must be sequential. This often means you will want to
+//! maintain at least one actor ID per device. It is fine to generate a new
+//! actor ID for each change, but be aware that each actor ID takes up space in
+//! a document so if you expect a document to be long lived and/or to have many
+//! changes then you should try to reuse actor IDs where possible.
+//!
+//! ### Text Encoding
+//!
+//! Both [`Automerge`] and [`AutoCommit`] provide a `with_encoding` method which
+//! allows you to specify the [`crate::TextEncoding`] which is used for
+//! interpreting the indexes passed to methods like [`ReadDoc::list_range`] or
+//! [`transaction::Transactable::splice`]. The default encoding is UTF-8, but
+//! you can switch to UTF-16.
+//!
+//! ## Sync Protocol
+//!
+//! See the [`sync`] module.
+//!
+//! ## Serde serialization
+//!
+//! Sometimes you just want to get the JSON value of an automerge document. For
+//! this you can use [`AutoSerde`], which implements `serde::Serialize` for an
+//! automerge document.
+//!
+//! ## Example
+//!
+//! Let's create a document representing an address book.
+//!
+//! ```
+//! use automerge::{ObjType, AutoCommit, transaction::Transactable, ReadDoc};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut doc = AutoCommit::new();
+//!
+//! // `put_object` creates a nested object in the root key/value map and
+//! // returns the ID of the new object, in this case a list.
+//! let contacts = doc.put_object(automerge::ROOT, "contacts", ObjType::List)?;
+//!
+//! // Now we can insert objects into the list
+//! let alice = doc.insert_object(&contacts, 0, ObjType::Map)?;
+//!
+//! // Finally we can set keys in the "alice" map
+//! doc.put(&alice, "name", "Alice")?;
+//! doc.put(&alice, "email", "alice@example.com")?;
+//!
+//! // Create another contact
+//! let bob = doc.insert_object(&contacts, 1, ObjType::Map)?;
+//! doc.put(&bob, "name", "Bob")?;
+//! doc.put(&bob, "email", "bob@example.com")?;
+//!
+//! // Now we save the address book, we can put this in a file
+//! let data: Vec<u8> = doc.save();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Now modify this document on two separate devices and merge the modifications.
+//!
+//! ```
+//! use std::borrow::Cow;
+//! use automerge::{ObjType, AutoCommit, transaction::Transactable, ReadDoc};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let mut doc = AutoCommit::new();
+//! # let contacts = doc.put_object(automerge::ROOT, "contacts", ObjType::List)?;
+//! # let alice = doc.insert_object(&contacts, 0, ObjType::Map)?;
+//! # doc.put(&alice, "name", "Alice")?;
+//! # doc.put(&alice, "email", "alice@example.com")?;
+//! # let bob = doc.insert_object(&contacts, 1, ObjType::Map)?;
+//! # doc.put(&bob, "name", "Bob")?;
+//! # doc.put(&bob, "email", "bob@example.com")?;
+//! # let saved: Vec<u8> = doc.save();
+//!
+//! // Load the document on the first device and change alices email
+//! let mut doc1 = AutoCommit::load(&saved)?;
+//! let contacts = match doc1.get(automerge::ROOT, "contacts")? {
+//!     Some((automerge::Value::Object(ObjType::List), contacts)) => contacts,
+//!     _ => panic!("contacts should be a list"),
+//! };
+//! let alice = match doc1.get(&contacts, 0)? {
+//!    Some((automerge::Value::Object(ObjType::Map), alice)) => alice,
+//!    _ => panic!("alice should be a map"),
+//! };
+//! doc1.put(&alice, "email", "alicesnewemail@example.com")?;
+//!
+//!
+//! // Load the document on the second device and change bobs name
+//! let mut doc2 = AutoCommit::load(&saved)?;
+//! let contacts = match doc2.get(automerge::ROOT, "contacts")? {
+//!    Some((automerge::Value::Object(ObjType::List), contacts)) => contacts,
+//!    _ => panic!("contacts should be a list"),
+//! };
+//! let bob = match doc2.get(&contacts, 1)? {
+//!   Some((automerge::Value::Object(ObjType::Map), bob)) => bob,
+//!   _ => panic!("bob should be a map"),
+//! };
+//! doc2.put(&bob, "name", "Robert")?;
+//!
+//! // Finally, we can merge the changes from the two devices
+//! doc1.merge(&mut doc2)?;
+//! let bobsname: Option<automerge::Value> = doc1.get(&bob, "name")?.map(|(v, _)| v);
+//! assert_eq!(bobsname, Some(automerge::Value::Scalar(Cow::Owned("Robert".into()))));
+//!
+//! let alices_email: Option<automerge::Value> = doc1.get(&alice, "email")?.map(|(v, _)| v);
+//! assert_eq!(alices_email, Some(automerge::Value::Scalar(Cow::Owned("alicesnewemail@example.com".into()))));
+//! # Ok(())
+//! # }
+//! ```
+//!
+
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/automerge/automerge-rs/main/img/brandmark.svg",
     html_favicon_url = "https:///raw.githubusercontent.com/automerge/automerge-rs/main/img/favicon.ico"
@@ -71,11 +258,12 @@ mod list_range;
 mod list_range_at;
 mod map_range;
 mod map_range_at;
-mod op_observer;
+pub mod op_observer;
 mod op_set;
 mod op_tree;
 mod parents;
 mod query;
+mod read;
 mod sequence_tree;
 mod storage;
 pub mod sync;
@@ -105,9 +293,12 @@ pub use op_observer::OpObserver;
 pub use op_observer::Patch;
 pub use op_observer::VecOpObserver;
 pub use parents::{Parent, Parents};
+pub use read::ReadDoc;
+#[doc(hidden)]
 pub use sequence_tree::SequenceTree;
 pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};
 pub use value::{ScalarValue, Value};
 pub use values::Values;
 
+/// The object ID for the root map of a document
 pub const ROOT: ObjId = ObjId::Root;

--- a/rust/automerge/src/list_range.rs
+++ b/rust/automerge/src/list_range.rs
@@ -3,6 +3,9 @@ use crate::{exid::ExId, Value};
 use crate::{query, Automerge};
 use std::ops::RangeBounds;
 
+/// An iterator over the elements of a list object
+///
+/// This is returned by the [`crate::ReadDoc::list_range`] method
 #[derive(Debug)]
 pub struct ListRange<'a, R: RangeBounds<usize>> {
     range: Option<query::ListRange<'a, R>>,

--- a/rust/automerge/src/list_range_at.rs
+++ b/rust/automerge/src/list_range_at.rs
@@ -3,6 +3,9 @@ use std::ops::RangeBounds;
 
 use crate::{query, Automerge};
 
+/// An iterator over the elements of a list object at a particular set of heads
+///
+/// This is returned by the [`crate::ReadDoc::list_range_at`] method
 #[derive(Debug)]
 pub struct ListRangeAt<'a, R: RangeBounds<usize>> {
     range: Option<query::ListRangeAt<'a, R>>,

--- a/rust/automerge/src/map_range.rs
+++ b/rust/automerge/src/map_range.rs
@@ -3,6 +3,9 @@ use std::ops::RangeBounds;
 
 use crate::{query, Automerge};
 
+/// An iterator over the keys and values of a map object
+///
+/// This is returned by the [`crate::ReadDoc::map_range`] method
 #[derive(Debug)]
 pub struct MapRange<'a, R: RangeBounds<String>> {
     range: Option<query::MapRange<'a, R>>,

--- a/rust/automerge/src/map_range_at.rs
+++ b/rust/automerge/src/map_range_at.rs
@@ -3,6 +3,9 @@ use std::ops::RangeBounds;
 
 use crate::{query, Automerge};
 
+/// An iterator over the keys and values of a map object as at a particuar heads
+///
+/// This is returned by the [`crate::ReadDoc::map_range_at`] method
 #[derive(Debug)]
 pub struct MapRangeAt<'a, R: RangeBounds<String>> {
     range: Option<query::MapRangeAt<'a, R>>,

--- a/rust/automerge/src/op_observer.rs
+++ b/rust/automerge/src/op_observer.rs
@@ -1,7 +1,10 @@
 use crate::exid::ExId;
-use crate::Automerge;
 use crate::Prop;
+use crate::ReadDoc;
 use crate::Value;
+
+mod compose;
+pub use compose::compose;
 
 /// An observer of operations applied to the document.
 pub trait OpObserver {
@@ -12,15 +15,16 @@ pub trait OpObserver {
     /// - `index`: the index the new value has been inserted at.
     /// - `tagged_value`: the value that has been inserted and the id of the operation that did the
     /// insert.
-    fn insert(
+    fn insert<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         objid: ExId,
         index: usize,
         tagged_value: (Value<'_>, ExId),
     );
 
-    fn splice_text(&mut self, _doc: &Automerge, _objid: ExId, _index: usize, _value: &str);
+    /// Some text has been spliced into a text object
+    fn splice_text<R: ReadDoc>(&mut self, _doc: &R, _objid: ExId, _index: usize, _value: &str);
 
     /// A new value has been put into the given object.
     ///
@@ -30,9 +34,9 @@ pub trait OpObserver {
     /// - `tagged_value`: the value that has been put into the object and the id of the operation
     /// that did the put.
     /// - `conflict`: whether this put conflicts with other operations.
-    fn put(
+    fn put<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         objid: ExId,
         prop: Prop,
         tagged_value: (Value<'_>, ExId),
@@ -49,9 +53,9 @@ pub trait OpObserver {
     /// - `tagged_value`: the value that has been put into the object and the id of the operation
     /// that did the put.
     /// - `conflict`: whether this put conflicts with other operations.
-    fn expose(
+    fn expose<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         objid: ExId,
         prop: Prop,
         tagged_value: (Value<'_>, ExId),
@@ -63,7 +67,7 @@ pub trait OpObserver {
     /// - `doc`: a handle to the doc after the op has been inserted, can be used to query information
     /// - `objid`: the object that has been put into.
     /// - `prop`: the prop that the value as been put at.
-    fn flag_conflict(&mut self, _doc: &Automerge, _objid: ExId, _prop: Prop) {}
+    fn flag_conflict<R: ReadDoc>(&mut self, _doc: &R, _objid: ExId, _prop: Prop) {}
 
     /// A counter has been incremented.
     ///
@@ -72,14 +76,20 @@ pub trait OpObserver {
     /// - `prop`: they prop that the chounter is at.
     /// - `tagged_value`: the amount the counter has been incremented by, and the the id of the
     /// increment operation.
-    fn increment(&mut self, doc: &Automerge, objid: ExId, prop: Prop, tagged_value: (i64, ExId));
+    fn increment<R: ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: ExId,
+        prop: Prop,
+        tagged_value: (i64, ExId),
+    );
 
     /// A map value has beeen deleted.
     ///
     /// - `doc`: a handle to the doc after the op has been inserted, can be used to query information
     /// - `objid`: the object that has been deleted in.
     /// - `prop`: the prop to be deleted
-    fn delete(&mut self, doc: &Automerge, objid: ExId, prop: Prop) {
+    fn delete<R: ReadDoc>(&mut self, doc: &R, objid: ExId, prop: Prop) {
         match prop {
             Prop::Map(k) => self.delete_map(doc, objid, &k),
             Prop::Seq(i) => self.delete_seq(doc, objid, i, 1),
@@ -91,7 +101,7 @@ pub trait OpObserver {
     /// - `doc`: a handle to the doc after the op has been inserted, can be used to query information
     /// - `objid`: the object that has been deleted in.
     /// - `key`: the map key to be deleted
-    fn delete_map(&mut self, doc: &Automerge, objid: ExId, key: &str);
+    fn delete_map<R: ReadDoc>(&mut self, doc: &R, objid: ExId, key: &str);
 
     /// A one or more list values have beeen deleted.
     ///
@@ -99,21 +109,7 @@ pub trait OpObserver {
     /// - `objid`: the object that has been deleted in.
     /// - `index`: the index of the deletion
     /// - `num`: the number of sequential elements deleted
-    fn delete_seq(&mut self, doc: &Automerge, objid: ExId, index: usize, num: usize);
-
-    /// Branch of a new op_observer later to be merged
-    ///
-    /// Called by AutoCommit when creating a new transaction.  Observer branch
-    /// will be merged on `commit()` or thrown away on `rollback()`
-    ///
-    fn branch(&self) -> Self;
-
-    /// Merge observed information from a transaction.
-    ///
-    /// Called by AutoCommit on `commit()`
-    ///
-    /// - `other`: Another Op Observer of the same type
-    fn merge(&mut self, other: &Self);
+    fn delete_seq<R: ReadDoc>(&mut self, doc: &R, objid: ExId, index: usize, num: usize);
 
     /// Whether to call sequence methods or `splice_text` when encountering changes in text
     ///
@@ -123,21 +119,41 @@ pub trait OpObserver {
     }
 }
 
+/// An observer which can be branched
+///
+/// This is used when observing operations in a transaction. In this case `branch` will be called
+/// at the beginning of the transaction to return a new observer and then `merge` will be called
+/// with the branched observer as `other` when the transaction is comitted.
+pub trait BranchableObserver {
+    /// Branch of a new op_observer later to be merged
+    ///
+    /// Called when creating a new transaction.  Observer branch will be merged on `commit()` or
+    /// thrown away on `rollback()`
+    fn branch(&self) -> Self;
+
+    /// Merge observed information from a transaction.
+    ///
+    /// Called by AutoCommit on `commit()`
+    ///
+    /// - `other`: Another Op Observer of the same type
+    fn merge(&mut self, other: &Self);
+}
+
 impl OpObserver for () {
-    fn insert(
+    fn insert<R: ReadDoc>(
         &mut self,
-        _doc: &Automerge,
+        _doc: &R,
         _objid: ExId,
         _index: usize,
         _tagged_value: (Value<'_>, ExId),
     ) {
     }
 
-    fn splice_text(&mut self, _doc: &Automerge, _objid: ExId, _index: usize, _value: &str) {}
+    fn splice_text<R: ReadDoc>(&mut self, _doc: &R, _objid: ExId, _index: usize, _value: &str) {}
 
-    fn put(
+    fn put<R: ReadDoc>(
         &mut self,
-        _doc: &Automerge,
+        _doc: &R,
         _objid: ExId,
         _prop: Prop,
         _tagged_value: (Value<'_>, ExId),
@@ -145,9 +161,9 @@ impl OpObserver for () {
     ) {
     }
 
-    fn expose(
+    fn expose<R: ReadDoc>(
         &mut self,
-        _doc: &Automerge,
+        _doc: &R,
         _objid: ExId,
         _prop: Prop,
         _tagged_value: (Value<'_>, ExId),
@@ -155,21 +171,22 @@ impl OpObserver for () {
     ) {
     }
 
-    fn increment(
+    fn increment<R: ReadDoc>(
         &mut self,
-        _doc: &Automerge,
+        _doc: &R,
         _objid: ExId,
         _prop: Prop,
         _tagged_value: (i64, ExId),
     ) {
     }
 
-    fn delete_map(&mut self, _doc: &Automerge, _objid: ExId, _key: &str) {}
+    fn delete_map<R: ReadDoc>(&mut self, _doc: &R, _objid: ExId, _key: &str) {}
 
-    fn delete_seq(&mut self, _doc: &Automerge, _objid: ExId, _index: usize, _num: usize) {}
+    fn delete_seq<R: ReadDoc>(&mut self, _doc: &R, _objid: ExId, _index: usize, _num: usize) {}
+}
 
+impl BranchableObserver for () {
     fn merge(&mut self, _other: &Self) {}
-
     fn branch(&self) -> Self {}
 }
 
@@ -188,8 +205,14 @@ impl VecOpObserver {
 }
 
 impl OpObserver for VecOpObserver {
-    fn insert(&mut self, doc: &Automerge, obj: ExId, index: usize, (value, id): (Value<'_>, ExId)) {
-        if let Ok(mut p) = doc.parents(&obj) {
+    fn insert<R: ReadDoc>(
+        &mut self,
+        doc: &R,
+        obj: ExId,
+        index: usize,
+        (value, id): (Value<'_>, ExId),
+    ) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Insert {
                 obj,
                 path: p.path(),
@@ -199,8 +222,8 @@ impl OpObserver for VecOpObserver {
         }
     }
 
-    fn splice_text(&mut self, doc: &Automerge, obj: ExId, index: usize, value: &str) {
-        if let Ok(mut p) = doc.parents(&obj) {
+    fn splice_text<R: ReadDoc>(&mut self, doc: &R, obj: ExId, index: usize, value: &str) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Splice {
                 obj,
                 path: p.path(),
@@ -210,15 +233,15 @@ impl OpObserver for VecOpObserver {
         }
     }
 
-    fn put(
+    fn put<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         obj: ExId,
         prop: Prop,
         (value, id): (Value<'_>, ExId),
         conflict: bool,
     ) {
-        if let Ok(mut p) = doc.parents(&obj) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Put {
                 obj,
                 path: p.path(),
@@ -229,15 +252,15 @@ impl OpObserver for VecOpObserver {
         }
     }
 
-    fn expose(
+    fn expose<R: ReadDoc>(
         &mut self,
-        doc: &Automerge,
+        doc: &R,
         obj: ExId,
         prop: Prop,
         (value, id): (Value<'_>, ExId),
         conflict: bool,
     ) {
-        if let Ok(mut p) = doc.parents(&obj) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Expose {
                 obj,
                 path: p.path(),
@@ -248,8 +271,8 @@ impl OpObserver for VecOpObserver {
         }
     }
 
-    fn increment(&mut self, doc: &Automerge, obj: ExId, prop: Prop, tagged_value: (i64, ExId)) {
-        if let Ok(mut p) = doc.parents(&obj) {
+    fn increment<R: ReadDoc>(&mut self, doc: &R, obj: ExId, prop: Prop, tagged_value: (i64, ExId)) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Increment {
                 obj,
                 path: p.path(),
@@ -259,8 +282,8 @@ impl OpObserver for VecOpObserver {
         }
     }
 
-    fn delete_map(&mut self, doc: &Automerge, obj: ExId, key: &str) {
-        if let Ok(mut p) = doc.parents(&obj) {
+    fn delete_map<R: ReadDoc>(&mut self, doc: &R, obj: ExId, key: &str) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Delete {
                 obj,
                 path: p.path(),
@@ -270,8 +293,8 @@ impl OpObserver for VecOpObserver {
         }
     }
 
-    fn delete_seq(&mut self, doc: &Automerge, obj: ExId, index: usize, num: usize) {
-        if let Ok(mut p) = doc.parents(&obj) {
+    fn delete_seq<R: ReadDoc>(&mut self, doc: &R, obj: ExId, index: usize, num: usize) {
+        if let Ok(p) = doc.parents(&obj) {
             self.patches.push(Patch::Delete {
                 obj,
                 path: p.path(),
@@ -280,7 +303,9 @@ impl OpObserver for VecOpObserver {
             })
         }
     }
+}
 
+impl BranchableObserver for VecOpObserver {
     fn merge(&mut self, other: &Self) {
         self.patches.extend_from_slice(other.patches.as_slice())
     }

--- a/rust/automerge/src/op_observer/compose.rs
+++ b/rust/automerge/src/op_observer/compose.rs
@@ -1,0 +1,102 @@
+use super::OpObserver;
+
+pub fn compose<'a, O1: OpObserver, O2: OpObserver>(
+    obs1: &'a mut O1,
+    obs2: &'a mut O2,
+) -> impl OpObserver + 'a {
+    ComposeObservers { obs1, obs2 }
+}
+
+struct ComposeObservers<'a, O1: OpObserver, O2: OpObserver> {
+    obs1: &'a mut O1,
+    obs2: &'a mut O2,
+}
+
+impl<'a, O1: OpObserver, O2: OpObserver> OpObserver for ComposeObservers<'a, O1, O2> {
+    fn insert<R: crate::ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: crate::ObjId,
+        index: usize,
+        tagged_value: (crate::Value<'_>, crate::ObjId),
+    ) {
+        self.obs1
+            .insert(doc, objid.clone(), index, tagged_value.clone());
+        self.obs2.insert(doc, objid, index, tagged_value);
+    }
+
+    fn splice_text<R: crate::ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: crate::ObjId,
+        index: usize,
+        value: &str,
+    ) {
+        self.obs1.splice_text(doc, objid.clone(), index, value);
+        self.obs2.splice_text(doc, objid, index, value);
+    }
+
+    fn put<R: crate::ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: crate::ObjId,
+        prop: crate::Prop,
+        tagged_value: (crate::Value<'_>, crate::ObjId),
+        conflict: bool,
+    ) {
+        self.obs1.put(
+            doc,
+            objid.clone(),
+            prop.clone(),
+            tagged_value.clone(),
+            conflict,
+        );
+        self.obs2.put(doc, objid, prop, tagged_value, conflict);
+    }
+
+    fn expose<R: crate::ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: crate::ObjId,
+        prop: crate::Prop,
+        tagged_value: (crate::Value<'_>, crate::ObjId),
+        conflict: bool,
+    ) {
+        self.obs1.expose(
+            doc,
+            objid.clone(),
+            prop.clone(),
+            tagged_value.clone(),
+            conflict,
+        );
+        self.obs2.expose(doc, objid, prop, tagged_value, conflict);
+    }
+
+    fn increment<R: crate::ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: crate::ObjId,
+        prop: crate::Prop,
+        tagged_value: (i64, crate::ObjId),
+    ) {
+        self.obs1
+            .increment(doc, objid.clone(), prop.clone(), tagged_value.clone());
+        self.obs2.increment(doc, objid, prop, tagged_value);
+    }
+
+    fn delete_map<R: crate::ReadDoc>(&mut self, doc: &R, objid: crate::ObjId, key: &str) {
+        self.obs1.delete_map(doc, objid.clone(), key);
+        self.obs2.delete_map(doc, objid, key);
+    }
+
+    fn delete_seq<R: crate::ReadDoc>(
+        &mut self,
+        doc: &R,
+        objid: crate::ObjId,
+        index: usize,
+        num: usize,
+    ) {
+        self.obs2.delete_seq(doc, objid.clone(), index, num);
+        self.obs2.delete_seq(doc, objid, index, num);
+    }
+}

--- a/rust/automerge/src/read.rs
+++ b/rust/automerge/src/read.rs
@@ -1,0 +1,199 @@
+use crate::{
+    error::AutomergeError, exid::ExId, keys::Keys, keys_at::KeysAt, list_range::ListRange,
+    list_range_at::ListRangeAt, map_range::MapRange, map_range_at::MapRangeAt, parents::Parents,
+    values::Values, Change, ChangeHash, ObjType, Prop, Value,
+};
+
+use std::ops::RangeBounds;
+
+/// Methods for reading values from an automerge document
+///
+/// Many of the methods on this trait have an alternate `*_at` version which
+/// takes an additional argument of `&[ChangeHash]`. This allows you to retrieve
+/// the value at a particular point in the document history identified by the
+/// given change hashes.
+pub trait ReadDoc {
+    /// Get the parents of an object in the document tree.
+    ///
+    /// See the documentation for [`Parents`] for more details.
+    ///
+    /// ### Errors
+    ///
+    /// Returns an error when the id given is not the id of an object in this document.
+    /// This function does not get the parents of scalar values contained within objects.
+    ///
+    /// ### Experimental
+    ///
+    /// This function may in future be changed to allow getting the parents from the id of a scalar
+    /// value.
+    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError>;
+
+    /// Get the path to an object
+    ///
+    /// "path" here means the sequence of `(object Id, key)` pairs which leads
+    /// to the object in question.
+    ///
+    /// ### Errors
+    ///
+    /// * If the object ID `obj` is not in the document
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<(ExId, Prop)>, AutomergeError>;
+
+    /// Get the keys of the object `obj`.
+    ///
+    /// For a map this returns the keys of the map.
+    /// For a list this returns the element ids (opids) encoded as strings.
+    fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_, '_>;
+
+    /// Get the keys of the object `obj` as at `heads`
+    ///
+    /// See [`Self::keys`]
+    fn keys_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> KeysAt<'_, '_>;
+
+    /// Iterate over the keys and values of the map `obj` in the given range.
+    ///
+    /// If the object correspoding to `obj` is a list then this will return an empty iterator
+    ///
+    /// The returned iterator yields `(key, value, exid)` tuples, where the
+    /// third element is the ID of the operation which created the value.
+    fn map_range<O: AsRef<ExId>, R: RangeBounds<String>>(
+        &self,
+        obj: O,
+        range: R,
+    ) -> MapRange<'_, R>;
+
+    /// Iterate over the keys and values of the map `obj` in the given range as
+    /// at `heads`
+    ///
+    /// If the object correspoding to `obj` is a list then this will return an empty iterator
+    ///
+    /// The returned iterator yields `(key, value, exid)` tuples, where the
+    /// third element is the ID of the operation which created the value.
+    ///
+    /// See [`Self::map_range`]
+    fn map_range_at<O: AsRef<ExId>, R: RangeBounds<String>>(
+        &self,
+        obj: O,
+        range: R,
+        heads: &[ChangeHash],
+    ) -> MapRangeAt<'_, R>;
+
+    /// Iterate over the indexes and values of the list or text `obj` in the given range.
+    ///
+    /// The reuturned iterator yields `(index, value, exid)` tuples, where the third
+    /// element is the ID of the operation which created the value.
+    fn list_range<O: AsRef<ExId>, R: RangeBounds<usize>>(
+        &self,
+        obj: O,
+        range: R,
+    ) -> ListRange<'_, R>;
+
+    /// Iterate over the indexes and values of the list or text `obj` in the given range as at `heads`
+    ///
+    /// The returned iterator yields `(index, value, exid)` tuples, where the third
+    /// element is the ID of the operation which created the value.
+    ///
+    /// See [`Self::list_range`]
+    fn list_range_at<O: AsRef<ExId>, R: RangeBounds<usize>>(
+        &self,
+        obj: O,
+        range: R,
+        heads: &[ChangeHash],
+    ) -> ListRangeAt<'_, R>;
+
+    /// Iterate over the values in a map, list, or text object
+    ///
+    /// The returned iterator yields `(value, exid)` tuples, where the second element
+    /// is the ID of the operation which created the value.
+    fn values<O: AsRef<ExId>>(&self, obj: O) -> Values<'_>;
+
+    /// Iterate over the values in a map, list, or text object as at `heads`
+    ///
+    /// The returned iterator yields `(value, exid)` tuples, where the second element
+    /// is the ID of the operation which created the value.
+    ///
+    /// See [`Self::values`]
+    fn values_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Values<'_>;
+
+    /// Get the length of the given object.
+    ///
+    /// If the given object is not in this document this method will return `0`
+    fn length<O: AsRef<ExId>>(&self, obj: O) -> usize;
+
+    /// Get the length of the given object as at `heads`
+    ///
+    /// If the given object is not in this document this method will return `0`
+    ///
+    /// See [`Self::length`]
+    fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize;
+
+    /// Get the type of this object, if it is an object.
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError>;
+
+    /// Get the string represented by the given text object.
+    fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError>;
+
+    /// Get the string represented by the given text object as at `heads`, see
+    /// [`Self::text`]
+    fn text_at<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: &[ChangeHash],
+    ) -> Result<String, AutomergeError>;
+
+    /// Get a value out of the document.
+    ///
+    /// This returns a tuple of `(value, object ID)`. This is for two reasons:
+    ///
+    /// 1. If `value` is an object (represented by `Value::Object`) then the ID
+    ///    is the ID of that object. This can then be used to retrieve nested
+    ///    values from the document.
+    /// 2. Even if `value` is a scalar, the ID represents the operation which
+    ///    created the value. This is useful if there are conflicting values for
+    ///    this key as each value is tagged with the ID.
+    ///
+    /// In the case of a key which has conflicting values, this method will
+    /// return a single arbitrarily chosen value. This value will be chosen
+    /// deterministically on all nodes. If you want to get all the values for a
+    /// key use [`Self::get_all`].
+    fn get<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError>;
+
+    /// Get the value of the given key as at `heads`, see `[Self::get]`
+    fn get_at<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+        heads: &[ChangeHash],
+    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError>;
+
+    /// Get all conflicting values out of the document at this prop that conflict.
+    ///
+    /// If there are multiple conflicting values for a given key this method
+    /// will return all of them, with each value tagged by the ID of the
+    /// operation which created it.
+    fn get_all<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError>;
+
+    /// Get all possibly conflicting values for a key as at `heads`
+    ///
+    /// See `[Self::get_all]`
+    fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+        heads: &[ChangeHash],
+    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError>;
+
+    /// Get the hashes of the changes in this document that aren't transitive dependencies of the
+    /// given `heads`.
+    fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash>;
+
+    /// Get a change by its hash.
+    fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&Change>;
+}

--- a/rust/automerge/src/sync/state.rs
+++ b/rust/automerge/src/sync/state.rs
@@ -23,13 +23,23 @@ impl From<parse::leb128::Error> for DecodeError {
 }
 
 /// The state of synchronisation with a peer.
+///
+/// This should be persisted using [`Self::encode`] when you know you will be interacting with the
+/// same peer in multiple sessions. [`Self::encode`] only encodes state which should be reused
+/// across connections.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct State {
+    /// The hashes which we know both peers have
     pub shared_heads: Vec<ChangeHash>,
+    /// The heads we last sent
     pub last_sent_heads: Vec<ChangeHash>,
+    /// The heads we last received from them
     pub their_heads: Option<Vec<ChangeHash>>,
+    /// Any specific changes they last said they needed
     pub their_need: Option<Vec<ChangeHash>>,
+    /// The bloom filters summarising what they said they have
     pub their_have: Option<Vec<Have>>,
+    /// The hashes we have sent in this session
     pub sent_hashes: BTreeSet<ChangeHash>,
 
     /// `generate_sync_message` should return `None` if there are no new changes to send. In

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -717,7 +717,7 @@ struct SpliceArgs<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{transaction::Transactable, ROOT};
+    use crate::{transaction::Transactable, ReadDoc, ROOT};
 
     use super::*;
 

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -1,7 +1,10 @@
 use std::ops::RangeBounds;
 
 use crate::exid::ExId;
-use crate::{Automerge, ChangeHash, KeysAt, ObjType, OpObserver, Prop, ScalarValue, Value, Values};
+use crate::op_observer::BranchableObserver;
+use crate::{
+    Automerge, ChangeHash, KeysAt, ObjType, OpObserver, Prop, ReadDoc, ScalarValue, Value, Values,
+};
 use crate::{AutomergeError, Keys};
 use crate::{ListRange, ListRangeAt, MapRange, MapRangeAt};
 
@@ -49,7 +52,7 @@ impl<'a> Transaction<'a, observation::UnObserved> {
     }
 }
 
-impl<'a, Obs: OpObserver> Transaction<'a, observation::Observed<Obs>> {
+impl<'a, Obs: OpObserver + BranchableObserver> Transaction<'a, observation::Observed<Obs>> {
     pub fn observer(&mut self) -> &mut Obs {
         self.observation.as_mut().unwrap().observer()
     }
@@ -112,95 +115,7 @@ impl<'a, Obs: observation::Observation> Transaction<'a, Obs> {
     }
 }
 
-impl<'a, Obs: observation::Observation> Transactable for Transaction<'a, Obs> {
-    /// Get the number of pending operations in this transaction.
-    fn pending_ops(&self) -> usize {
-        self.inner.as_ref().unwrap().pending_ops()
-    }
-
-    /// Set the value of property `P` to value `V` in object `obj`.
-    ///
-    /// # Errors
-    ///
-    /// This will return an error if
-    /// - The object does not exist
-    /// - The key is the wrong type for the object
-    /// - The key does not exist in the object
-    fn put<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
-        &mut self,
-        obj: O,
-        prop: P,
-        value: V,
-    ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.put(doc, obs, obj.as_ref(), prop, value))
-    }
-
-    fn put_object<O: AsRef<ExId>, P: Into<Prop>>(
-        &mut self,
-        obj: O,
-        prop: P,
-        value: ObjType,
-    ) -> Result<ExId, AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.put_object(doc, obs, obj.as_ref(), prop, value))
-    }
-
-    fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
-        &mut self,
-        obj: O,
-        index: usize,
-        value: V,
-    ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.insert(doc, obs, obj.as_ref(), index, value))
-    }
-
-    fn insert_object<O: AsRef<ExId>>(
-        &mut self,
-        obj: O,
-        index: usize,
-        value: ObjType,
-    ) -> Result<ExId, AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.insert_object(doc, obs, obj.as_ref(), index, value))
-    }
-
-    fn increment<O: AsRef<ExId>, P: Into<Prop>>(
-        &mut self,
-        obj: O,
-        prop: P,
-        value: i64,
-    ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.increment(doc, obs, obj.as_ref(), prop, value))
-    }
-
-    fn delete<O: AsRef<ExId>, P: Into<Prop>>(
-        &mut self,
-        obj: O,
-        prop: P,
-    ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.delete(doc, obs, obj.as_ref(), prop))
-    }
-
-    /// Splice new elements into the given sequence. Returns a vector of the OpIds used to insert
-    /// the new elements
-    fn splice<O: AsRef<ExId>, V: IntoIterator<Item = ScalarValue>>(
-        &mut self,
-        obj: O,
-        pos: usize,
-        del: usize,
-        vals: V,
-    ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.splice(doc, obs, obj.as_ref(), pos, del, vals))
-    }
-
-    fn splice_text<O: AsRef<ExId>>(
-        &mut self,
-        obj: O,
-        pos: usize,
-        del: usize,
-        text: &str,
-    ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.splice_text(doc, obs, obj.as_ref(), pos, del, text))
-    }
-
+impl<'a, Obs: observation::Observation> ReadDoc for Transaction<'a, Obs> {
     fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_, '_> {
         self.doc.keys(obj)
     }
@@ -311,6 +226,108 @@ impl<'a, Obs: observation::Observation> Transactable for Transaction<'a, Obs> {
 
     fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<crate::Parents<'_>, AutomergeError> {
         self.doc.parents(obj)
+    }
+
+    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<(ExId, Prop)>, AutomergeError> {
+        self.doc.path_to_object(obj)
+    }
+
+    fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash> {
+        self.doc.get_missing_deps(heads)
+    }
+
+    fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&crate::Change> {
+        self.doc.get_change_by_hash(hash)
+    }
+}
+
+impl<'a, Obs: observation::Observation> Transactable for Transaction<'a, Obs> {
+    /// Get the number of pending operations in this transaction.
+    fn pending_ops(&self) -> usize {
+        self.inner.as_ref().unwrap().pending_ops()
+    }
+
+    /// Set the value of property `P` to value `V` in object `obj`.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if
+    /// - The object does not exist
+    /// - The key is the wrong type for the object
+    /// - The key does not exist in the object
+    fn put<O: AsRef<ExId>, P: Into<Prop>, V: Into<ScalarValue>>(
+        &mut self,
+        obj: O,
+        prop: P,
+        value: V,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.put(doc, obs, obj.as_ref(), prop, value))
+    }
+
+    fn put_object<O: AsRef<ExId>, P: Into<Prop>>(
+        &mut self,
+        obj: O,
+        prop: P,
+        value: ObjType,
+    ) -> Result<ExId, AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.put_object(doc, obs, obj.as_ref(), prop, value))
+    }
+
+    fn insert<O: AsRef<ExId>, V: Into<ScalarValue>>(
+        &mut self,
+        obj: O,
+        index: usize,
+        value: V,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.insert(doc, obs, obj.as_ref(), index, value))
+    }
+
+    fn insert_object<O: AsRef<ExId>>(
+        &mut self,
+        obj: O,
+        index: usize,
+        value: ObjType,
+    ) -> Result<ExId, AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.insert_object(doc, obs, obj.as_ref(), index, value))
+    }
+
+    fn increment<O: AsRef<ExId>, P: Into<Prop>>(
+        &mut self,
+        obj: O,
+        prop: P,
+        value: i64,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.increment(doc, obs, obj.as_ref(), prop, value))
+    }
+
+    fn delete<O: AsRef<ExId>, P: Into<Prop>>(
+        &mut self,
+        obj: O,
+        prop: P,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.delete(doc, obs, obj.as_ref(), prop))
+    }
+
+    /// Splice new elements into the given sequence. Returns a vector of the OpIds used to insert
+    /// the new elements
+    fn splice<O: AsRef<ExId>, V: IntoIterator<Item = ScalarValue>>(
+        &mut self,
+        obj: O,
+        pos: usize,
+        del: usize,
+        vals: V,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.splice(doc, obs, obj.as_ref(), pos, del, vals))
+    }
+
+    fn splice_text<O: AsRef<ExId>>(
+        &mut self,
+        obj: O,
+        pos: usize,
+        del: usize,
+        text: &str,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, obs| tx.splice_text(doc, obs, obj.as_ref(), pos, del, text))
     }
 
     fn base_heads(&self) -> Vec<ChangeHash> {

--- a/rust/automerge/src/transaction/transactable.rs
+++ b/rust/automerge/src/transaction/transactable.rs
@@ -1,13 +1,8 @@
-use std::ops::RangeBounds;
-
 use crate::exid::ExId;
-use crate::{
-    AutomergeError, ChangeHash, Keys, KeysAt, ListRange, ListRangeAt, MapRange, MapRangeAt,
-    ObjType, Parents, Prop, ScalarValue, Value, Values,
-};
+use crate::{AutomergeError, ChangeHash, ObjType, Prop, ReadDoc, ScalarValue};
 
 /// A way of mutating a document within a single change.
-pub trait Transactable {
+pub trait Transactable: ReadDoc {
     /// Get the number of pending operations in this transaction.
     fn pending_ops(&self) -> usize;
 
@@ -92,106 +87,6 @@ pub trait Transactable {
         del: usize,
         text: &str,
     ) -> Result<(), AutomergeError>;
-
-    /// Get the keys of the given object, it should be a map.
-    fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_, '_>;
-
-    /// Get the keys of the given object at a point in history.
-    fn keys_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> KeysAt<'_, '_>;
-
-    fn map_range<O: AsRef<ExId>, R: RangeBounds<String>>(
-        &self,
-        obj: O,
-        range: R,
-    ) -> MapRange<'_, R>;
-
-    fn map_range_at<O: AsRef<ExId>, R: RangeBounds<String>>(
-        &self,
-        obj: O,
-        range: R,
-        heads: &[ChangeHash],
-    ) -> MapRangeAt<'_, R>;
-
-    fn list_range<O: AsRef<ExId>, R: RangeBounds<usize>>(
-        &self,
-        obj: O,
-        range: R,
-    ) -> ListRange<'_, R>;
-
-    fn list_range_at<O: AsRef<ExId>, R: RangeBounds<usize>>(
-        &self,
-        obj: O,
-        range: R,
-        heads: &[ChangeHash],
-    ) -> ListRangeAt<'_, R>;
-
-    fn values<O: AsRef<ExId>>(&self, obj: O) -> Values<'_>;
-
-    fn values_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Values<'_>;
-
-    /// Get the length of the given object.
-    fn length<O: AsRef<ExId>>(&self, obj: O) -> usize;
-
-    /// Get the length of the given object at a point in history.
-    fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize;
-
-    /// Get type for object
-    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError>;
-
-    /// Get the string that this text object represents.
-    fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError>;
-
-    /// Get the string that this text object represents at a point in history.
-    fn text_at<O: AsRef<ExId>>(
-        &self,
-        obj: O,
-        heads: &[ChangeHash],
-    ) -> Result<String, AutomergeError>;
-
-    /// Get the value at this prop in the object.
-    fn get<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError>;
-
-    /// Get the value at this prop in the object at a point in history.
-    fn get_at<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-        heads: &[ChangeHash],
-    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError>;
-
-    fn get_all<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError>;
-
-    fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
-        &self,
-        obj: O,
-        prop: P,
-        heads: &[ChangeHash],
-    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError>;
-
-    /// Get the parents of an object in the document tree.
-    ///
-    /// ### Errors
-    ///
-    /// Returns an error when the id given is not the id of an object in this document.
-    /// This function does not get the parents of scalar values contained within objects.
-    ///
-    /// ### Experimental
-    ///
-    /// This function may in future be changed to allow getting the parents from the id of a scalar
-    /// value.
-    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError>;
-
-    fn path_to_object<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<(ExId, Prop)>, AutomergeError> {
-        Ok(self.parents(obj.as_ref().clone())?.path())
-    }
 
     /// The heads this transaction will be based on
     fn base_heads(&self) -> Vec<ChangeHash>;

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -143,12 +143,17 @@ impl fmt::Display for ActorId {
     }
 }
 
+/// The type of an object
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Copy, Hash)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum ObjType {
+    /// A map
     Map,
+    /// Retained for backwards compatibility, tables are identical to maps
     Table,
+    /// A sequence of arbitrary values
     List,
+    /// A sequence of characters
     Text,
 }
 
@@ -378,9 +383,15 @@ pub(crate) enum Key {
     Seq(ElemId),
 }
 
+/// A property of an object
+///
+/// This is either a string representing a property in a map, or an integer
+/// which is the index into a sequence
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone)]
 pub enum Prop {
+    /// A property in a map
     Map(String),
+    /// An index into a sequence
     Seq(usize),
 }
 
@@ -454,9 +465,17 @@ impl ObjId {
     }
 }
 
+/// How indexes into text sequeces are calculated
+///
+/// Automerge text objects are internally sequences of utf8 characters. This
+/// means that in environments (such as javascript) which use a different
+/// encoding the indexes into the text sequence will be different. This enum
+/// represents the different ways indexes can be calculated.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TextEncoding {
+    /// The indexes are calculated using the utf8 encoding
     Utf8,
+    /// The indexes are calculated using the utf16 encoding
     Utf16,
 }
 

--- a/rust/automerge/src/value.rs
+++ b/rust/automerge/src/value.rs
@@ -5,9 +5,12 @@ use smol_str::SmolStr;
 use std::borrow::Cow;
 use std::fmt;
 
+/// The type of values in an automerge document
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value<'a> {
+    /// An composite object of type `ObjType`
     Object(ObjType),
+    /// A non composite value
     // TODO: if we don't have to store this in patches any more then it might be able to be just a
     // &'a ScalarValue rather than a Cow
     Scalar(Cow<'a, ScalarValue>),
@@ -431,6 +434,7 @@ impl From<&Counter> for f64 {
     }
 }
 
+/// A value which is not a composite value
 #[derive(Serialize, PartialEq, Debug, Clone)]
 #[serde(untagged)]
 pub enum ScalarValue {
@@ -442,7 +446,11 @@ pub enum ScalarValue {
     Counter(Counter),
     Timestamp(i64),
     Boolean(bool),
-    Unknown { type_code: u8, bytes: Vec<u8> },
+    /// A value from a future version of automerge
+    Unknown {
+        type_code: u8,
+        bytes: Vec<u8>,
+    },
     Null,
 }
 

--- a/rust/automerge/src/values.rs
+++ b/rust/automerge/src/values.rs
@@ -2,6 +2,9 @@ use crate::exid::ExId;
 use crate::{Automerge, Value};
 use std::fmt;
 
+/// An iterator over the values in an object
+///
+/// This is returned by the [`crate::ReadDoc::values`] and [`crate::ReadDoc::values_at`] methods
 pub struct Values<'a> {
     range: Box<dyn 'a + ValueIter<'a>>,
     doc: &'a Automerge,
@@ -50,11 +53,5 @@ impl<'a> Iterator for Values<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.range.next_value(self.doc)
-    }
-}
-
-impl<'a> DoubleEndedIterator for Values<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        unimplemented!()
     }
 }

--- a/rust/edit-trace/src/main.rs
+++ b/rust/edit-trace/src/main.rs
@@ -1,4 +1,5 @@
 use automerge::ObjType;
+use automerge::ReadDoc;
 use automerge::{transaction::Transactable, Automerge, AutomergeError, ROOT};
 use std::time::Instant;
 


### PR DESCRIPTION
The Rust API has so far grown somewhat organically driven by the needs of the javascript implementation. This has led to an API which is quite awkward and unfamiliar to Rust programmers. Additionally there is no documentation to speak of. This commit is the first movement towards cleaning things up a bit. We touch a lot of files but the changes are all very mechanical. We introduce a few traits to abstract over the common operations between `Automerge` and `AutoCommit`, and add a whole bunch of documentation.

* Add a `ReadDoc` trait to describe methods which read value from a document. make `Transactable` extend `ReadDoc`
* Add a `SyncDoc` trait to describe methods necessary for synchronizing documents.
* Put the `SyncDoc` implementation for `AutoCommit` behind `AutoCommit::sync` to ensure that any open transactions are closed before taking part in the sync protocol
* Split `OpObserver` into two traits: `OpObserver` + `BranchableObserver`. `BranchableObserver` captures the methods which are only needed for observing transactions.
* Add a whole bunch of documentation.

The main changes Rust users will need to make is:

* Import the `ReadDoc` trait wherever you are using the methods which have been moved to it. Optionally change concrete paramters on functions to `ReadDoc` constraints.
* Likewise import the `SyncDoc` trait wherever you are doing synchronisation work
* If you are using the `AutoCommit::*_sync_message` methods you will need to add a call to `AutoCommit::sync()` first. E.g. `doc.generate_sync_message` becomes `doc.sync().generate_sync_message`
* If you have an implementation of `OpObserver` which you are using in an `AutoCommit` then split it into an implementation of `OpObserver` and `BranchableObserver`