### PR TITLE
patchfix for block text issue

### DIFF
--- a/javascript/test/block_test.ts
+++ b/javascript/test/block_test.ts
@@ -26,6 +26,11 @@ describe("Automerge", () => {
         Automerge.splitBlock(d, ["text"], 3, block)
       })
 
+      // make sure the block is escaped
+      assert.deepStrictEqual(doc.text, "aaa\u{FFFC}bbbccc");
+      // ensure round-tripping works
+      assert.deepStrictEqual(doc, Automerge.load(Automerge.save(doc)));
+
       assert.deepStrictEqual(Automerge.block(doc, ["text"], 3), block)
 
       assert.deepStrictEqual(callbacks[0][0], {

--- a/rust/automerge-wasm/src/export_cache.rs
+++ b/rust/automerge-wasm/src/export_cache.rs
@@ -150,6 +150,8 @@ impl<'a> ExportCache<'a> {
                 if let Some((new_o, new_p)) = self.obj_cache.get(&obj) {
                     o = new_o.clone();
                     parent_prop = new_p.clone();
+                } else {
+                    continue; // disconnected object
                 }
                 current_obj_id = obj;
                 index = 0;

--- a/rust/automerge-wasm/src/interop.rs
+++ b/rust/automerge-wasm/src/interop.rs
@@ -1418,6 +1418,15 @@ impl Automerge {
                 let result = before.concat(&value.make_string().into()).concat(&after);
                 Ok(result.into())
             }
+            PatchAction::Insert { index, values, .. } => {
+                let index = *index as u32;
+                let placeholder = "\u{fffc}".repeat(values.len());
+                let length = string.length();
+                let before = string.slice(0, index);
+                let after = string.slice(index, length);
+                let result = before.concat(&placeholder.into()).concat(&after);
+                Ok(result.into())
+            }
             _ => Ok(string.into()),
         }
     }


### PR DESCRIPTION
Two pretty bad bugs were reported with text and block handling in the js library.  The first was on document load where patches to blocks were not properly discarded but instead attaached to the root object.  The second was where the string representing the text was not getting a unicode  object replacement caracter properly spliced in.  Tests have been extended to cover this.