### PR TITLE
fix(test): use explicit text encoding in incorrect_patches test

### DIFF
--- a/rust/automerge/tests/text.rs
+++ b/rust/automerge/tests/text.rs
@@ -875,7 +875,7 @@ fn incorrect_patches_produced_when_isolating_and_integrating() {
 
     // Hard code actor ID to avoid flakes in patch ordering
     let actor = ActorId::from_str("aaaaaa").unwrap();
-    let mut doc = AutoCommit::new().with_actor(actor);
+    let mut doc = AutoCommit::new_with_encoding(TextEncoding::UnicodeCodePoint).with_actor(actor);
 
     let beginning = doc.get_heads();
 


### PR DESCRIPTION
  The test was using AutoCommit::new() which uses platform_default()
  encoding, but expected values hardcoded UnicodeCodePoint. This caused
  test failures on platforms (i.e. macos) where the default is Utf16CodeUnit.

  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>