### PR TITLE
Fix type hints in applyPatch and applyPatches functions

### DIFF
--- a/javascript/src/apply_patches.ts
+++ b/javascript/src/apply_patches.ts
@@ -18,7 +18,7 @@ import {
   UnmarkPatch,
 } from "./wasm_types.js"
 
-export function applyPatch(doc: unknown, patch: Patch) {
+export function applyPatch(doc: Doc<unknown>, patch: Patch) {
   let path = resolvePath(doc, patch.path)
   if (patch.action === "put") {
     applyPutPatch(doc, path, patch)
@@ -183,7 +183,7 @@ function applyUnmarkPatch(
   )
 }
 
-export function applyPatches(doc: unknown, patches: Patch[]) {
+export function applyPatches(doc: Doc<unknown>, patches: Patch[]) {
   for (const patch of patches) {
     applyPatch(doc, patch)
   }


### PR DESCRIPTION
Changed doc parameter type from 'unknown' to 'Doc<unknown>' in both applyPatch and applyPatches functions to add proper type hints.

Fixes #1183