### PR TITLE
Fix duplicate splice results when using clone() + changeAt()

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -715,6 +715,11 @@ impl AutoCommit {
     }
 
     fn patch_to(&mut self, after: &[ChangeHash]) {
+        // Ensure the actor is in the actor table before computing diffs.
+        // If a new actor is inserted later, it would shift actor indices and
+        // cause the diff computation to be incorrect. See issue #1270.
+        self.doc.ensure_actor_in_table();
+
         // we may be isolated so we dont use self.doc.get_heads()
         let before = self.get_heads();
         if before.as_slice() != after {

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -332,6 +332,15 @@ impl Automerge {
         }
     }
 
+    /// Ensure the actor is in the actor table.
+    ///
+    /// This is useful when you need to ensure the actor table is stable before
+    /// computing diffs that depend on actor indices. If the actor is already
+    /// in the table, this is a no-op.
+    pub(crate) fn ensure_actor_in_table(&mut self) {
+        let _ = self.get_or_create_actor_index();
+    }
+
     fn get_actor_index(&self) -> Option<usize> {
         match &self.actor {
             Actor::Unused(_) => None,

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1809,6 +1809,45 @@ fn can_isolate() -> Result<(), AutomergeError> {
     Ok(())
 }
 
+// Regression test for issue #1270:
+// https://github.com/automerge/automerge/issues/1270
+// When clone() + changeAt() is used with a new actor ID that is lexicographically
+// smaller than the existing actor, the actor indices would shift during the
+// transaction, causing incorrect patches to be generated.
+#[test]
+fn isolate_with_new_lower_actor_does_not_produce_duplicate_patches() -> Result<(), AutomergeError> {
+    // Create a document with actor "2222"
+    let actor1 = ActorId::from(&b"2222"[..]);
+    let mut doc1 = AutoCommit::new().with_actor(actor1);
+
+    let txt = doc1.put_object(&ROOT, "text", ObjType::Text)?;
+    let heads = doc1.get_heads();
+
+    // Add some text
+    doc1.splice_text(&txt, 0, 0, "def")?;
+
+    // Fork with a new actor "1111" which is lexicographically smaller
+    // This will cause actor indices to shift when the actor is inserted
+    let actor2 = ActorId::from(&b"1111"[..]);
+    let mut doc2 = doc1.fork().with_actor(actor2);
+
+    // Isolate at the initial heads (before "def" was added)
+    doc2.isolate(&heads);
+
+    // Add text at the beginning in the isolated context
+    doc2.splice_text(&txt, 0, 0, "abc")?;
+
+    // Integrate to merge the changes
+    doc2.integrate();
+
+    // The result should be "abcdef" - the concurrent changes should merge correctly
+    // Before the fix, this would produce "abcdefdef" when actor2 < actor1
+    let text = doc2.text(&txt)?;
+    assert_eq!(text, "abcdef", "Expected 'abcdef' but got '{}'", text);
+
+    Ok(())
+}
+
 #[test]
 fn inserting_text_near_deleted_marks() {
     let mut doc = Automerge::new();


### PR DESCRIPTION
Fixes #1270

## Problem

When using `clone()` with a new actor ID followed by `changeAt()`, duplicate content would appear in the document. For example:

```typescript
let doc = Automerge.change(Automerge.init(), doc => { doc.text = ""; });
const heads = Automerge.getHeads(doc);
const result = Automerge.change(doc, doc => Automerge.splice(doc, ["text"], 0, 0, "def"));
const result2 = Automerge.changeAt(Automerge.clone(result), heads, doc => Automerge.splice(doc, ["text"], 0, 0, "abc"));
// Expected: "abcdef"
// Actual: "abcdefdef" (duplicate "def")
```

This bug appeared flaky (~50% of the time with random actor IDs) but was actually deterministic based on actor ID ordering:
- When `cloneActorId < originalActorId` lexicographically: Bug occurs 100% of the time
- When `cloneActorId > originalActorId`: Bug never occurs

## Root Cause

The bug occurs due to a timing issue between diff computation and actor table insertion:

1. `fork()` creates a new document with the new actor stored as `Actor::Unused` (not yet in the actor table)
2. `isolate()` calls `patch_to()` which computes diffs using the current actor table
3. Events are logged to the `PatchLog` with OpIds referencing the current actor indices
4. Later, when a transaction opens, the new actor is inserted into the actor table
5. If the new actor sorts before existing actors, all actor indices shift
6. The `migrate_actors()` function is designed to fix this, but it has a gap: when `self.actors` is empty (which is the case for a freshly forked document), it just copies the new actor list and returns without migrating existing events
7. The events logged by `patch_to()` now have stale actor indices, causing patches to reference wrong objects

## Solution

Ensure the actor is inserted into the actor table **before** computing any diffs in `patch_to()`. This prevents the index mismatch from occurring in the first place.

The fix adds `ensure_actor_in_table()` at the start of `patch_to()`:

```rust
fn patch_to(&mut self, after: &[ChangeHash]) {
    // Ensure the actor is in the actor table before computing diffs.
    // If a new actor is inserted later, it would shift actor indices and
    // cause the diff computation to be incorrect. See issue #1270.
    self.doc.ensure_actor_in_table();
    
    // ... rest of the function
}
```

This is a preventative fix rather than a corrective one - by stabilizing the actor table before logging any events, we avoid the need for migration entirely.

## Changes

- `rust/automerge/src/automerge.rs`: Added `ensure_actor_in_table()` method
- `rust/automerge/src/autocommit.rs`: Call `ensure_actor_in_table()` at the start of `patch_to()`
- `rust/automerge/tests/test.rs`: Added regression test for issue #1270

## Testing

- All existing Rust tests pass (83 tests)
- All existing JavaScript tests pass (309 tests)
- New regression test verifies the fix works for the reported scenario
