### PR TITLE
automerge-c: Fix automerge#1235

### DIFF
--- a/rust/automerge-c/test/CMakeLists.txt
+++ b/rust/automerge-c/test/CMakeLists.txt
@@ -60,7 +60,7 @@ add_custom_command(
     TARGET ${LIBRARY_NAME}_test
     POST_BUILD
     COMMAND
-        ${CMAKE_CTEST_COMMAND} --config $<CONFIG> --output-on-failure
+        ${CMAKE_CTEST_COMMAND} --build-config $<CONFIG> --output-on-failure
     COMMENT
         "Running the test(s)..."
     VERBATIM

--- a/rust/automerge-c/test/ported_wasm/cursor_tests.c
+++ b/rust/automerge-c/test/ported_wasm/cursor_tests.c
@@ -88,7 +88,7 @@ static void test_make_cursor_from_position_and_use_it(void** state) {
     /*
        // cursor works at the heads
        let cursor4 = doc1.getCursor("/text", 0);                                                                      */
-    AMcursor* cursor4;
+    AMcursor const* cursor4;
     assert_true(AMitemToCursor(
         AMstackItem(stack_ptr, AMgetCursor(doc1, text, 0, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)), &cursor4));
     /* let index4 = doc1.getCursorPosition("/text", cursor4);                                                         */


### PR DESCRIPTION
@alexjg, this PR fixes issue automerge#1235.

@shikokuchuo, this PR may be of interest to you because it affects the unit tests.

* Add missing `const` qualifier.
* Replace non-existent CTest `--config` flag with `--build-config` flag.