### PR TITLE
Fix duplicate splice results when using clone() + changeAt()

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -411,6 +411,9 @@ impl AutoCommit {
         if let Some((patch_log, tx)) = self.transaction.take() {
             self.patch_log.merge(patch_log);
             let hash = tx.commit(&mut self.doc, None, None);
+            self.patch_log
+                .migrate_actors(&self.doc.ops().actors)
+                .unwrap();
             if self.isolation.is_some() && hash.is_some() {
                 self.isolation = hash.map(|h| vec![h])
             }

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1809,6 +1809,64 @@ fn can_isolate() -> Result<(), AutomergeError> {
     Ok(())
 }
 
+// Regression test for issue #1270:
+// https://github.com/automerge/automerge/issues/1270
+// When clone() + changeAt() is used with a new actor ID that is lexicographically
+// smaller than the existing actor, the actor indices would shift during the
+// transaction, causing incorrect patches to be generated.
+#[test]
+fn isolate_with_new_lower_actor_does_not_produce_duplicate_patches() -> Result<(), AutomergeError> {
+    // Create a document with actor "2222"
+    let actor1 = ActorId::from(&b"2222"[..]);
+    let mut doc1 = AutoCommit::new().with_actor(actor1);
+
+    let txt = doc1.put_object(&ROOT, "text", ObjType::Text)?;
+    let heads = doc1.get_heads();
+
+    // Add some text
+    doc1.splice_text(&txt, 0, 0, "def")?;
+
+    // Fork with a new actor "1111" which is lexicographically smaller
+    // This will cause actor indices to shift when the actor is inserted
+    let actor2 = ActorId::from(&b"1111"[..]);
+    let mut doc2 = doc1.fork().with_actor(actor2);
+
+    // Isolate at the initial heads (before "def" was added)
+    doc2.isolate(&heads);
+
+    // Add text at the beginning in the isolated context
+    doc2.splice_text(&txt, 0, 0, "abc")?;
+
+    // Integrate to merge the changes
+    doc2.integrate();
+
+    // The result should be "abcdef" - the concurrent changes should merge correctly
+    // Before the fix, this would produce "abcdefdef" when actor2 < actor1
+    let text = doc2.text(&txt)?;
+    assert_eq!(text, "abcdef", "Expected 'abcdef' but got '{}'", text);
+
+    Ok(())
+}
+
+#[test]
+fn isolate_followed_by_integrate_does_not_introduce_unused_actors() -> Result<(), AutomergeError> {
+    let mut doc1 = AutoCommit::new();
+    doc1.put_object(&ROOT, "text", ObjType::Text)?;
+    let heads = doc1.get_heads();
+
+    let mut doc2 = doc1.fork();
+
+    let saved_before = doc2.save();
+
+    // Isolate then integrate with no changes should result in the same saved doc
+    doc2.isolate(&heads);
+    doc2.integrate();
+    let saved_after = doc2.save();
+    assert_eq!(saved_before, saved_after);
+
+    Ok(())
+}
+
 #[test]
 fn inserting_text_near_deleted_marks() {
     let mut doc = Automerge::new();


### PR DESCRIPTION
Problem: when clone() is called with a new actor ID that is lexicographically smaller than existing actors, and then changeAt()/isolate() is used, the actor indices would shift during the transaction causing incorrect patches. 

In an Automerge document we keep a table of Actor IDs in a Vec<ActorId>. The index in this vector is then used as a proxy for the actor ID elsewhere in the document. In various places we need to compare actor IDs lexicographically in order to do tie-breaks on concurrent operations. To make this efficient we order the actors in the actor table lexicographically so that the index can be compared directly. This means that when a new actor ID is added we need to relabel all the references to actor IDs that come after it in the table wherever they appear in the codebase.

One important place where actor IDs are referenced is in the PatchLog. The PatchLog contains an internal event log which is sorted by object ID. When we turn the patch log into a list of patches to return to the caller we sort the events by object ID, which means that the events are causally ordered. The object IDs contain actor indices, so when we relabel actor IDs we also need to relabel the object IDs in the patch log. This is achieved by the PatchLog::migrate_actors() method.

The problem this commit fixes is that in
`AutoCommit::ensure_transaction_closed`, which is called in `AutoCommit::integrate`, we were not calling
`PatchLog::migrate_actors()`. This meant that if a change had been made since `AutoCommit::isolate` was called and the actor ID of the document was fresh (i.e. there had been no changes made in the document prior to `AutoCommit::isolate`), then the patch log would contain events with incorrect object IDs, leading to incorrect patches.

A specific sequence of events that would cause this problem is:

* fork() creates a new document with the new actor stored as Actor::Unused (not yet in the actor table)
* AutoCommit::isolate()
* Begin transaction
* Make some changes
* AutoCommit::integrate()
    * This results in a `patch_to()` call _without_ calling `PatchLog::migrate_actors()`
* If the new actor sorts before existing actors, all actor indices shift
* The events logged by patch_to() now have stale actor indices, causing patches to reference wrong objects


Solution: Call `PatchLog::migrate_actors()` in
`AutoCommit::ensure_transaction_closed` (called by `AutoCommit::integrate()`) so that the patch log is always up to date with the actor table.

Fixes #1270 