### PR TITLE
Move automerge::SequenceTree to automerge_wasm::SequenceTree

### DIFF
--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -57,5 +57,6 @@ features = ["console"]
 
 [dev-dependencies]
 futures = "^0.1"
+proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
 wasm-bindgen-futures = "^0.4"
 wasm-bindgen-test = "^0.3"

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -41,6 +41,7 @@ use wasm_bindgen::JsCast;
 
 mod interop;
 mod observer;
+mod sequence_tree;
 mod sync;
 mod value;
 

--- a/rust/automerge-wasm/src/observer.rs
+++ b/rust/automerge-wasm/src/observer.rs
@@ -6,9 +6,11 @@ use crate::{
     interop::{self, alloc, js_set},
     TextRepresentation,
 };
-use automerge::{ObjId, OpObserver, Prop, ReadDoc, ScalarValue, SequenceTree, Value};
+use automerge::{ObjId, OpObserver, Prop, ReadDoc, ScalarValue, Value};
 use js_sys::{Array, Object};
 use wasm_bindgen::prelude::*;
+
+use crate::sequence_tree::SequenceTree;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Observer {

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -264,7 +264,6 @@ mod op_tree;
 mod parents;
 mod query;
 mod read;
-mod sequence_tree;
 mod storage;
 pub mod sync;
 pub mod transaction;
@@ -294,8 +293,6 @@ pub use op_observer::Patch;
 pub use op_observer::VecOpObserver;
 pub use parents::{Parent, Parents};
 pub use read::ReadDoc;
-#[doc(hidden)]
-pub use sequence_tree::SequenceTree;
 pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};
 pub use value::{ScalarValue, Value};
 pub use values::Values;


### PR DESCRIPTION
The `SequenceTree` is only ever used in `automerge_wasm` so move it there.