### PR TITLE
always add parents to to_visit()

### DIFF
--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -676,10 +676,11 @@ impl ChangeGraph {
 
             if let Some(cached) = self.clock_cache.get(&idx) {
                 SeqClock::merge(clock, cached);
-            } else if visited.len() <= limit {
-                to_visit.extend(self.parents(idx).filter(|p| !visited.contains(p)));
             } else {
-                break;
+                to_visit.extend(self.parents(idx).filter(|p| !visited.contains(p)));
+                if visited.len() > limit {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
When hitting the cache limit the current node idx was popped and its parents are never added to to_visit() creating a situation where some of the history is never cached.
