### PR TITLE
TextEncoding only resides in the document

### DIFF
--- a/rust/automerge/examples/watch.rs
+++ b/rust/automerge/examples/watch.rs
@@ -2,7 +2,6 @@ use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
 use automerge::Automerge;
 use automerge::AutomergeError;
-use automerge::TextEncoding;
 use automerge::ROOT;
 use automerge::{Patch, PatchAction, PatchLog};
 
@@ -21,7 +20,7 @@ fn main() {
         .unwrap();
     get_changes(&doc, doc.make_patches(&mut result.patch_log));
 
-    let mut tx = doc.transaction_log_patches(PatchLog::active(TextEncoding::platform_default()));
+    let mut tx = doc.transaction_log_patches(PatchLog::active());
     let map = tx
         .put_object(ROOT, "my new map", automerge::ObjType::Map)
         .unwrap();

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -72,12 +72,10 @@ pub struct AutoCommit {
 /// See [`AutoCommit`]
 impl Default for AutoCommit {
     fn default() -> Self {
-        let doc = Automerge::new();
-        let text_rep = doc.text_encoding();
         AutoCommit {
             doc: Automerge::new(),
             transaction: None,
-            patch_log: PatchLog::inactive(text_rep),
+            patch_log: PatchLog::inactive(),
             diff_cursor: Vec::new(),
             diff_cache: None,
             save_cursor: Vec::new(),
@@ -97,11 +95,10 @@ impl AutoCommit {
 
     pub fn new_with_encoding(encoding: TextEncoding) -> AutoCommit {
         let doc = Automerge::new_with_encoding(encoding);
-        let text_rep = doc.text_encoding();
         AutoCommit {
             doc,
             transaction: None,
-            patch_log: PatchLog::inactive(text_rep),
+            patch_log: PatchLog::inactive(),
             diff_cursor: Vec::new(),
             diff_cache: None,
             save_cursor: Vec::new(),
@@ -111,11 +108,10 @@ impl AutoCommit {
 
     pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {
         let doc = Automerge::load(data)?;
-        let text_encoding = doc.text_encoding();
         Ok(Self {
             doc,
             transaction: None,
-            patch_log: PatchLog::inactive(text_encoding),
+            patch_log: PatchLog::inactive(),
             diff_cursor: Vec::new(),
             diff_cache: None,
             save_cursor: Vec::new(),
@@ -125,11 +121,10 @@ impl AutoCommit {
 
     pub fn load_unverified_heads(data: &[u8]) -> Result<Self, AutomergeError> {
         let doc = Automerge::load_unverified_heads(data)?;
-        let text_encoding = doc.text_encoding();
         Ok(Self {
             doc,
             transaction: None,
-            patch_log: PatchLog::inactive(text_encoding),
+            patch_log: PatchLog::inactive(),
             diff_cursor: Vec::new(),
             diff_cache: None,
             save_cursor: Vec::new(),
@@ -156,11 +151,10 @@ impl AutoCommit {
         options: LoadOptions<'_>,
     ) -> Result<Self, AutomergeError> {
         let doc = Automerge::load_with_options(data, options)?;
-        let text_encoding = doc.text_encoding();
         Ok(Self {
             doc,
             transaction: None,
-            patch_log: PatchLog::inactive(text_encoding),
+            patch_log: PatchLog::inactive(),
             diff_cursor: Vec::new(),
             diff_cache: None,
             save_cursor: Vec::new(),
@@ -172,7 +166,7 @@ impl AutoCommit {
     /// longer indexes changes to the document.
     pub fn reset_diff_cursor(&mut self) {
         self.ensure_transaction_closed();
-        self.patch_log = PatchLog::inactive(self.doc.text_encoding());
+        self.patch_log = PatchLog::inactive();
         self.diff_cursor = Vec::new();
     }
 
@@ -255,7 +249,7 @@ impl AutoCommit {
         {
             self.patch_log.make_patches(&self.doc)
         } else if range.before().is_empty() && range.after() == heads {
-            let mut patch_log = PatchLog::active(self.patch_log.text_encoding());
+            let mut patch_log = PatchLog::active();
             // This if statement is only active if the current heads are the same as `after`
             // so we don't need to tell the patch log to target a specific heads and consequently
             // it wll be able to generate patches very fast as it doesn't need to make any clocks
@@ -265,7 +259,7 @@ impl AutoCommit {
         } else {
             let before_clock = self.doc.clock_at(range.before());
             let after_clock = self.doc.clock_at(range.after());
-            let mut patch_log = PatchLog::active(self.patch_log.text_encoding());
+            let mut patch_log = PatchLog::active();
             patch_log.heads = Some(range.after().to_vec());
             diff::log_diff(&self.doc, &before_clock, &after_clock, &mut patch_log);
             patch_log.make_patches(&self.doc)
@@ -298,7 +292,7 @@ impl AutoCommit {
         Self {
             doc: self.doc.fork(),
             transaction: self.transaction.clone(),
-            patch_log: PatchLog::inactive(self.patch_log.text_encoding()),
+            patch_log: PatchLog::inactive(),
             diff_cursor: vec![],
             diff_cache: None,
             save_cursor: vec![],
@@ -311,7 +305,7 @@ impl AutoCommit {
         Ok(Self {
             doc: self.doc.fork_at(heads)?,
             transaction: self.transaction.clone(),
-            patch_log: PatchLog::inactive(self.patch_log.text_encoding()),
+            patch_log: PatchLog::inactive(),
             diff_cursor: vec![],
             diff_cache: None,
             save_cursor: vec![],

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use crate::{
         patches::PatchLog, read::ReadDoc, transaction::Transactable, Automerge, ObjType, Patch,
-        PatchAction, Prop, TextEncoding, Value,
+        PatchAction, Prop, Value,
     };
 
     // Patches often carry a "tagged value", which is a value and the OpID of the op which
@@ -522,7 +522,7 @@ mod tests {
             fs::read("./tests/fixtures/".to_owned() + name).unwrap()
         }
 
-        let mut patch_log = PatchLog::active(TextEncoding::platform_default());
+        let mut patch_log = PatchLog::active();
         let _doc = Automerge::load_with_options(
             &fixture("counter_value_is_ok.automerge"),
             crate::LoadOptions::new()

--- a/rust/automerge/src/iter/doc.rs
+++ b/rust/automerge/src/iter/doc.rs
@@ -214,9 +214,9 @@ pub(crate) struct DocObjItemInternal<'a> {
 }
 
 impl DocObjItemInternal<'_> {
-    pub(crate) fn log(self, log: &mut PatchLog) {
+    pub(crate) fn log(self, log: &mut PatchLog, text_encoding: TextEncoding) {
         let obj = self.obj;
-        self.item.log(obj, log)
+        self.item.log(obj, log, text_encoding)
     }
 }
 
@@ -304,20 +304,20 @@ impl<'a> DocItemInternal<'a> {
         }
     }
 
-    pub(crate) fn log(self, obj: ObjId, log: &mut PatchLog) {
+    pub(crate) fn log(self, obj: ObjId, log: &mut PatchLog, text_encoding: TextEncoding) {
         match self {
             Self::Map(map) => {
                 let id = map.op_id();
                 let key = &map.key;
                 let conflict = map.conflict;
-                let value = map.value.hydrate(log.text_encoding());
+                let value = map.value.hydrate(text_encoding);
                 log.put_map(obj, key, value, id, conflict, false);
             }
             Self::List(list) => {
                 let index = list.index;
                 let id = list.op_id();
                 let conflict = list.conflict;
-                let value = list.value.hydrate(log.text_encoding());
+                let value = list.value.hydrate(text_encoding);
                 log.insert(obj, index, value, id, conflict)
             }
             Self::Text(SpanInternal::Text(text, index, marks)) => {

--- a/rust/automerge/src/op_set2/change/batch.rs
+++ b/rust/automerge/src/op_set2/change/batch.rs
@@ -986,7 +986,7 @@ impl Automerge {
         &mut self,
         changes: impl IntoIterator<Item = Change> + Clone,
     ) -> Result<(), AutomergeError> {
-        self.apply_changes_batch_log_patches(changes, &mut PatchLog::inactive(self.text_encoding()))
+        self.apply_changes_batch_log_patches(changes, &mut PatchLog::inactive())
     }
 
     pub fn apply_changes_batch_log_patches<I: IntoIterator<Item = Change>>(

--- a/rust/automerge/src/sync.rs
+++ b/rust/automerge/src/sync.rs
@@ -283,7 +283,7 @@ impl SyncDoc for Automerge {
         sync_state: &mut State,
         message: Message,
     ) -> Result<(), AutomergeError> {
-        let mut patch_log = PatchLog::inactive(self.text_encoding());
+        let mut patch_log = PatchLog::inactive();
         self.receive_sync_message_inner(sync_state, message, &mut patch_log)
     }
 

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1,7 +1,6 @@
 use automerge::marks::{ExpandMark, Mark};
 //use automerge::op_tree::B;
 use automerge::transaction::{CommitOptions, Transactable};
-use automerge::TextEncoding;
 use automerge::{
     sync::SyncDoc, ActorId, AutoCommit, Automerge, AutomergeError, Change, ExpandedChange, ObjId,
     ObjType, Patch, PatchAction, PatchLog, Prop, ReadDoc, ScalarValue, SequenceTree, Value, ROOT,
@@ -1576,7 +1575,7 @@ fn regression_insert_opid() {
 
     let change2 = doc.get_last_local_change().unwrap().clone();
     let mut new_doc = Automerge::new();
-    let mut patch_log = PatchLog::active(TextEncoding::platform_default());
+    let mut patch_log = PatchLog::active();
     new_doc
         .apply_changes_log_patches(vec![change1], &mut patch_log)
         .unwrap();
@@ -1650,7 +1649,7 @@ fn big_list() {
 
     let change2 = doc.get_last_local_change().unwrap().clone();
     let mut new_doc = Automerge::new();
-    let mut patch_log = PatchLog::active(TextEncoding::platform_default());
+    let mut patch_log = PatchLog::active();
     new_doc
         .apply_changes_log_patches(vec![change1], &mut patch_log)
         .unwrap();


### PR DESCRIPTION
Trying to simplify the codebase by removing text_encoding from Patchog and Transaction now that TextRep is gone.  This makes the code cleaner and easier to read.  The only downside I can see to this is its no longer possible to have a patch_log who's encoding is different from the document.  This is likely a good idea anyway given the internal text index is calculated using the document encoding.  If we have a concrete use case for one document with many encodings I'd like to spec it out and have a test case for it in anycase.