### PR TITLE
Fix compiler warning (clang) in automerge-c

### DIFF
--- a/rust/automerge-c/src/utils/string.c
+++ b/rust/automerge-c/src/utils/string.c
@@ -13,7 +13,7 @@ char* AMstrdup(AMbyteSpan const str, char const* nul) {
     size_t const nul_len = strlen(nul);
     char* dup = NULL;
     size_t dup_len = 0;
-    char const* begin = str.src;
+    char const* begin = (char const*) str.src;
     char const* end = begin;
     for (size_t i = 0; i != str.count; ++i, ++end) {
         if (!*end) {


### PR DESCRIPTION
Fixes #1211.

By making the cast explicit in `utils/string.c`.