### PR TITLE
rework how skip works to push the logic into node

### DIFF
--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -58,6 +58,22 @@ describe("Automerge", () => {
       })
     })
 
+    it("should be able to insert and delete a large number of properties", () => {
+      let doc = Automerge.init<any>()
+
+      doc = Automerge.change(doc, doc => {
+        doc['k1'] = true;
+      });
+
+      for (let idx = 1; idx <= 200; idx++) {
+        doc = Automerge.change(doc, doc => {
+          delete doc['k' + idx];
+          doc['k' + (idx + 1)] = true;
+          assert(Object.keys(doc).length == 1)
+        });
+      }
+    })
+
     it("can detect an automerge doc with isAutomerge()", () => {
       const doc1 = Automerge.from({ sub: { object: true } })
       assert(Automerge.isAutomerge(doc1))

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -62,15 +62,15 @@ describe("Automerge", () => {
       let doc = Automerge.init<any>()
 
       doc = Automerge.change(doc, doc => {
-        doc['k1'] = true;
-      });
+        doc["k1"] = true
+      })
 
       for (let idx = 1; idx <= 200; idx++) {
         doc = Automerge.change(doc, doc => {
-          delete doc['k' + idx];
-          doc['k' + (idx + 1)] = true;
+          delete doc["k" + idx]
+          doc["k" + (idx + 1)] = true
           assert(Object.keys(doc).length == 1)
-        });
+        })
       }
     })
 

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -1447,7 +1447,7 @@ describe('Automerge', () => {
       sync(n1, n2, s1, s2)
 
       // Having n3's last change concurrent to the last sync heads forces us into the slower code path
-      const change3 = n2.getLastLocalChange()
+      const change3 = n3.getLastLocalChange()
       if (change3 === null) throw new RangeError("no local change")
       n2.applyChanges([change3])
       n1.put("_root", "n1", "final"); n1.commit("", 0)

--- a/rust/automerge/src/op_tree/node.rs
+++ b/rust/automerge/src/op_tree/node.rs
@@ -69,7 +69,7 @@ impl OpTreeNode {
                         skip = Some(n - child.len() - 1);
                     }
                     Some(n) if n == child.len() => {
-                        skip = None;
+                        skip = Some(0); // important to not be None so we never call query_node again
                         if self.search_element(query, m, ops, child_index) {
                             return true;
                         }
@@ -78,7 +78,7 @@ impl OpTreeNode {
                         if child.search(query, m, ops, Some(n)) {
                             return true;
                         }
-                        skip = Some(0);  // important to not be None so we never call query_node again
+                        skip = Some(0); // important to not be None so we never call query_node again
                         if self.search_element(query, m, ops, child_index) {
                             return true;
                         }

--- a/rust/automerge/src/query/prop.rs
+++ b/rust/automerge/src/query/prop.rs
@@ -1,6 +1,6 @@
 use crate::op_tree::{OpSetMetadata, OpTreeNode};
 use crate::query::{binary_search_by, QueryResult, TreeQuery};
-use crate::types::{Key, ListEncoding, Op};
+use crate::types::{Key, Op};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -9,15 +9,6 @@ pub(crate) struct Prop<'a> {
     pub(crate) ops: Vec<&'a Op>,
     pub(crate) ops_pos: Vec<usize>,
     pub(crate) pos: usize,
-    start: Option<Start>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct Start {
-    /// The index to start searching for in the optree
-    idx: usize,
-    /// The total length of the optree
-    optree_len: usize,
 }
 
 impl<'a> Prop<'a> {
@@ -27,7 +18,6 @@ impl<'a> Prop<'a> {
             ops: vec![],
             ops_pos: vec![],
             pos: 0,
-            start: None,
         }
     }
 }
@@ -39,38 +29,9 @@ impl<'a> TreeQuery<'a> for Prop<'a> {
         m: &OpSetMetadata,
         ops: &[Op],
     ) -> QueryResult {
-        if let Some(Start {
-            idx: start,
-            optree_len,
-        }) = self.start
-        {
-            if self.pos + child.len() >= start {
-                // skip empty nodes
-                if child.index.visible_len(ListEncoding::default()) == 0 {
-                    if self.pos + child.len() >= optree_len {
-                        self.pos = optree_len;
-                        QueryResult::Finish
-                    } else {
-                        self.pos += child.len();
-                        QueryResult::Next
-                    }
-                } else {
-                    QueryResult::Descend
-                }
-            } else {
-                self.pos += child.len();
-                QueryResult::Next
-            }
-        } else {
-            // in the root node find the first op position for the key
-            let start = binary_search_by(child, ops, |op| m.key_cmp(&op.key, &self.key));
-            self.start = Some(Start {
-                idx: start,
-                optree_len: child.len(),
-            });
-            self.pos = start;
-            QueryResult::Skip(start)
-        }
+        let start = binary_search_by(child, ops, |op| m.key_cmp(&op.key, &self.key));
+        self.pos = start;
+        QueryResult::Skip(start)
     }
 
     fn query_element(&mut self, op: &'a Op) -> QueryResult {


### PR DESCRIPTION
Found a bug in the op_tree query skip code.  Moved all the logic in into op_tree/node.rs and made it much simpler.  Added a test.